### PR TITLE
Make CODEX_REVIEW_MODEL configurable via GitHub Actions variable

### DIFF
--- a/.github/workflows/codex-code-review.yaml
+++ b/.github/workflows/codex-code-review.yaml
@@ -25,9 +25,6 @@ on:
       - synchronize
       - ready_for_review
 
-env:
-  CODEX_MODEL: gpt-5.3-codex
-
 concurrency:
   group: codex-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -55,6 +52,12 @@ jobs:
       PR_AUTHOR: ${{ github.event.pull_request.user.login }}
 
     steps:
+      - name: Validate required variables
+        env:
+          CODEX_REVIEW_MODEL: ${{ vars.CODEX_REVIEW_MODEL }}
+        run: |
+          : "${CODEX_REVIEW_MODEL:?CODEX_REVIEW_MODEL is not set. Configure it in Settings → Actions → Variables.}"
+
       - name: Checkout PR
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
         with:
@@ -84,7 +87,7 @@ jobs:
         uses: openai/codex-action@086169432f1d2ab2f4057540b1754d550f6a1189 # @v1 as 1.4
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          model: ${{ env.CODEX_MODEL }}
+          model: ${{ vars.CODEX_REVIEW_MODEL }}
           sandbox: read-only
           prompt: |
             You are reviewing a GitHub pull request for this repository.


### PR DESCRIPTION
## Summary

- Removes the hardcoded `env.CODEX_MODEL: gpt-5.3-codex` workflow-level constant
- Adds a `Validate required variables` step that fails immediately with a clear
  message if `CODEX_REVIEW_MODEL` is not set in Settings → Actions → Variables
- Passes `vars.CODEX_REVIEW_MODEL` directly to the Codex action with no fallback

## Why

Model upgrades previously required a pull request to change a hardcoded constant.
`CODEX_REVIEW_MODEL` is a purely operational setting — it belongs in repository
variables alongside `CODEX_REVIEW_USERS`, which is already managed that way.

Failing fast on a missing variable avoids the harder-to-diagnose failure that
would occur if an empty value were silently passed to the Codex action.

## How to configure

After merging, set `CODEX_REVIEW_MODEL` in:
Settings → Secrets and variables → Actions → Variables → New repository variable