### PR TITLE
Shorten SKILL.md description to fit bundle limit (#56)

### DIFF
--- a/skill-system-foundry/SKILL.md
+++ b/skill-system-foundry/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: skill-system-foundry
 description: >
-  Designs, builds, validates, and evolves AI-agnostic skill systems composed of
-  skills (with optional capabilities) and roles. Activates when the user wants
-  to: create a new skill or capability, define or refine a role, restructure
-  their skill/role hierarchy, migrate from flat skills to a router+capabilities
-  pattern, audit skill system consistency, or reason about token efficiency and
-  maintainability trade-offs. Also triggers when the user mentions "skill
-  system", "canonical skill", "orchestrator", or discusses organizing
-  AI-agnostic automation across multiple tools like Claude Code, Cursor, or
-  Codex.
+  Designs and evolves AI-agnostic skill systems with skills, capabilities, and
+  roles. Triggers on skill/capability creation, role definition, router
+  migration, consistency audits, or token efficiency.
 allowed-tools: Bash Read Write Edit Glob Grep
 compatibility: Requires Python 3.12+ (stdlib only) for validation, scaffolding, and bundling scripts.
 license: MIT


### PR DESCRIPTION
## Summary

- Shortened the SKILL.md frontmatter `description` from 606 characters to 198 characters to comply with the Claude.ai bundle limit of 200 characters, unblocking the v1.0.0 release bundle.

## Details

The v1.0.0 release bundle [failed](https://github.com/milanhorvatovic/skill-system-foundry/actions/runs/23170973568) because the description exceeded the 200-character bundle limit. The description was rewritten to be concise while preserving key trigger keywords:

| Trigger | Coverage |
|---------|----------|
| Skill/capability creation | `skill/capability creation` |
| Role definition | `role definition` |
| Flat-to-router migration | `router migration` |
| System consistency auditing | `consistency audits` |
| Token efficiency reasoning | `token efficiency` |

**Before (606 chars):**
> Designs, builds, validates, and evolves AI-agnostic skill systems composed of skills (with optional capabilities) and roles. Activates when the user wants to: create a new skill or capability, define or refine a role, restructure their skill/role hierarchy, migrate from flat skills to a router+capabilities pattern, audit skill system consistency, or reason about token efficiency and maintainability trade-offs. Also triggers when the user mentions "skill system", "canonical skill", "orchestrator", or discusses organizing AI-agnostic automation across multiple tools like Claude Code, Cursor, or Codex.

**After (198 chars):**
> Designs and evolves AI-agnostic skill systems with skills, capabilities, and roles. Triggers on skill/capability creation, role definition, router migration, consistency audits, or token efficiency.

## Closes #56