### PR TITLE
Fix validate_skill.py to resolve references from skill root, not containing file

### DIFF
--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -59,7 +59,7 @@ def find_skill_root(start_dir: str) -> str | None:
     """
     current = os.path.abspath(start_dir)
     while True:
-        if os.path.exists(os.path.join(current, FILE_SKILL_MD)):
+        if os.path.isfile(os.path.join(current, FILE_SKILL_MD)):
             return current
         parent = os.path.dirname(current)
         if parent == current:
@@ -421,9 +421,10 @@ def validate_skill(
         body_errors, body_passes = validate_body(body, skill_md, skill_root, allow_nested_refs)
         errors.extend(body_errors)
         passes.extend(body_passes)
-        # Validate references in all other .md files in the capability tree
+        # Validate references in all .md files across the skill tree
+        # (walk skill_root, not skill_path, so the entire skill is scanned)
         ref_errors, ref_passes = validate_skill_references(
-            skill_path, skill_root, skill_md,
+            skill_root, skill_root, skill_md,
         )
         errors.extend(ref_errors)
         passes.extend(ref_passes)

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -910,6 +910,13 @@ class FindSkillRootTests(unittest.TestCase):
             result = find_skill_root(tmpdir)
         self.assertEqual(result, os.path.abspath(tmpdir))
 
+    def test_ignores_directory_named_skill_md(self) -> None:
+        """A directory named SKILL.md is not treated as a valid skill root."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "SKILL.md"))
+            result = find_skill_root(tmpdir)
+        self.assertIsNone(result)
+
 
 # ===================================================================
 # validate_body — skill-root-relative resolution
@@ -1071,6 +1078,27 @@ class ValidateSkillCapabilityRootTests(unittest.TestCase):
         warn_errors = [e for e in errors if e.startswith(LEVEL_WARN)]
         broken = [e for e in warn_errors if "does not exist" in e]
         self.assertEqual(broken, [])
+
+    def test_capability_mode_scans_entire_skill_tree(self) -> None:
+        """In --capability mode, skill-wide scanning walks the skill root,
+        not just the capability subtree, catching broken refs elsewhere."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(tmpdir, body="# Router Skill\n")
+            # Broken ref in a reference file at the skill root (outside capability dir)
+            write_text(
+                os.path.join(tmpdir, "references", "guide.md"),
+                "# Guide\n\nSee [missing](references/missing.md).\n",
+            )
+            cap_dir = os.path.join(tmpdir, "capabilities", "validation")
+            write_text(
+                os.path.join(cap_dir, "capability.md"),
+                "# Validation\n\nSome content.\n",
+            )
+            errors, passes = validate_skill(cap_dir, is_capability=True)
+        warn_errors = [e for e in errors if e.startswith(LEVEL_WARN)]
+        broken = [e for e in warn_errors if "does not exist" in e]
+        self.assertEqual(len(broken), 1)
+        self.assertIn("references/missing.md", broken[0])
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

- Resolve all markdown file references relative to the skill root directory (containing `SKILL.md`) instead of the containing file's directory, fixing incorrect resolution for capability files and reference documents
- Add `validate_skill_references()` to scan every `.md` file in the skill tree — not just entry points — catching broken links, parent traversals, and external references across the entire skill
- Strip fenced code blocks before extracting references so example links inside ``` are not falsely reported as broken

Fixes #66