### PR TITLE
Enforce per-file branch coverage minimum in CI (#71)

### DIFF
--- a/.github/scripts/check-per-file-coverage.py
+++ b/.github/scripts/check-per-file-coverage.py
@@ -161,7 +161,20 @@ def check_per_file(
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Entry point.  Returns 0 when all files pass, 1 otherwise."""
+    """Entry point.  Returns 0 when all files pass, 1 otherwise.
+
+    Returns 2 when the command-line arguments are invalid (mirrors
+    ``argparse``'s default exit code for usage errors).
+    """
+    try:
+        args = _parse_args(argv)
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 2
+    return _run(args)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse command-line arguments.  Raises ``SystemExit`` on errors."""
     parser = argparse.ArgumentParser(
         description="Check per-file branch coverage against a minimum threshold."
     )
@@ -181,8 +194,11 @@ def main(argv: list[str] | None = None) -> int:
         default=".coveragerc",
         help="Path to .coveragerc (default: .coveragerc)",
     )
-    args = parser.parse_args(argv)
+    return parser.parse_args(argv)
 
+
+def _run(args: argparse.Namespace) -> int:
+    """Execute the coverage check using parsed *args*.  Returns exit code."""
     # Determine threshold
     if args.threshold is not None:
         threshold = args.threshold

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -31,6 +31,7 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Run tests with coverage
+        id: run-tests
         run: python -m coverage run -m unittest discover -s tests -p "test_*.py" -v
         env:
           PYTHONUTF8: "1"
@@ -42,11 +43,11 @@ jobs:
         run: python .github/scripts/check-per-file-coverage.py
 
       - name: Generate coverage HTML report
-        if: always()
+        if: always() && steps.run-tests.outcome != 'skipped'
         run: python -m coverage html
 
       - name: Upload coverage report
-        if: always()
+        if: always() && steps.run-tests.outcome != 'skipped'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4 as 4.6.2
         with:
           name: coverage-report-${{ matrix.os }}

--- a/tests/test_check_per_file_coverage.py
+++ b/tests/test_check_per_file_coverage.py
@@ -616,6 +616,25 @@ class CheckPerFileMalformedTests(unittest.TestCase):
 
 
 # ===================================================================
+# main — argument parsing errors
+# ===================================================================
+
+
+class MainArgparseErrorTests(unittest.TestCase):
+    """Integration tests for main with invalid CLI arguments."""
+
+    def test_invalid_threshold_type_returns_two(self) -> None:
+        """Returns 2 when --threshold receives a non-numeric value."""
+        result = main(["--threshold", "abc"])
+        self.assertEqual(result, 2)
+
+    def test_unknown_flag_returns_two(self) -> None:
+        """Returns 2 when an unknown flag is passed."""
+        result = main(["--bogus"])
+        self.assertEqual(result, 2)
+
+
+# ===================================================================
 # main — integration tests
 # ===================================================================
 


### PR DESCRIPTION
## Summary

- Adds `.github/scripts/check-per-file-coverage.py` — stdlib-only Python script that checks per-file branch coverage against the threshold from `.coveragerc`
- Adds two new steps to `.github/workflows/python-tests.yaml`: generate `coverage.json` and run per-file check
- Strict `.coveragerc` parsing — no silent fallback on missing or malformed config
- Uses `percent_branches_covered` metric for accurate branch-only enforcement
- Validates `coverage.json` schema — rejects malformed files instead of treating them as success
- 16 unit tests covering threshold parsing, metric extraction, edge cases, and error modes
- Works cross-platform (ubuntu and windows) — Python-based, no shell parsing

**Note:** This will intentionally fail on main until #68 and #69 are merged, as `bundle.py` (41%) and `scaffold.py` (46%) are currently below the 70% threshold.

## Test plan

- [x] All 779 tests pass locally
- [x] Script correctly identifies files below threshold
- [x] Strict error handling for malformed inputs
- [x] CI steps work on both ubuntu-latest and windows-latest
- [x] Merge #68 and #69 first, then merge this PR

Closes #71