### PR TITLE
Fix coverage badge update to use orphan badges branch instead of pushing to main

### DIFF
--- a/.github/scripts/update-coverage-badge.sh
+++ b/.github/scripts/update-coverage-badge.sh
@@ -4,15 +4,15 @@ set -euo pipefail
 # Validate required environment variables
 : "${TOTAL:?Environment variable TOTAL is required}"
 
-# Update the coverage badge in README.md and push to main.
+# Create coverage.json and push it to the orphan badges branch.
 #
 # Environment variables:
 #   TOTAL  — integer coverage percentage (e.g. 72)
 #
 # Behaviour:
 #   1. Maps the percentage to a shields.io colour band.
-#   2. Replaces the badge URL in README.md via sed.
-#   3. Commits and pushes only when the badge actually changed.
+#   2. Creates a coverage.json file following the shields.io endpoint schema.
+#   3. Pushes the file to the orphan badges branch (creates it if missing).
 #   4. Uses [skip ci] to prevent infinite workflow loops.
 
 # Determine badge colour from coverage percentage
@@ -22,23 +22,36 @@ elif [ "$TOTAL" -ge 70 ]; then COLOR="yellowgreen"
 elif [ "$TOTAL" -ge 60 ]; then COLOR="yellow"
 else COLOR="red"; fi
 
-# Fail fast if the expected badge pattern is missing
-grep -q "img.shields.io/badge/coverage-" README.md || {
-  echo "Coverage badge pattern not found in README.md" >&2
-  exit 1
+# Build coverage.json in a temporary directory
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+cat > "$WORK_DIR/coverage.json" <<EOF
+{
+  "schemaVersion": 1,
+  "label": "coverage",
+  "message": "${TOTAL}%",
+  "color": "${COLOR}"
 }
+EOF
 
-# Replace the badge URL with the current percentage and colour
-sed -i "s|img.shields.io/badge/coverage-[0-9]*%25-[a-z]*|img.shields.io/badge/coverage-${TOTAL}%25-${COLOR}|" README.md
+# Initialise a throwaway repo so the push carries only coverage.json
+git init "$WORK_DIR/repo"
+cp "$WORK_DIR/coverage.json" "$WORK_DIR/repo/coverage.json"
 
-# Commit and push only when the badge changed
-if git diff --quiet README.md; then
-  echo "Badge already up to date"
-else
-  git config user.name "github-actions[bot]"
-  git config user.email "github-actions[bot]@users.noreply.github.com"
-  git add README.md
-  git commit -m "Update coverage badge to ${TOTAL}% [skip ci]"
-  git pull --rebase origin main
-  git push origin HEAD:main
+git -C "$WORK_DIR/repo" checkout --orphan badges
+git -C "$WORK_DIR/repo" add coverage.json
+
+git -C "$WORK_DIR/repo" \
+  -c user.name="github-actions[bot]" \
+  -c user.email="github-actions[bot]@users.noreply.github.com" \
+  commit -m "Update coverage badge to ${TOTAL}% [skip ci]"
+
+# Propagate authentication from the checkout created by actions/checkout
+AUTH_HEADER=$(git config --get http.https://github.com/.extraheader || true)
+if [ -n "$AUTH_HEADER" ]; then
+  git -C "$WORK_DIR/repo" config http.https://github.com/.extraheader "$AUTH_HEADER"
 fi
+
+REMOTE_URL=$(git remote get-url origin)
+git -C "$WORK_DIR/repo" push --force "$REMOTE_URL" badges

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -76,10 +76,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
         with:
           ref: ${{ github.sha }}
-          fetch-depth: 0
-
-      - name: Prepare main branch for badge update
-        run: git switch -C main
 
       - name: Download coverage total
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # @v4 as 4.3.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Skill System Foundry
 
-![Coverage](https://img.shields.io/badge/coverage-70%25-yellowgreen)
+![Coverage](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmilanhorvatovic%2Fskill-system-foundry%2Fbadges%2Fcoverage.json)
 
 Meta-skill for building AI-agnostic skill systems with a two-layer architecture of skills and roles, templates, validation tools, and cross-platform authoring guidance based on the [Agent Skills specification](https://agentskills.io).
 


### PR DESCRIPTION
## Summary

- Replace the direct-push-to-main badge update with an orphan `badges` branch approach, so the CI respects branch protection rules (required PRs, signed commits)
- Switch the README badge from a static shields.io URL to a shields.io endpoint badge that reads `coverage.json` from the `badges` branch

## Problem

The `update-badge` job pushed a README change directly to `main`, which is blocked by branch protection:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
remote: - Commits must have verified signatures.
```

## Approach

Instead of modifying `README.md` on `main`, the badge script now:

1. Generates a `coverage.json` file following the [shields.io endpoint schema](https://shields.io/badges/endpoint-badge)
2. Pushes it to an orphan `badges` branch via a throwaway git repo (so only `coverage.json` is included)
3. The README references this JSON via a shields.io endpoint badge URL, keeping the badge live without ever touching `main`