### PR TITLE
Add missing type hints to discovery, frontmatter, yaml_parser, and audit (#70)

### DIFF
--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -72,7 +72,7 @@ from lib.constants import (
 )
 
 
-def check_upward_references(content, component_type, allow_orchestration=False):
+def check_upward_references(content: str, component_type: str, allow_orchestration: bool = False) -> list[tuple[str, str]]:
     """Check for references that violate dependency direction.
 
     Returns a list of (level, message) tuples.

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -8,7 +8,7 @@ from .constants import (
 )
 
 
-def find_skill_dirs(system_root):
+def find_skill_dirs(system_root: str) -> list[dict[str, str]]:
     """Find all skill and capability directories.
 
     Registered skills contain SKILL.md; capabilities contain capability.md.
@@ -48,7 +48,7 @@ def find_skill_dirs(system_root):
     return skills
 
 
-def find_roles(system_root):
+def find_roles(system_root: str) -> list[dict[str, str]]:
     """Find all role files."""
     roles = []
     roles_dir = os.path.join(system_root, DIR_ROLES)
@@ -72,13 +72,13 @@ def find_roles(system_root):
     return roles
 
 
-def check_line_count(filepath):
+def check_line_count(filepath: str) -> int:
     """Return line count of a file."""
     with open(filepath, "r", encoding="utf-8") as f:
         return sum(1 for _ in f)
 
 
-def read_file(filepath):
+def read_file(filepath: str) -> str:
     """Read file content."""
     with open(filepath, "r", encoding="utf-8") as f:
         return f.read()

--- a/skill-system-foundry/scripts/lib/frontmatter.py
+++ b/skill-system-foundry/scripts/lib/frontmatter.py
@@ -3,7 +3,7 @@
 from .yaml_parser import parse_yaml_subset
 
 
-def load_frontmatter(filepath):
+def load_frontmatter(filepath: str) -> tuple[dict | None, str]:
     """Extract YAML frontmatter from a SKILL.md file.
 
     Returns (frontmatter_dict, body_string). If no frontmatter is found,
@@ -32,7 +32,7 @@ def load_frontmatter(filepath):
     return frontmatter, body
 
 
-def count_body_lines(body):
+def count_body_lines(body: str) -> int:
     """Count lines in the SKILL.md body (after frontmatter).
 
     Returns 0 for empty/whitespace-only body, otherwise the number

--- a/skill-system-foundry/scripts/lib/yaml_parser.py
+++ b/skill-system-foundry/scripts/lib/yaml_parser.py
@@ -7,7 +7,7 @@ strings — no type coercion for booleans, numbers, or null.
 """
 
 
-def parse_yaml_subset(text):
+def parse_yaml_subset(text: str) -> dict:
     """Parse a limited YAML subset into a Python dict.
 
     Raises ValueError on structural parse failures.
@@ -32,7 +32,7 @@ def parse_yaml_subset(text):
     return result if isinstance(result, dict) else {}
 
 
-def _strip_inline_comment(text):
+def _strip_inline_comment(text: str) -> str:
     """Remove trailing ``# comment``, respecting quoted strings."""
     in_quote = False
     quote_char = None
@@ -47,7 +47,7 @@ def _strip_inline_comment(text):
     return text
 
 
-def _unquote(s):
+def _unquote(s: str) -> str:
     """Strip surrounding quotes from a scalar value."""
     s = s.strip()
     if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
@@ -55,7 +55,7 @@ def _unquote(s):
     return s
 
 
-def _parse_structure(lines, start, base_indent):
+def _parse_structure(lines: list[tuple[int, str]], start: int, base_indent: int) -> tuple[dict | list, int]:
     """Dispatch to mapping or list parser based on the first token."""
     if start >= len(lines):
         return {}, start
@@ -64,7 +64,7 @@ def _parse_structure(lines, start, base_indent):
     return _parse_mapping(lines, start, base_indent)
 
 
-def _parse_mapping(lines, start, base_indent):
+def _parse_mapping(lines: list[tuple[int, str]], start: int, base_indent: int) -> tuple[dict, int]:
     """Parse ``key: value`` pairs at *base_indent*."""
     result = {}
     i = start
@@ -110,7 +110,7 @@ def _parse_mapping(lines, start, base_indent):
     return result, i
 
 
-def _parse_list(lines, start, base_indent):
+def _parse_list(lines: list[tuple[int, str]], start: int, base_indent: int) -> tuple[list, int]:
     """Parse ``- item`` entries at *base_indent*."""
     result = []
     i = start


### PR DESCRIPTION
## Summary

- Adds type hints to 13 function signatures across 4 files
- `discovery.py`: `find_skill_dirs`, `find_roles`, `check_line_count`, `read_file`
- `frontmatter.py`: `load_frontmatter`, `count_body_lines`
- `yaml_parser.py`: `parse_yaml_subset`, `_strip_inline_comment`, `_unquote`, `_parse_structure`, `_parse_mapping`, `_parse_list`
- `audit_skill_system.py`: `check_upward_references`
- Uses builtin generics (`list`, `dict`, `tuple`) and `X | None` per project convention
- Zero untyped function signatures remain in production code

## Test plan

- [x] All 759 tests pass with no regressions
- [x] AST-based scan confirms zero untyped signatures in `scripts/**/*.py`
- [x] No runtime behavior changes (purely declarative)

Closes #70