### PR TITLE
Raise coverage above 95% for validate_skill, codex_config, bundling

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1473,10 +1473,11 @@ class PostValidateCoverageTests(unittest.TestCase):
             )
             errors = postvalidate(bundle_dir)
         multi = [e for e in errors if "Multiple SKILL.md" in e]
-        if not multi:
-            # Case-insensitive match requires a case-insensitive lookup —
-            # on case-sensitive filesystems we compare via lower().
-            self.skipTest("case-insensitive SKILL.md detection skipped")
+        self.assertTrue(
+            multi,
+            f"Expected a multiple SKILL.md validation error for "
+            f"case-insensitive detection, got: {errors}",
+        )
         self.assertIn(LEVEL_FAIL, multi[0])
         self.assertIn("SKILL.md", multi[0])
         self.assertIn("skill.md", multi[0])

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -20,6 +20,7 @@ from lib.bundling import (
     _copy_inlined_skills,
     _copy_skill,
     _rewrite_markdown_content,
+    _rewrite_markdown_paths,
     _rewrite_reference_target,
     create_bundle,
     postvalidate,
@@ -1139,6 +1140,49 @@ class PrevalidateGuardTests(unittest.TestCase):
         self.assertTrue(any(e.startswith(LEVEL_FAIL) and "Invalid bundle_target" in e for e in errors))
         self.assertIsNone(result)
 
+    def test_skill_without_description_skips_length_check(self) -> None:
+        """Frontmatter without ``description`` skips the length-enforcement branch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_text(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: demo-skill\n---\n",
+            )
+            # Skip the spec check so the description-length branch is
+            # reached.  Normally validate_skill would FAIL on missing
+            # description and prevalidate would exit earlier.
+            with mock.patch(
+                "validate_skill.validate_skill", return_value=([], []),
+            ):
+                errors, warnings, result = prevalidate(skill_dir, None)
+        # No description-length FAIL/WARN should appear since there is
+        # nothing to measure.
+        self.assertEqual(
+            [e for e in errors + warnings if "Description is" in e],
+            [],
+        )
+
+    def test_non_fail_spec_messages_surfaced_as_warnings(self) -> None:
+        """WARN/INFO from validate_skill flow into prevalidate warnings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            system_root = os.path.join(tmpdir, "root")
+            skill_dir = os.path.join(system_root, "skills", "demo-skill")
+            write_text(os.path.join(system_root, "manifest.yaml"), "name: demo\n")
+            # A broken reference is a WARN, not a FAIL — exercises the
+            # else-branch at bundling.py:107 where spec_errors are copied
+            # into warnings.
+            write_text(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: demo-skill\ndescription: x\n---\n\n"
+                "See [g](references/missing.md).\n",
+            )
+            errors, warnings, result = prevalidate(skill_dir, system_root)
+        # Broken intra-skill refs are WARNs surfaced from validate_skill.
+        self.assertTrue(
+            any("does not exist" in w for w in warnings),
+            msg=f"warnings={warnings}",
+        )
+
     def test_spec_failures_aggregated_in_prevalidate(self) -> None:
         """Missing SKILL.md yields spec FAILs that prevalidate surfaces."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1157,6 +1201,25 @@ class PrevalidateGuardTests(unittest.TestCase):
 # ===================================================================
 # Copy OSError Wrapping
 # ===================================================================
+
+
+class RewriteMarkdownPathsEmptyMapTests(unittest.TestCase):
+    """Ensure the empty-rewrite-map fast-path in ``_rewrite_markdown_paths``."""
+
+    def test_empty_rewrite_map_skips_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(os.path.join(bundle_dir, "SKILL.md"), "# x\n")
+            file_mapping = {
+                "/unused/ext.md": "references/ext.md",
+            }
+            with mock.patch(
+                "lib.bundling._build_rewrite_map", return_value={},
+            ):
+                count = _rewrite_markdown_paths(
+                    bundle_dir, tmpdir, None, file_mapping,
+                )
+        self.assertEqual(count, 0)
 
 
 class CopyOSErrorTests(unittest.TestCase):
@@ -1298,6 +1361,50 @@ class RelpathValueErrorFallbackTests(unittest.TestCase):
                 reverse_mapping={},
             )
         self.assertTrue(result)
+
+    def test_build_rewrite_map_with_empty_skill_files(self) -> None:
+        """The ``if skill_files:`` False branch skips the alias-map block."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            bundle_file = os.path.join(bundle_dir, "SKILL.md")
+            skill_path = os.path.join(tmpdir, "skill")
+            os.makedirs(bundle_dir)
+            os.makedirs(skill_path)
+            write_text(bundle_file, "# x\n")
+
+            result = _build_rewrite_map(
+                bundle_file=bundle_file,
+                bundle_dir=bundle_dir,
+                skill_path=skill_path,
+                system_root=None,
+                file_mapping={},
+                reverse_mapping={},
+                skill_files={},
+            )
+        self.assertEqual(result, {})
+
+    def test_build_rewrite_map_with_skill_files_no_system_root(self) -> None:
+        """With skill_files present but no system_root, the system-rel block is skipped."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            bundle_file = os.path.join(bundle_dir, "SKILL.md")
+            skill_path = os.path.join(tmpdir, "skill")
+            os.makedirs(bundle_dir)
+            os.makedirs(skill_path)
+            write_text(bundle_file, "# x\n")
+            skill_files = {
+                os.path.join(skill_path, "nested", "f.md"): "nested/f.md",
+            }
+            result = _build_rewrite_map(
+                bundle_file=bundle_file,
+                bundle_dir=bundle_dir,
+                skill_path=skill_path,
+                system_root=None,
+                file_mapping={},
+                reverse_mapping={},
+                skill_files=skill_files,
+            )
+        self.assertNotEqual(result, {})
 
     def test_build_rewrite_map_swallows_valueerror_in_alias_block(self) -> None:
         """Skill-internal alias relpath ValueErrors must be swallowed."""
@@ -1477,6 +1584,33 @@ class PostValidateCoverageTests(unittest.TestCase):
             )
             errors = postvalidate(bundle_dir)
         self.assertEqual(errors, [])
+
+    def test_backtick_reference_to_existing_file_is_accepted(self) -> None:
+        """A backtick pointing to an existing in-bundle file produces no error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(
+                os.path.join(bundle_dir, "SKILL.md"),
+                "---\nname: a\n---\n\nSee `refs/guide.md` for details.\n",
+            )
+            write_text(
+                os.path.join(bundle_dir, "refs", "guide.md"), "# Guide\n",
+            )
+            errors = postvalidate(bundle_dir)
+        self.assertEqual(errors, [])
+
+    def test_multiple_backticks_on_same_line_each_checked(self) -> None:
+        """Multiple backtick references on one line each iterate the inner loop."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(
+                os.path.join(bundle_dir, "SKILL.md"),
+                "---\nname: a\n---\n\n"
+                "See `refs/missing-a.md` and `refs/missing-b.md` today.\n",
+            )
+            errors = postvalidate(bundle_dir)
+        unresolved = [e for e in errors if "Unresolved backtick reference" in e]
+        self.assertEqual(len(unresolved), 2)
 
     def test_backtick_query_only_path_is_skipped(self) -> None:
         """A backtick whose clean path strips to empty exits early."""

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -14,10 +14,13 @@ if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
 from lib.bundling import (
+    _build_rewrite_map,
+    _compute_original_paths,
     _copy_external_files,
     _copy_inlined_skills,
     _copy_skill,
     _rewrite_markdown_content,
+    _rewrite_reference_target,
     create_bundle,
     postvalidate,
     prevalidate,
@@ -1113,6 +1116,396 @@ class PrevalidateTargetTests(unittest.TestCase):
             errors, warnings, result = prevalidate(skill_dir, system_root)
             self.assertTrue(any(e.startswith(LEVEL_FAIL) for e in errors))
             self.assertIsNone(result)
+
+
+# ===================================================================
+# Prevalidate Guards
+# ===================================================================
+
+
+class PrevalidateGuardTests(unittest.TestCase):
+    """Tests for prevalidate's argument-guard branches."""
+
+    def test_invalid_bundle_target_returns_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_text(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: demo-skill\ndescription: x\n---\n",
+            )
+            errors, warnings, result = prevalidate(
+                skill_dir, None, bundle_target="martian",
+            )
+        self.assertTrue(any(e.startswith(LEVEL_FAIL) and "Invalid bundle_target" in e for e in errors))
+        self.assertIsNone(result)
+
+    def test_spec_failures_aggregated_in_prevalidate(self) -> None:
+        """Missing SKILL.md yields spec FAILs that prevalidate surfaces."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            os.makedirs(skill_dir)
+            # No SKILL.md: validate_skill returns a FAIL
+            errors, warnings, result = prevalidate(skill_dir, None)
+        fails = [e for e in errors if e.startswith(LEVEL_FAIL)]
+        self.assertGreaterEqual(len(fails), 2)  # header + at least one spec err
+        self.assertTrue(
+            any("spec validation failures" in e for e in fails)
+        )
+        self.assertIsNone(result)
+
+
+# ===================================================================
+# Copy OSError Wrapping
+# ===================================================================
+
+
+class CopyOSErrorTests(unittest.TestCase):
+    """OSError during file copy must be wrapped as ValueError."""
+
+    def test_copy_skill_oserror_wrapped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            os.makedirs(bundle_dir)
+            write_text(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: demo-skill\ndescription: x\n---\n",
+            )
+            with mock.patch(
+                "lib.bundling.shutil.copy2", side_effect=OSError("disk full"),
+            ):
+                with self.assertRaises(ValueError) as cm:
+                    _copy_skill(skill_dir, bundle_dir, [], None)
+            self.assertIn("Failed to copy bundled file", str(cm.exception))
+
+    def test_copy_external_files_oserror_wrapped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            system_root = os.path.join(tmpdir, "root")
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            os.makedirs(bundle_dir)
+            ext_file = os.path.join(system_root, "references", "note.md")
+            write_text(ext_file, "# Note\n")
+
+            with mock.patch(
+                "lib.bundling.shutil.copy2", side_effect=OSError("EACCES"),
+            ):
+                with self.assertRaises(ValueError) as cm:
+                    _copy_external_files({ext_file}, system_root, bundle_dir)
+            self.assertIn("Failed to copy external file", str(cm.exception))
+
+    def test_copy_inlined_skill_oserror_wrapped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            inlined = os.path.join(tmpdir, "other-skill")
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            os.makedirs(bundle_dir)
+            write_text(
+                os.path.join(inlined, "SKILL.md"),
+                "---\nname: other-skill\ndescription: x\n---\n",
+            )
+            with mock.patch(
+                "lib.bundling.shutil.copy2", side_effect=OSError("EIO"),
+            ):
+                with self.assertRaises(ValueError) as cm:
+                    _copy_inlined_skills(
+                        {inlined: "other-skill"}, bundle_dir, [], None,
+                    )
+            self.assertIn("Failed to copy inlined skill file", str(cm.exception))
+
+
+class CopyExternalFilesEdgeTests(unittest.TestCase):
+    """Edge cases for ``_copy_external_files``."""
+
+    def test_external_reference_is_directory_raises(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            system_root = os.path.join(tmpdir, "root")
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            ext_dir = os.path.join(system_root, "references", "sub")
+            os.makedirs(ext_dir)
+            os.makedirs(bundle_dir)
+
+            with self.assertRaises(ValueError) as cm:
+                _copy_external_files({ext_dir}, system_root, bundle_dir)
+            self.assertIn("is not a regular file", str(cm.exception))
+
+
+# ===================================================================
+# _rewrite_reference_target Edge Cases
+# ===================================================================
+
+
+class RewriteReferenceTargetEdgeTests(unittest.TestCase):
+    """Edge-case inputs for ``_rewrite_reference_target``."""
+
+    def test_empty_target_returned_unchanged(self) -> None:
+        self.assertEqual(_rewrite_reference_target("", {}, allow_title=True), "")
+
+    def test_backtick_target_unchanged_when_no_match(self) -> None:
+        source = "Use `path/unknown.md` here."
+        self.assertEqual(_rewrite_markdown_content(source, {"other.md": "x.md"}), source)
+
+
+# ===================================================================
+# relpath ValueError Fallback (cross-drive paths on Windows)
+# ===================================================================
+
+
+class RelpathValueErrorFallbackTests(unittest.TestCase):
+    """Confirm that ValueError from os.path.relpath is swallowed."""
+
+    def test_compute_original_paths_swallows_valueerror(self) -> None:
+        """Inner relpath() calls raise → the except ValueError: pass path runs."""
+        original_relpath = os.path.relpath
+        call_count = {"n": 0}
+
+        def selective_relpath(path: str, start: str | None = None) -> str:
+            call_count["n"] += 1
+            # Let the initial header call succeed, then raise on the
+            # two inner try/except blocks at lines 517 and 526.
+            if call_count["n"] == 1:
+                return original_relpath(path, start) if start else original_relpath(path)
+            raise ValueError("cross-drive")
+
+        with mock.patch(
+            "lib.bundling.os.path.relpath", side_effect=selective_relpath,
+        ):
+            result = _compute_original_paths(
+                abs_source="/a/b/roles/r.md",
+                bundle_file="/bundle/skill/SKILL.md",
+                skill_path="/a/b/skill",
+                bundle_dir="/bundle",
+                system_root="/a/b",
+                reverse_mapping={},
+            )
+        self.assertEqual(result, set())
+
+    def test_compute_original_paths_without_system_root(self) -> None:
+        """Without a system_root, only the source-dir-relative form is emitted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_path = os.path.join(tmpdir, "skill")
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            os.makedirs(skill_path)
+            os.makedirs(bundle_dir)
+            abs_source = os.path.join(tmpdir, "roles", "reviewer.md")
+            bundle_file = os.path.join(bundle_dir, "SKILL.md")
+            write_text(bundle_file, "# x\n")
+
+            result = _compute_original_paths(
+                abs_source=abs_source,
+                bundle_file=bundle_file,
+                skill_path=skill_path,
+                bundle_dir=bundle_dir,
+                system_root=None,
+                reverse_mapping={},
+            )
+        self.assertTrue(result)
+
+    def test_build_rewrite_map_swallows_valueerror_in_alias_block(self) -> None:
+        """Skill-internal alias relpath ValueErrors must be swallowed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            bundle_file = os.path.join(bundle_dir, "SKILL.md")
+            skill_path = os.path.join(tmpdir, "skill")
+            os.makedirs(bundle_dir)
+            os.makedirs(skill_path)
+            write_text(bundle_file, "# x\n")
+
+            skill_files = {os.path.join(skill_path, "nested", "f.md"): "nested/f.md"}
+
+            original_relpath = os.path.relpath
+            call_count = {"n": 0}
+
+            def selective_relpath(path: str, start: str | None = None) -> str:
+                call_count["n"] += 1
+                # Raise on skill-internal alias block calls (calls 3+),
+                # let the earlier ones succeed so we reach the alias block.
+                if call_count["n"] >= 3:
+                    raise ValueError("cross-drive")
+                if start is None:
+                    return original_relpath(path)
+                return original_relpath(path, start)
+
+            with mock.patch(
+                "lib.bundling.os.path.relpath", side_effect=selective_relpath,
+            ):
+                result = _build_rewrite_map(
+                    bundle_file=bundle_file,
+                    bundle_dir=bundle_dir,
+                    skill_path=skill_path,
+                    system_root=tmpdir,
+                    file_mapping={},
+                    reverse_mapping={},
+                    skill_files=skill_files,
+                )
+        self.assertIsInstance(result, dict)
+
+
+# ===================================================================
+# Postvalidate Coverage
+# ===================================================================
+
+
+class PostValidateCoverageTests(unittest.TestCase):
+    """Tests for each uncovered branch in ``postvalidate``."""
+
+    def test_zero_skill_md_reports_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            os.makedirs(bundle_dir)
+            errors = postvalidate(bundle_dir)
+        no_skill = [e for e in errors if "No SKILL.md found" in e]
+        self.assertEqual(len(no_skill), 1)
+        self.assertIn(LEVEL_FAIL, no_skill[0])
+
+    def test_multiple_skill_md_case_insensitive_reports_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(os.path.join(bundle_dir, "SKILL.md"), "---\nname: a\n---\n")
+            write_text(
+                os.path.join(bundle_dir, "nested", "skill.md"),
+                "---\nname: b\n---\n",
+            )
+            errors = postvalidate(bundle_dir)
+        multi = [e for e in errors if "Multiple SKILL.md" in e]
+        if not multi:
+            # Case-insensitive match requires a case-insensitive lookup —
+            # on case-sensitive filesystems we compare via lower().
+            self.skipTest("case-insensitive SKILL.md detection skipped")
+        self.assertIn(LEVEL_FAIL, multi[0])
+        self.assertIn("SKILL.md", multi[0])
+        self.assertIn("skill.md", multi[0])
+
+    def test_capability_dir_missing_capability_md_reports_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(os.path.join(bundle_dir, "SKILL.md"), "---\nname: a\n---\n")
+            os.makedirs(os.path.join(bundle_dir, "capabilities", "orphan"))
+            errors = postvalidate(bundle_dir)
+        missing = [
+            e for e in errors
+            if "missing" in e and "capability.md" in e
+        ]
+        self.assertEqual(len(missing), 1)
+        self.assertIn(LEVEL_FAIL, missing[0])
+        self.assertIn("orphan", missing[0])
+
+    def test_markdown_reference_escapes_bundle_reports_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(
+                os.path.join(bundle_dir, "SKILL.md"),
+                "---\nname: a\n---\n\n[x](../../outside.md)\n",
+            )
+            errors = postvalidate(bundle_dir)
+        escape = [
+            e for e in errors
+            if "Markdown reference escapes bundle" in e
+        ]
+        self.assertEqual(len(escape), 1)
+        self.assertIn(LEVEL_FAIL, escape[0])
+
+    def test_backtick_reference_escapes_bundle_reports_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(
+                os.path.join(bundle_dir, "SKILL.md"),
+                "---\nname: a\n---\n\nUse `../../etc/passwd` config.\n",
+            )
+            errors = postvalidate(bundle_dir)
+        escape = [
+            e for e in errors
+            if "Backtick reference escapes bundle" in e
+        ]
+        self.assertEqual(len(escape), 1)
+        self.assertIn(LEVEL_FAIL, escape[0])
+
+    def test_capabilities_non_directory_entry_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(os.path.join(bundle_dir, "SKILL.md"), "---\nname: a\n---\n")
+            write_text(
+                os.path.join(bundle_dir, "capabilities", "NOTES.txt"),
+                "file, not a cap dir",
+            )
+            errors = postvalidate(bundle_dir)
+        self.assertEqual(
+            [e for e in errors if "capability.md" in e and "missing" in e],
+            [],
+        )
+
+    def test_markdown_link_with_url_is_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(
+                os.path.join(bundle_dir, "SKILL.md"),
+                "---\nname: a\n---\n\n[home](https://example.com/page)\n",
+            )
+            errors = postvalidate(bundle_dir)
+        self.assertEqual(errors, [])
+
+    def test_pure_fragment_markdown_link_is_skipped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(
+                os.path.join(bundle_dir, "SKILL.md"),
+                "---\nname: a\n---\n\n[top](#heading)\n",
+            )
+            errors = postvalidate(bundle_dir)
+        self.assertEqual(errors, [])
+
+    def test_markdown_ref_with_query_only_path_is_skipped(self) -> None:
+        """``[x](?q=1)`` passes should_skip, strip_fragment returns empty."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(
+                os.path.join(bundle_dir, "SKILL.md"),
+                "---\nname: a\n---\n\n[x](?q=1)\n",
+            )
+            errors = postvalidate(bundle_dir)
+        # Neither escape nor unresolved errors — the empty ref_clean path exits early.
+        self.assertEqual(
+            [e for e in errors if "?q=1" in e or "Markdown reference" in e],
+            [],
+        )
+
+    def test_backtick_url_is_skipped(self) -> None:
+        """A backtick containing a URL with a ``/`` is skipped before resolution."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(
+                os.path.join(bundle_dir, "SKILL.md"),
+                "---\nname: a\n---\n\nVisit `https://example.com/page` today.\n",
+            )
+            errors = postvalidate(bundle_dir)
+        self.assertEqual(errors, [])
+
+    def test_backtick_query_only_path_is_skipped(self) -> None:
+        """A backtick whose clean path strips to empty exits early."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(
+                os.path.join(bundle_dir, "SKILL.md"),
+                "---\nname: a\n---\n\nSee `?q=1/foo` here.\n",
+            )
+            errors = postvalidate(bundle_dir)
+        self.assertEqual(
+            [e for e in errors if "?q=1" in e],
+            [],
+        )
+
+    def test_backtick_reference_unresolved_reports_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bundle_dir = os.path.join(tmpdir, "bundle")
+            write_text(
+                os.path.join(bundle_dir, "SKILL.md"),
+                "---\nname: a\n---\n\nUse `refs/missing.md` somewhere.\n",
+            )
+            errors = postvalidate(bundle_dir)
+        unresolved = [
+            e for e in errors
+            if "Unresolved backtick reference" in e
+        ]
+        self.assertEqual(len(unresolved), 1)
+        self.assertIn(LEVEL_FAIL, unresolved[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1199,7 +1199,7 @@ class PrevalidateGuardTests(unittest.TestCase):
 
 
 # ===================================================================
-# Copy OSError Wrapping
+# Markdown Rewrite Fast-Path
 # ===================================================================
 
 
@@ -1220,6 +1220,11 @@ class RewriteMarkdownPathsEmptyMapTests(unittest.TestCase):
                     bundle_dir, tmpdir, None, file_mapping,
                 )
         self.assertEqual(count, 0)
+
+
+# ===================================================================
+# Copy OSError Wrapping
+# ===================================================================
 
 
 class CopyOSErrorTests(unittest.TestCase):

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -938,6 +938,26 @@ class IsValidRelativePathEdgeTests(unittest.TestCase):
     def test_empty_string_rejected(self) -> None:
         self.assertFalse(_is_valid_relative_path(""))
 
+    def test_valid_icon_large_path_emits_pass(self) -> None:
+        config = 'interface:\n  icon_large: "./assets/big.svg"\n'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, config)
+            errors, passes = validate_codex_config(tmpdir)
+        icon_large_passes = [p for p in passes if "icon_large" in p]
+        self.assertEqual(len(icon_large_passes), 1)
+
+    def test_invalid_icon_large_path_returns_warn(self) -> None:
+        config = 'interface:\n  icon_large: "/abs/icon.svg"\n'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, config)
+            errors, passes = validate_codex_config(tmpdir)
+        warns = [
+            e for e in errors
+            if e.startswith(LEVEL_WARN) and "icon_large" in e
+            and "relative path" in e
+        ]
+        self.assertEqual(len(warns), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -10,6 +10,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 from helpers import write_text, write_skill_md
 
@@ -19,7 +20,12 @@ SCRIPTS_DIR = os.path.abspath(
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
-from lib.codex_config import validate_codex_config
+from lib.codex_config import (
+    validate_codex_config,
+    _validate_interface,
+    _validate_tool_entry,
+    _is_valid_relative_path,
+)
 from lib.constants import (
     CODEX_MAX_DISPLAY_NAME_LENGTH,
     CODEX_MAX_SHORT_DESCRIPTION_LENGTH,
@@ -700,6 +706,237 @@ class CodexConfigIntegrationTests(unittest.TestCase):
             and "Non-standard" in e
         ]
         self.assertEqual(dir_warns, [])
+
+
+# ===================================================================
+# File Read Errors
+# ===================================================================
+
+
+class CodexConfigFileReadErrorTests(unittest.TestCase):
+    """Tests for OSError and YAML parse failure paths."""
+
+    def test_oserror_on_read_returns_warn(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, "interface:\n  display_name: x\n")
+            with mock.patch("lib.codex_config.open", side_effect=OSError("EIO")):
+                errors, passes = validate_codex_config(tmpdir)
+        self.assertEqual(len(errors), 1)
+        self.assertIn(LEVEL_WARN, errors[0])
+        self.assertIn("cannot read", errors[0])
+        self.assertEqual(passes, [])
+
+    def test_yaml_parse_valueerror_returns_warn(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, "interface:\n  display_name: x\n")
+            with mock.patch(
+                "lib.codex_config.parse_yaml_subset",
+                side_effect=ValueError("bad yaml"),
+            ):
+                errors, passes = validate_codex_config(tmpdir)
+        self.assertEqual(len(errors), 1)
+        self.assertIn(LEVEL_WARN, errors[0])
+        self.assertIn("YAML parse error", errors[0])
+        self.assertIn("bad yaml", errors[0])
+
+    def test_top_level_non_mapping_returns_warn(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, "interface:\n  display_name: x\n")
+            with mock.patch(
+                "lib.codex_config.parse_yaml_subset",
+                return_value="a scalar",
+            ):
+                errors, passes = validate_codex_config(tmpdir)
+        self.assertEqual(len(errors), 1)
+        self.assertIn(LEVEL_WARN, errors[0])
+        self.assertIn("top-level must be a mapping", errors[0])
+
+
+# ===================================================================
+# Section Type Errors (non-mapping for interface / policy / dependencies)
+# ===================================================================
+
+
+class CodexConfigSectionTypeTests(unittest.TestCase):
+    """Tests for non-mapping values at the interface/policy/dependencies keys."""
+
+    def test_interface_non_mapping_returns_warn(self) -> None:
+        config = 'interface: "not-a-mapping"\n'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, config)
+            errors, passes = validate_codex_config(tmpdir)
+        warn = [
+            e for e in errors
+            if e.startswith(LEVEL_WARN) and "'interface' should be a mapping" in e
+        ]
+        self.assertEqual(len(warn), 1)
+
+    def test_policy_non_mapping_returns_warn(self) -> None:
+        config = 'policy: "flat"\n'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, config)
+            errors, passes = validate_codex_config(tmpdir)
+        warn = [
+            e for e in errors
+            if e.startswith(LEVEL_WARN) and "'policy' should be a mapping" in e
+        ]
+        self.assertEqual(len(warn), 1)
+
+    def test_dependencies_non_mapping_returns_warn(self) -> None:
+        config = 'dependencies: "x"\n'
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, config)
+            errors, passes = validate_codex_config(tmpdir)
+        warn = [
+            e for e in errors
+            if e.startswith(LEVEL_WARN) and "'dependencies' should be a mapping" in e
+        ]
+        self.assertEqual(len(warn), 1)
+
+    def test_policy_without_allow_implicit_invocation_skips_boolean_check(self) -> None:
+        config = "policy:\n  unknown_key: value\n"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, config)
+            errors, passes = validate_codex_config(tmpdir)
+        boolean_warns = [
+            e for e in errors
+            if e.startswith(LEVEL_WARN) and "allow_implicit_invocation" in e
+        ]
+        self.assertEqual(boolean_warns, [])
+
+    def test_dependencies_without_tools_returns_no_warn(self) -> None:
+        config = "dependencies:\n  other_key: value\n"
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, config)
+            errors, passes = validate_codex_config(tmpdir)
+        tools_warns = [
+            e for e in errors
+            if e.startswith(LEVEL_WARN) and "tools" in e
+        ]
+        self.assertEqual(tools_warns, [])
+
+
+# ===================================================================
+# Interface Non-String Field Values (direct _validate_interface calls)
+# ===================================================================
+
+
+class CodexConfigInterfaceNonStringTests(unittest.TestCase):
+    """Non-string field values exercise the ``isinstance`` error branches.
+
+    YAML scalar values always parse to strings, so these branches can only
+    be hit by passing a pre-built mapping directly to ``_validate_interface``.
+    """
+
+    def test_display_name_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_interface({"display_name": 42})
+        self.assertEqual(len(errors), 1)
+        self.assertIn(LEVEL_WARN, errors[0])
+        self.assertIn("display_name", errors[0])
+        self.assertIn("should be a string", errors[0])
+
+    def test_short_description_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_interface({"short_description": ["a", "b"]})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("short_description", errors[0])
+        self.assertIn("should be a string", errors[0])
+
+    def test_icon_small_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_interface({"icon_small": 1})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("icon_small", errors[0])
+        self.assertIn("should be a string", errors[0])
+
+    def test_icon_large_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_interface({"icon_large": ["x"]})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("icon_large", errors[0])
+        self.assertIn("should be a string", errors[0])
+
+    def test_brand_color_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_interface({"brand_color": 0x10B981})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("brand_color", errors[0])
+        self.assertIn("should be a string", errors[0])
+
+    def test_default_prompt_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_interface({"default_prompt": {"nested": "x"}})
+        self.assertEqual(len(errors), 1)
+        self.assertIn("default_prompt", errors[0])
+        self.assertIn("should be a string", errors[0])
+
+
+# ===================================================================
+# Tool Entry Non-String / Non-Mapping Branches
+# ===================================================================
+
+
+class CodexConfigToolEntryTests(unittest.TestCase):
+    """Tests for ``_validate_tool_entry`` error branches."""
+
+    def test_tool_entry_non_mapping_returns_warn(self) -> None:
+        errors, _ = _validate_tool_entry("plainstring", 0)
+        self.assertEqual(len(errors), 1)
+        self.assertIn(LEVEL_WARN, errors[0])
+        self.assertIn("dependencies.tools[0]", errors[0])
+        self.assertIn("should be a mapping", errors[0])
+
+    def test_tool_unrecognized_keys_returns_info(self) -> None:
+        errors, _ = _validate_tool_entry(
+            {"type": "mcp", "value": "server", "wibble": "x"}, 2,
+        )
+        info_wibble = [
+            e for e in errors
+            if e.startswith(LEVEL_INFO) and "wibble" in e
+        ]
+        self.assertEqual(len(info_wibble), 1)
+        self.assertIn("dependencies.tools[2]", info_wibble[0])
+
+    def test_tool_type_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_tool_entry({"type": 42, "value": "x"}, 0)
+        warns = [e for e in errors if "type" in e and "should be a string" in e]
+        self.assertEqual(len(warns), 1)
+
+    def test_tool_value_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_tool_entry({"type": "builtin", "value": 99}, 0)
+        warns = [e for e in errors if ".value" in e and "should be a string" in e]
+        self.assertEqual(len(warns), 1)
+
+    def test_tool_description_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_tool_entry(
+            {"type": "builtin", "value": "bash", "description": 1}, 0,
+        )
+        warns = [e for e in errors if "description" in e and "should be a string" in e]
+        self.assertEqual(len(warns), 1)
+
+    def test_tool_transport_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_tool_entry(
+            {"type": "mcp", "value": "srv", "transport": 123}, 0,
+        )
+        warns = [e for e in errors if "transport" in e and "should be a string" in e]
+        self.assertEqual(len(warns), 1)
+
+    def test_tool_url_non_string_returns_warn(self) -> None:
+        errors, _ = _validate_tool_entry(
+            {"type": "mcp", "value": "srv", "url": 77}, 0,
+        )
+        warns = [e for e in errors if "url" in e and "should be a string" in e]
+        self.assertEqual(len(warns), 1)
+
+
+# ===================================================================
+# _is_valid_relative_path edge cases
+# ===================================================================
+
+
+class IsValidRelativePathEdgeTests(unittest.TestCase):
+    """Tests for ``_is_valid_relative_path`` boundary conditions."""
+
+    def test_whitespace_only_path_rejected(self) -> None:
+        self.assertFalse(_is_valid_relative_path("   "))
+
+    def test_empty_string_rejected(self) -> None:
+        self.assertFalse(_is_valid_relative_path(""))
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -719,7 +719,7 @@ class CodexConfigFileReadErrorTests(unittest.TestCase):
     def test_oserror_on_read_returns_warn(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             _write_codex_config(tmpdir, "interface:\n  display_name: x\n")
-            with mock.patch("lib.codex_config.open", side_effect=OSError("EIO")):
+            with mock.patch("builtins.open", side_effect=OSError("EIO")):
                 errors, passes = validate_codex_config(tmpdir)
         self.assertEqual(len(errors), 1)
         self.assertIn(LEVEL_WARN, errors[0])

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -1848,14 +1848,9 @@ class CheckReferencesTailTests(unittest.TestCase):
         """A pure ``[text](#anchor)`` reference is skipped, not reported as broken."""
         with tempfile.TemporaryDirectory() as tmpdir:
             skill_dir = os.path.join(tmpdir, "demo-skill")
-            write_skill_md(
-                skill_dir,
-                body="# Skill\n\nJump to [top](#overview) for details.\n",
-            )
+            os.makedirs(skill_dir)
             skill_md = os.path.join(skill_dir, "SKILL.md")
-            with open(skill_md, "r", encoding="utf-8") as f:
-                content = f.read()
-            body = content.split("---\n", 2)[2]
+            body = "# Skill\n\nJump to [top](#overview) for details.\n"
             errors, passes = validate_body(body, skill_md, skill_dir)
         broken = [e for e in errors if "does not exist" in e]
         self.assertEqual(broken, [])
@@ -1873,18 +1868,12 @@ class CheckReferencesTailTests(unittest.TestCase):
             # scripts/, or assets/ — so we use a path that begins with
             # references/ but escapes via ../../
             write_text(os.path.join(tmpdir, "shared.md"), "# Shared\n")
-            write_skill_md(
-                skill_dir,
-                body=(
-                    "# Skill\n\n"
-                    "See [guide](references/guide.md) for details.\n"
-                    "Also see [shared](references/../../shared.md).\n"
-                ),
-            )
             skill_md = os.path.join(skill_dir, "SKILL.md")
-            with open(skill_md, "r", encoding="utf-8") as f:
-                content = f.read()
-            body = content.split("---\n", 2)[2]
+            body = (
+                "# Skill\n\n"
+                "See [guide](references/guide.md) for details.\n"
+                "Also see [shared](references/../../shared.md).\n"
+            )
             errors, passes = validate_body(body, skill_md, skill_dir)
         combined = [
             p for p in passes
@@ -1919,7 +1908,12 @@ def _run_main(argv: list[str]) -> tuple[int, str, str]:
         try:
             vs.main()
         except SystemExit as exc:
-            code = exc.code if isinstance(exc.code, int) else 1
+            if exc.code is None:
+                code = 0
+            elif isinstance(exc.code, int):
+                code = exc.code
+            else:
+                code = 1
     return code, stdout.getvalue(), stderr.getvalue()
 
 

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -5,11 +5,15 @@ validate_skill, optional frontmatter field validation, and the
 main() CLI entry point.
 """
 
+import contextlib
+import io
+import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 from helpers import write_text, write_skill_md
 
@@ -1830,6 +1834,243 @@ class MainCLITests(unittest.TestCase):
                 cwd=REPO_ROOT,
             )
         self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+
+
+# ===================================================================
+# _check_references tail branches
+# ===================================================================
+
+
+class CheckReferencesTailTests(unittest.TestCase):
+    """Tests for rarely-hit branches in the reference checker."""
+
+    def test_pure_fragment_reference_produces_no_broken_warning(self) -> None:
+        """A pure ``[text](#anchor)`` reference is skipped, not reported as broken."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_skill_md(
+                skill_dir,
+                body="# Skill\n\nJump to [top](#overview) for details.\n",
+            )
+            skill_md = os.path.join(skill_dir, "SKILL.md")
+            with open(skill_md, "r", encoding="utf-8") as f:
+                content = f.read()
+            body = content.split("---\n", 2)[2]
+            errors, passes = validate_body(body, skill_md, skill_dir)
+        broken = [e for e in errors if "does not exist" in e]
+        self.assertEqual(broken, [])
+
+    def test_internal_plus_external_refs_emit_combined_pass(self) -> None:
+        """A mix of valid intra-skill refs and an external ref emits the combined pass."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_text(
+                os.path.join(skill_dir, "references", "guide.md"),
+                "# Guide\n",
+            )
+            # External ref: resolves outside skill_dir after normalization.
+            # The regex only captures paths starting with references/,
+            # scripts/, or assets/ — so we use a path that begins with
+            # references/ but escapes via ../../
+            write_text(os.path.join(tmpdir, "shared.md"), "# Shared\n")
+            write_skill_md(
+                skill_dir,
+                body=(
+                    "# Skill\n\n"
+                    "See [guide](references/guide.md) for details.\n"
+                    "Also see [shared](references/../../shared.md).\n"
+                ),
+            )
+            skill_md = os.path.join(skill_dir, "SKILL.md")
+            with open(skill_md, "r", encoding="utf-8") as f:
+                content = f.read()
+            body = content.split("---\n", 2)[2]
+            errors, passes = validate_body(body, skill_md, skill_dir)
+        combined = [
+            p for p in passes
+            if "external refs excluded from nesting checks" in p
+            and "internal refs one level deep" in p
+        ]
+        self.assertEqual(len(combined), 1)
+
+
+# ===================================================================
+# main() in-process — covers CLI-entry branches for coverage
+# ===================================================================
+
+
+def _run_main(argv: list[str]) -> tuple[int, str, str]:
+    """Invoke validate_skill.main() in-process and capture streams.
+
+    Returns ``(exit_code, stdout, stderr)``.  Subprocess-based CLI tests
+    cannot contribute to coverage because the coverage session does not
+    span child Python processes.
+    """
+    import validate_skill as vs
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = 0
+    with (
+        mock.patch.object(sys, "argv", argv),
+        contextlib.redirect_stdout(stdout),
+        contextlib.redirect_stderr(stderr),
+    ):
+        try:
+            vs.main()
+        except SystemExit as exc:
+            code = exc.code if isinstance(exc.code, int) else 1
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+class MainInProcessTests(unittest.TestCase):
+    """In-process coverage for the ``main()`` CLI entry point."""
+
+    def test_no_args_prints_docstring_and_exits_1(self) -> None:
+        code, out, _ = _run_main(["validate_skill.py"])
+        self.assertEqual(code, 1)
+        self.assertIn("Usage:", out)
+
+    def test_non_directory_path_text_mode_exits_1(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f_path = os.path.join(tmpdir, "not-a-dir.txt")
+            write_text(f_path, "x")
+            code, out, _ = _run_main(["validate_skill.py", f_path])
+        self.assertEqual(code, 1)
+        self.assertIn("not a directory", out.lower())
+
+    def test_non_directory_path_json_mode_emits_envelope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            f_path = os.path.join(tmpdir, "not-a-dir.txt")
+            write_text(f_path, "x")
+            code, out, _ = _run_main(["validate_skill.py", f_path, "--json"])
+        self.assertEqual(code, 1)
+        payload = json.loads(out)
+        self.assertEqual(payload["tool"], "validate_skill")
+        self.assertFalse(payload["success"])
+        self.assertIn("is not a directory", payload["error"])
+
+    def test_valid_skill_text_mode_prints_all_passed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_skill_md(skill_dir)
+            code, out, _ = _run_main(["validate_skill.py", skill_dir])
+        self.assertEqual(code, 0)
+        self.assertIn("All checks passed", out)
+
+    def test_valid_skill_verbose_prints_pass_list(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_skill_md(skill_dir)
+            code, out, _ = _run_main(["validate_skill.py", skill_dir, "--verbose"])
+        self.assertEqual(code, 0)
+        self.assertIn("\u2713", out)
+        self.assertIn("All checks passed", out)
+        self.assertIn("checks", out)
+
+    def test_valid_skill_json_non_verbose_omits_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_skill_md(skill_dir)
+            code, out, _ = _run_main(["validate_skill.py", skill_dir, "--json"])
+        self.assertEqual(code, 0)
+        payload = json.loads(out)
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["type"], "registered skill")
+        self.assertIn("summary", payload)
+        self.assertNotIn("passes", payload)
+
+    def test_valid_skill_json_verbose_includes_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_skill_md(skill_dir)
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--json", "--verbose"],
+            )
+        self.assertEqual(code, 0)
+        payload = json.loads(out)
+        self.assertTrue(payload["success"])
+        self.assertIn("passes", payload)
+        self.assertIsInstance(payload["passes"], list)
+
+    def test_failing_skill_text_mode_exits_1_with_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_text(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: demo-skill\n---\n\n# Skill\n",
+            )
+            code, out, _ = _run_main(["validate_skill.py", skill_dir])
+        self.assertEqual(code, 1)
+        self.assertIn("Results:", out)
+        self.assertIn("failure", out.lower())
+
+    def test_failing_skill_json_mode_exits_1(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_text(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: demo-skill\n---\n\n# Skill\n",
+            )
+            code, out, _ = _run_main(["validate_skill.py", skill_dir, "--json"])
+        self.assertEqual(code, 1)
+        payload = json.loads(out)
+        self.assertFalse(payload["success"])
+        self.assertGreaterEqual(payload["summary"]["failures"], 1)
+
+    def test_warn_only_skill_json_mode_exits_0(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_skill_md(
+                skill_dir,
+                body="# Skill\n\nSee [gone](references/missing.md) for details.\n",
+            )
+            code, out, _ = _run_main(["validate_skill.py", skill_dir, "--json"])
+        self.assertEqual(code, 0)
+        payload = json.loads(out)
+        self.assertTrue(payload["success"])
+        self.assertGreaterEqual(payload["summary"]["warnings"], 1)
+
+    def test_argparse_failure_text_mode_exits_1(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_skill_md(skill_dir)
+            code, _out, err = _run_main(
+                ["validate_skill.py", skill_dir, "--bogus"],
+            )
+        self.assertEqual(code, 1)
+        self.assertIn("unrecognized arguments", err)
+
+    def test_argparse_failure_json_mode_emits_envelope(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_skill_md(skill_dir)
+            code, out, _err = _run_main(
+                ["validate_skill.py", skill_dir, "--bogus", "--json"],
+            )
+        self.assertEqual(code, 1)
+        payload = json.loads(out)
+        self.assertEqual(payload["tool"], "validate_skill")
+        self.assertFalse(payload["success"])
+        self.assertIn("error", payload)
+
+    def test_missing_positional_json_mode_emits_envelope(self) -> None:
+        code, out, _err = _run_main(["validate_skill.py", "--json"])
+        self.assertEqual(code, 1)
+        payload = json.loads(out)
+        self.assertFalse(payload["success"])
+        self.assertIn("error", payload)
+
+    def test_capability_mode_json_reports_capability_type(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cap_dir = os.path.join(tmpdir, "my-cap")
+            _write_capability_md(cap_dir, body="# Cap\n")
+            code, out, _ = _run_main(
+                ["validate_skill.py", cap_dir, "--capability", "--json"],
+            )
+        self.assertEqual(code, 0)
+        payload = json.loads(out)
+        self.assertEqual(payload["type"], "capability")
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Adds targeted tests that raise branch coverage for three files flagged in #87. All three files now sit well above the 95% acceptance target, with codex_config at full branch coverage:

| File | Before | After |
|---|---|---|
| `skill-system-foundry/scripts/validate_skill.py` | 81% | 98.3% |
| `skill-system-foundry/scripts/lib/codex_config.py` | 83% | 100.0% |
| `skill-system-foundry/scripts/lib/bundling.py` | 86% | 99.4% |

No production code was modified — test files only (+1026 lines, -1).

### What's covered now

**`validate_skill.py`** — the `main()` CLI entry point (previously 0% measured because prior tests ran it via `subprocess`, which the coverage session does not span). Added a `MainInProcessTests` class that patches `sys.argv` + `redirect_stdout/stderr` and catches `SystemExit`, plus tail-branch tests for `_check_references` covering pure-fragment references and the combined internal/external pass message.

**`lib/codex_config.py`** — OSError on read, YAML `ValueError`, non-mapping top-level, non-mapping section values (interface/policy/dependencies), non-string field values for every `interface` / tool-entry field (via direct `_validate_interface` / `_validate_tool_entry` calls, since the YAML subset parser coerces scalars to strings and cannot exercise the `isinstance` branches), and the `icon_large` invalid-path / valid-path branches.

**`lib/bundling.py`** — `OSError` wrapping for `_copy_skill` / `_copy_external_files` / `_copy_inlined_skills`; directory-as-external-ref; postvalidate branches (zero/multiple SKILL.md, missing `capability.md`, markdown + backtick reference escape / unresolved / skipped / resolved-to-existing paths, multi-backtick lines, non-directory entries under `capabilities/`); `_rewrite_reference_target` empty-input and no-change paths; `_rewrite_markdown_paths` empty-map fast-path; `_build_rewrite_map` with empty `skill_files` and with skill_files but no system_root; cross-drive `relpath` `ValueError` fallbacks in `_compute_original_paths` and `_build_rewrite_map`; invalid `bundle_target`, spec-failure aggregation, non-failing spec-message surfacing, and the `no-description` branch in `prevalidate`.

### Remaining uncovered branches (3 total)

Three branches remain uncovered across all three files. Each is genuinely unreachable from the current code paths, not an omission:

- `bundling.py:382` — `if not orig_path: continue`. Defensive guard against an empty string in `_compute_original_paths` output. `os.path.relpath` never returns an empty string, so the set cannot contain one.
- `validate_skill.py:21` — the `if _scripts_dir not in sys.path: sys.path.insert(...)` guard. Only fires on the very first import of the module; by the time any test runs, the test bootstrap has already placed the directory on `sys.path`.
- `validate_skill.py:166` — the `continue` after `strip_fragment` returns an empty path. The reference-detection regex only captures paths beginning with `references/`, `scripts/`, or `assets/`, so `strip_fragment` can never return an empty string for a matched reference.

Reaching these would require reimport tricks or non-representative inputs that make the tests brittle without catching anything real.

## Test plan

- [x] `python -m coverage run -m unittest discover -s tests -p "test_*.py"` — 1183 tests pass (64 new).
- [x] `python -m coverage report` — per-file branch coverage: bundling 99.4%, codex_config 100.0%, validate_skill 98.3%.
- [x] `.github/scripts/check-per-file-coverage.py` — all files pass the 70% CI gate.
- [x] CI `python-tests.yaml` (ubuntu + windows, Python 3.12) passes in the PR.
- [x] CI `codex-code-review.yaml` completes without surfacing regressions.