### PR TITLE
Add broken file reference detection to validate_skill.py

### DIFF
--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -111,6 +111,7 @@ def validate_body(body, skill_md_path, allow_nested_refs=False):
     nested_found = False
 
     skill_dir = os.path.dirname(skill_md_path)
+    seen_paths: set[str] = set()
 
     for ref in refs:
         # Strip URL fragments, queries, and markdown link titles
@@ -120,6 +121,11 @@ def validate_body(body, skill_md_path, allow_nested_refs=False):
         ref_path = os.path.normpath(
             os.path.join(os.path.dirname(skill_md_path), normalized_ref)
         )
+
+        # Skip refs that resolve to the same file (e.g., guide.md#one vs guide.md#two)
+        if ref_path in seen_paths:
+            continue
+        seen_paths.add(ref_path)
 
         # Reject references that escape the skill directory
         if not is_within_directory(ref_path, skill_dir):

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -546,6 +546,46 @@ class ValidateBodyTests(unittest.TestCase):
         ref_passes = [p for p in passes if "one level deep" in p]
         self.assertEqual(len(ref_passes), 1)
 
+    def test_duplicate_fragment_refs_to_existing_file_checked_once(self) -> None:
+        """Multiple fragment refs to the same file produce a single nested-ref check."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_md = os.path.join(tmpdir, "SKILL.md")
+            ref_dir = os.path.join(tmpdir, "references")
+            # Create a file that contains nested references
+            write_text(
+                os.path.join(ref_dir, "guide.md"),
+                "# Guide\n\nSee [deep](references/deep.md) for more.\n",
+            )
+            write_text(os.path.join(ref_dir, "deep.md"), "# Deep\n")
+            # Two links to the same file with different fragments
+            body = (
+                "# Skill\n\n"
+                "See [intro](references/guide.md#intro) for details.\n"
+                "See [setup](references/guide.md#setup) for more.\n"
+            )
+            write_text(skill_md, body)
+            errors, passes = validate_body(body, skill_md)
+        # Should produce exactly one nested-ref WARN, not two
+        nested_warns = [e for e in errors if "nested references" in e]
+        self.assertEqual(len(nested_warns), 1)
+
+    def test_duplicate_fragment_refs_to_missing_file_warned_once(self) -> None:
+        """Multiple fragment refs to the same missing file produce a single WARN."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_md = os.path.join(tmpdir, "SKILL.md")
+            # Two links to the same missing file with different fragments
+            body = (
+                "# Skill\n\n"
+                "See [intro](references/missing.md#intro) for details.\n"
+                "See [setup](references/missing.md#setup) for more.\n"
+            )
+            write_text(skill_md, body)
+            errors, passes = validate_body(body, skill_md)
+        # Should produce exactly one "does not exist" WARN, not two
+        broken_warns = [e for e in errors if "does not exist" in e]
+        self.assertEqual(len(broken_warns), 1)
+        self.assertIn("references/missing.md", broken_warns[0])
+
     def test_body_with_no_refs_produces_no_ref_pass(self) -> None:
         """A body with no references produces no reference-related pass."""
         body = "# Skill\n\nJust plain content, no refs.\n"


### PR DESCRIPTION
## Summary

- Adds broken file reference detection to `validate_body()` in `validate_skill.py`
- References to files that don't exist on disk now emit a `WARN` with the entry filename in the message
- The check runs regardless of `--allow-nested-references` since missing files are always worth flagging
- Restructured the reference checking loop to handle broken refs, nested refs, and pass messages in a single pass

## Changes

**`validate_skill.py`**
- Broken references emit `WARN: '{ref}' referenced in {entry_filename} does not exist`
- Check runs for every ref before the nested-ref check, using `continue` to skip nesting analysis for missing files
- Pass messages ("one level deep" / "skipped") are suppressed when any broken ref is found
- Uses `strip_fragment()` from `lib/references.py` to handle URL fragments, query strings, and markdown link titles
- Normalizes paths with `os.path.normpath()` and rejects refs escaping the skill directory via `is_within_directory()`
- Uses `os.path.isfile()` to gracefully handle directory references instead of crashing
- Wraps `open()` in `try/except (OSError, UnicodeError)` so unreadable and binary/non-UTF8 files produce a WARN instead of crashing
- Readability check runs regardless of `allow_nested_refs` flag
- Deduplicates refs on normalized path after `strip_fragment()` to avoid redundant I/O and duplicate warnings when multiple fragments point to the same file

**`test_validate_skill.py` (17 new tests + 1 updated, 85 total)**
- `test_nonexistent_ref_file_returns_warn` — single broken ref produces WARN, no FAIL (updated from `test_nonexistent_ref_file_silently_skipped`)
- `test_multiple_broken_refs_each_reported` — each broken ref gets its own WARN
- `test_broken_and_valid_refs_mixed` — only broken refs are flagged, valid refs still checked
- `test_broken_and_nested_refs_both_reported` — broken ref WARN and nested ref WARN coexist
- `test_broken_ref_detected_with_allow_nested_refs` — broken refs detected even with `--allow-nested-references`
- `test_ref_with_fragment_to_existing_file_no_warn` — fragment-style refs to existing files produce no false WARN
- `test_duplicate_fragment_refs_to_existing_file_checked_once` — two fragment refs to same file produce single nested-ref check
- `test_duplicate_fragment_refs_to_missing_file_warned_once` — two fragment refs to same missing file produce single WARN
- `test_directory_reference_returns_warn` — directory ref produces WARN, not crash
- `test_path_traversal_returns_warn` — `../../somewhere` ref produces WARN
- `test_path_traversal_via_references_dotdot_returns_warn` — `references/../../../etc/passwd` produces WARN
- `test_markdown_link_title_handled` — `references/foo.md "Title"` resolves correctly
- `test_unreadable_ref_file_returns_warn` — unreadable file produces WARN, not crash (POSIX only, root-user guard)
- `test_unreadable_ref_file_with_allow_nested_refs_returns_warn` — unreadable files caught with `allow_nested_refs=True`
- `test_binary_ref_file_returns_warn` — binary file (invalid UTF-8) produces WARN, not crash
- `test_non_utf8_ref_file_returns_warn` — non-UTF8 text file produces WARN with UnicodeDecodeError in message
- `test_directory_ref_with_allow_nested_refs_returns_warn` — directory refs caught with `allow_nested_refs=True`
- `test_broken_reference_exits_zero` — CLI exits 0 (WARN only, non-blocking)