### PR TITLE
Add dedicated tests for yaml_parser.py (#28)

### DIFF
--- a/tests/test_yaml_parser.py
+++ b/tests/test_yaml_parser.py
@@ -386,7 +386,7 @@ class ParseMappingBasicTests(unittest.TestCase):
 
 
 class ParseMappingFoldedBlockTests(unittest.TestCase):
-    """Tests for _parse_mapping with folded block scalars (>)."""
+    """Tests for _parse_mapping with folded block scalars (>, >-)."""
 
     def test_folded_block_joins_with_spaces(self) -> None:
         """Folded block scalar (>) joins continuation lines with spaces."""
@@ -445,16 +445,6 @@ class ParseMappingFoldedBlockTests(unittest.TestCase):
         self.assertEqual(result, {"desc": "", "next": "value"})
         self.assertEqual(end, 2)
 
-    def test_literal_block_no_continuation_lines(self) -> None:
-        """Literal block scalar with no continuation lines yields empty string."""
-        lines = [
-            (0, "script: |"),
-            (0, "next: value"),
-        ]
-        result, end = _parse_mapping(lines, 0, 0)
-        self.assertEqual(result, {"script": "", "next": "value"})
-        self.assertEqual(end, 2)
-
     def test_folded_block_chomp_no_continuation_lines(self) -> None:
         """Folded block with chomp (>-) and no continuation yields empty string."""
         lines = [
@@ -463,16 +453,6 @@ class ParseMappingFoldedBlockTests(unittest.TestCase):
         ]
         result, end = _parse_mapping(lines, 0, 0)
         self.assertEqual(result, {"desc": "", "next": "value"})
-        self.assertEqual(end, 2)
-
-    def test_literal_block_chomp_no_continuation_lines(self) -> None:
-        """Literal block with chomp (|-) and no continuation yields empty string."""
-        lines = [
-            (0, "script: |-"),
-            (0, "next: value"),
-        ]
-        result, end = _parse_mapping(lines, 0, 0)
-        self.assertEqual(result, {"script": "", "next": "value"})
         self.assertEqual(end, 2)
 
     def test_block_scalar_at_end_of_input(self) -> None:
@@ -535,6 +515,26 @@ class ParseMappingLiteralBlockTests(unittest.TestCase):
         result, end = _parse_mapping(lines, 0, 0)
         self.assertEqual(result, {"script": "echo hello", "next": "value"})
         self.assertEqual(end, 3)
+
+    def test_literal_block_no_continuation_lines(self) -> None:
+        """Literal block scalar with no continuation lines yields empty string."""
+        lines = [
+            (0, "script: |"),
+            (0, "next: value"),
+        ]
+        result, end = _parse_mapping(lines, 0, 0)
+        self.assertEqual(result, {"script": "", "next": "value"})
+        self.assertEqual(end, 2)
+
+    def test_literal_block_chomp_no_continuation_lines(self) -> None:
+        """Literal block with chomp (|-) and no continuation yields empty string."""
+        lines = [
+            (0, "script: |-"),
+            (0, "next: value"),
+        ]
+        result, end = _parse_mapping(lines, 0, 0)
+        self.assertEqual(result, {"script": "", "next": "value"})
+        self.assertEqual(end, 2)
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

- Add comprehensive test suite for `lib/yaml_parser.py` covering all 6 public and internal functions with 107 tests across 15 test classes
- Include integration tests against the real `configuration.yaml` to catch regressions in parsed validation rules
- Cover all edge-case code paths including block scalars with no continuation lines, unclosed quotes, and continuation keys without colons

## Motivation

The custom YAML-subset parser (180 lines, no external dependencies) is loaded at import time by `constants.py` and feeds every validation rule in the codebase. A bug here would silently corrupt all validation. Despite this, there was no dedicated test file.

## Key edge cases covered

- `None`, empty, whitespace-only, and comment-only input
- Inline comment stripping with quotes (single, double, unclosed)
- Folded (`>`, `>-`) and literal (`|`, `|-`) block scalars — including zero continuation lines
- Deeply nested mappings (3 levels)
- List items with dict entries, continuation keys, and nested structures
- Continuation line without a colon breaking the collection loop
- Top-level list returning empty dict (not a valid mapping)
- Real `configuration.yaml` structural assertions (reserved words, patterns, limits)