### PR TITLE
Add GitHub Copilot review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@ The following checks are enforced by `validate_skill.py` and `audit_skill_system
 
 **`audit_skill_system.py`** (full system):
 - Spec compliance across all registered skills
-- Capability isolation (no registration frontmatter on capabilities)
+- Capability isolation (flags capabilities that look discovery-registered)
 - Dependency direction (no upward references from capabilities or skills to roles)
 - Nesting depth (no sub-capabilities)
 - Shared resource usage (shared files used by 2+ capabilities)

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -33,7 +33,7 @@ Include: what the skill does (verbs and nouns), when to trigger it (user intent 
 ## Naming Convention
 
 - **`SKILL.md` (uppercase)** is the registered entry point for a skill directory — agents discover and load it
-- **Capability files use lowercase** — capability entry points are not discovery-registered and follow a different casing convention
+- **Capabilities also use `SKILL.md` (uppercase)** — capability entry points are discovered the same way as skills; do not rename them to lowercase
 
 ## Structure Rules
 

--- a/.github/instructions/scripts.instructions.md
+++ b/.github/instructions/scripts.instructions.md
@@ -23,7 +23,7 @@ Review changes as a **Python tooling maintainer**, ensuring validation and scaff
 ## Code Quality
 
 - **Type hints on all function signatures** — use `typing` module for complex types (`List`, `Tuple`, `Dict`, `Optional`). Type hints make code self-documenting and catch errors early
-- **Docstrings on all public functions and modules** — follow PEP 257. Entry point module docstrings must serve as usage messages (shown when script is run without arguments)
+- **Docstrings on all public functions and modules** — follow PEP 257. Entry point module docstrings must double as the usage message printed when the script is run without arguments (via `print(__doc__)`)
 - **`encoding="utf-8"` on all `open()` calls** — omitting encoding causes platform-dependent behavior
 - **`if __name__ == "__main__"` guard** — required for all entry points so modules remain importable
 
@@ -38,14 +38,14 @@ Review changes as a **Python tooling maintainer**, ensuring validation and scaff
 
 - **Validation functions return `(errors, passes)` tuples** — do not raise exceptions for validation failures. Collect all issues and return them so callers can report everything at once
 - **Exit codes** — exit 0 on success (including warnings), exit 1 only on failures (`LEVEL_FAIL`). Scripts must be composable in CI pipelines
-- **Library functions return data, don't print** — keep `print()` and `sys.exit()` at the entry point level. Library code in `scripts/lib/` should return results, not produce side effects
+- **Library functions return data, don't print** — except for dedicated output/formatting helpers whose purpose is producing structured output. Keep `print()` and `sys.exit()` out of validation and domain logic
 - **Consistent path handling** — use `os.path` throughout. Do not mix `os.path` and `pathlib` within the same codebase
 - **Keep scripts focused** — one task per entry point. Do not combine unrelated operations in a single script
 - Document magic numbers with inline comments explaining why the value was chosen
 
 ## Review Scope
 
-The validation scripts (`validate_skill.py`, `audit_skill_system.py`) test the output of these Python scripts — not the scripts themselves. Review Python changes for code quality, maintainability, and adherence to the principles above. Only flag issues with high confidence.
+These scripts (`validate_skill.py`, `audit_skill_system.py`) validate repository content — SKILL.md files, manifests, and directory structure — not their own correctness. Regressions in the tooling itself are not caught automatically. Review Python changes for code quality, maintainability, and adherence to the principles above. Only flag issues with high confidence.
 
 ## Common Issues to Flag
 
@@ -58,7 +58,7 @@ The validation scripts (`validate_skill.py`, `audit_skill_system.py`) test the o
 - Hardcoded error level string (`"FAIL"`) instead of `LEVEL_FAIL` constant
 - Validation rule hardcoded in Python instead of `scripts/lib/configuration.yaml`
 - Use of Python 3.9+ features (`match`/`case`, `dict | dict` merge, `str.removeprefix`)
-- `print()` or `sys.exit()` in library code (`scripts/lib/`)
+- `print()` or `sys.exit()` in library code outside dedicated output helpers
 - Missing `if __name__ == "__main__"` guard in entry point
 - Unexplained magic numbers or hardcoded values
 - Mixing `os.path` and `pathlib` in the same file


### PR DESCRIPTION
## Summary

Adds three Copilot instruction files that give Copilot project-specific context for code generation and PR review:

- `.github/copilot-instructions.md` — repo-wide Agent Skills format compliance, architecture rules, platform-agnostic authoring, and capability policy
- `.github/instructions/markdown.instructions.md` — documentation quality rules scoped to `**/*.md` (description quality, frontmatter formatting, progressive disclosure, file references)
- `.github/instructions/scripts.instructions.md` — Python tooling rules scoped to `scripts/**/*.py` (stdlib-only, KISS/DRY/Modularity/Fail-fast, type hints, error handling conventions)

## Key design decisions

- **CI-awareness**: explicitly lists what `validate_skill.py` and `audit_skill_system.py` already check so Copilot focuses on what the scripts cannot catch (description quality, progressive disclosure, architecture justification, role completeness)
- **Confidence threshold**: Copilot only flags issues it is highly confident about — reduces false-positive review noise
- **Structured comment format**: problem → why it matters → suggested fix
- **Path-scoped instruction files**: uses `.github/instructions/` with `applyTo` glob patterns so each persona activates only for relevant file types
- **Patterns sourced from** `block/goose`, `anthropics/skills`, `github/awesome-copilot`, and `home-assistant/core`