### PR TITLE
Replace bundle.py with simple zip and bump to 1.0.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -51,7 +51,7 @@
         "skill-validation",
         "tool-integration"
       ],
-      "version": "1.0.1"
+      "version": "1.0.2"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -32,5 +32,5 @@
   "name": "skill-system-foundry",
   "repository": "https://github.com/milanhorvatovic/skill-system-foundry",
   "skills": "./",
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
 
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v5 as 5.6.0
-        with:
-          python-version: "3.12"
-
       - name: Build zip bundle
         run: |
-          python skill-system-foundry/scripts/bundle.py \
-            skill-system-foundry \
-            --output "dist/skill-system-foundry-${GITHUB_REF_NAME}.zip"
+          mkdir -p dist
+          zip -r "dist/skill-system-foundry-${GITHUB_REF_NAME}.zip" \
+            skill-system-foundry/
 
       - name: Upload release asset
         env:

--- a/skill-system-foundry/SKILL.md
+++ b/skill-system-foundry/SKILL.md
@@ -9,7 +9,7 @@ compatibility: Requires Python 3.12+ (stdlib only) for validation, scaffolding, 
 license: MIT
 metadata:
   author: Milan Horvatovič
-  version: 1.0.1
+  version: 1.0.2
   spec: agentskills.io
 ---
 


### PR DESCRIPTION
## Summary

- Replace `bundle.py` with a simple `zip` in the release workflow to avoid false-positive broken reference errors from illustrative documentation paths
- Bump version to 1.0.2 across all version references

Closes #60