### PR TITLE
Apply YAML 1.2.2 divergence checks at every parse and emit site

### DIFF
--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -62,7 +62,6 @@ from lib.discovery import (
     read_file,
 )
 from lib.constants import (
-    CONFIG_PATH,
     DIR_SKILLS, DIR_CAPABILITIES, DIR_SHARED,
     FILE_SKILL_MD, FILE_CAPABILITY_MD, FILE_MANIFEST, EXT_MARKDOWN,
     MAX_BODY_LINES, MAX_DESCRIPTION_CHARS,
@@ -70,7 +69,7 @@ from lib.constants import (
     RE_SKILL_REF, RE_CAPABILITY_REF, MIN_ROLE_SKILLS,
     SEPARATOR_WIDTH,
     LEVEL_FAIL, LEVEL_WARN, LEVEL_INFO,
-    get_config_findings,
+    collect_foundry_config_findings,
 )
 
 
@@ -170,18 +169,8 @@ def audit_skill_system(
     system_root = os.path.abspath(system_root)
 
     # When auditing the foundry itself, surface configuration.yaml
-    # divergences detected at constants.py import.  Detection matches
-    # the loaded config path against <system_root>/scripts/lib/...
-    candidate_config = os.path.abspath(
-        os.path.join(system_root, "scripts", "lib", "configuration.yaml")
-    )
-    if candidate_config == CONFIG_PATH:
-        for f in get_config_findings():
-            level, _, detail = f.partition(": ")
-            detail = detail.removeprefix("[spec] ").removeprefix("[spec]").lstrip()
-            errors.append(
-                f"{level}: [foundry] scripts/lib/configuration.yaml {detail}"
-            )
+    # divergences detected at constants.py import.
+    errors.extend(collect_foundry_config_findings(system_root))
 
     skills_dir = os.path.join(system_root, DIR_SKILLS)
     has_skills_dir = os.path.isdir(skills_dir)

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -412,7 +412,15 @@ def audit_skill_system(
             if verbose:
                 print(f"  \u2713 {FILE_MANIFEST} exists")
             try:
-                manifest = parse_yaml_subset(read_file(manifest_path))
+                scalar_findings: list[str] = []
+                manifest = parse_yaml_subset(
+                    read_file(manifest_path), scalar_findings,
+                )
+                for finding in scalar_findings:
+                    level, _, detail = finding.partition(": ")
+                    errors.append(
+                        f"{level}: [spec] {FILE_MANIFEST} {detail}"
+                    )
                 if manifest and isinstance(manifest.get("skills"), dict):
                     for skill_name, skill_def in manifest["skills"].items():
                         skill_dir = os.path.join(

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -62,6 +62,7 @@ from lib.discovery import (
     read_file,
 )
 from lib.constants import (
+    CONFIG_PATH,
     DIR_SKILLS, DIR_CAPABILITIES, DIR_SHARED,
     FILE_SKILL_MD, FILE_CAPABILITY_MD, FILE_MANIFEST, EXT_MARKDOWN,
     MAX_BODY_LINES, MAX_DESCRIPTION_CHARS,
@@ -69,6 +70,7 @@ from lib.constants import (
     RE_SKILL_REF, RE_CAPABILITY_REF, MIN_ROLE_SKILLS,
     SEPARATOR_WIDTH,
     LEVEL_FAIL, LEVEL_WARN, LEVEL_INFO,
+    get_config_findings,
 )
 
 
@@ -166,6 +168,19 @@ def audit_skill_system(
     """
     errors: list[str] = []
     system_root = os.path.abspath(system_root)
+
+    # When auditing the foundry itself, surface configuration.yaml
+    # divergences detected at constants.py import.  Detection matches
+    # the loaded config path against <system_root>/scripts/lib/...
+    candidate_config = os.path.abspath(
+        os.path.join(system_root, "scripts", "lib", "configuration.yaml")
+    )
+    if candidate_config == CONFIG_PATH:
+        for f in get_config_findings():
+            level, _, detail = f.partition(": ")
+            errors.append(
+                f"{level}: [foundry] scripts/lib/configuration.yaml {detail}"
+            )
 
     skills_dir = os.path.join(system_root, DIR_SKILLS)
     has_skills_dir = os.path.isdir(skills_dir)

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -178,6 +178,7 @@ def audit_skill_system(
     if candidate_config == CONFIG_PATH:
         for f in get_config_findings():
             level, _, detail = f.partition(": ")
+            detail = detail.removeprefix("[spec] ").removeprefix("[spec]").lstrip()
             errors.append(
                 f"{level}: [foundry] scripts/lib/configuration.yaml {detail}"
             )
@@ -418,6 +419,7 @@ def audit_skill_system(
                 )
                 for finding in scalar_findings:
                     level, _, detail = finding.partition(": ")
+                    detail = detail.removeprefix("[spec] ").removeprefix("[spec]").lstrip()
                     errors.append(
                         f"{level}: [spec] {FILE_MANIFEST} {detail}"
                     )

--- a/skill-system-foundry/scripts/lib/codex_config.py
+++ b/skill-system-foundry/scripts/lib/codex_config.py
@@ -98,6 +98,7 @@ def validate_codex_config(skill_path: str) -> tuple[list[str], list[str]]:
 
     for finding in scalar_findings:
         level, _, detail = finding.partition(": ")
+        detail = detail.removeprefix("[spec] ").removeprefix("[spec]").lstrip()
         errors.append(
             f"{level}: [platform: OpenAI] {FILE_CODEX_CONFIG} {detail}"
         )

--- a/skill-system-foundry/scripts/lib/codex_config.py
+++ b/skill-system-foundry/scripts/lib/codex_config.py
@@ -87,13 +87,20 @@ def validate_codex_config(skill_path: str) -> tuple[list[str], list[str]]:
         )
         return errors, passes
 
+    scalar_findings: list[str] = []
     try:
-        config = parse_yaml_subset(text)
+        config = parse_yaml_subset(text, scalar_findings)
     except ValueError as exc:
         errors.append(
             f"{LEVEL_WARN}: [platform: OpenAI] {FILE_CODEX_CONFIG} YAML parse error: {exc}"
         )
         return errors, passes
+
+    for finding in scalar_findings:
+        level, _, detail = finding.partition(": ")
+        errors.append(
+            f"{level}: [platform: OpenAI] {FILE_CODEX_CONFIG} {detail}"
+        )
 
     if not isinstance(config, dict):
         errors.append(

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -111,19 +111,26 @@ def collect_foundry_config_findings(target_path: str) -> list[str]:
     """Return configuration.yaml divergence findings when *target_path* is the foundry.
 
     Shared gate + retag helper used by ``validate_skill`` and
-    ``audit_skill_system``.  Detects the foundry by comparing
-    ``<target_path>/scripts/lib/configuration.yaml`` against the
-    absolute path that ``constants.py`` loaded at import.  When the
-    paths match, each finding produced by :func:`get_config_findings`
-    has its original ``[spec]`` tag stripped and is re-tagged with
-    ``[foundry] scripts/lib/configuration.yaml``.  Third-party skills
-    never trigger this check because their configuration file (if any)
-    lives at a different absolute path.
+    ``audit_skill_system``.  Detects the foundry by comparing a
+    canonicalized ``<target_path>/scripts/lib/configuration.yaml``
+    path against the canonicalized path that ``constants.py`` loaded
+    at import — matching the ``normcase(realpath(...))`` pattern used
+    elsewhere in ``scripts/lib/`` so symlinks and case-insensitive
+    filesystems (macOS, Windows) do not silently skip the check.
+    When the paths match, each finding produced by
+    :func:`get_config_findings` has its original ``[spec]`` tag
+    stripped and is re-tagged with ``[foundry]
+    scripts/lib/configuration.yaml``.  Third-party skills never
+    trigger this check because their configuration file (if any)
+    lives at a different canonical path.
     """
-    candidate = os.path.abspath(
-        os.path.join(target_path, "scripts", "lib", "configuration.yaml")
+    candidate = os.path.normcase(
+        os.path.realpath(
+            os.path.join(target_path, "scripts", "lib", "configuration.yaml")
+        )
     )
-    if candidate != CONFIG_PATH:
+    config_path = os.path.normcase(os.path.realpath(CONFIG_PATH))
+    if candidate != config_path:
         return []
     retagged: list[str] = []
     for f in get_config_findings():

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -106,6 +106,34 @@ def get_config_findings() -> list[str]:
         _CONFIG_FINDINGS = collected
     return list(_CONFIG_FINDINGS)
 
+
+def collect_foundry_config_findings(target_path: str) -> list[str]:
+    """Return configuration.yaml divergence findings when *target_path* is the foundry.
+
+    Shared gate + retag helper used by ``validate_skill`` and
+    ``audit_skill_system``.  Detects the foundry by comparing
+    ``<target_path>/scripts/lib/configuration.yaml`` against the
+    absolute path that ``constants.py`` loaded at import.  When the
+    paths match, each finding produced by :func:`get_config_findings`
+    has its original ``[spec]`` tag stripped and is re-tagged with
+    ``[foundry] scripts/lib/configuration.yaml``.  Third-party skills
+    never trigger this check because their configuration file (if any)
+    lives at a different absolute path.
+    """
+    candidate = os.path.abspath(
+        os.path.join(target_path, "scripts", "lib", "configuration.yaml")
+    )
+    if candidate != CONFIG_PATH:
+        return []
+    retagged: list[str] = []
+    for f in get_config_findings():
+        level, _, detail = f.partition(": ")
+        detail = detail.removeprefix("[spec] ").removeprefix("[spec]").lstrip()
+        retagged.append(
+            f"{level}: [foundry] scripts/lib/configuration.yaml {detail}"
+        )
+    return retagged
+
 # --- Skill Validation ---
 _skill = _config["skill"]
 

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -75,9 +75,36 @@ PH_ROLE_TITLE = "<Role Name>"
 # Validation Rules (loaded from configuration.yaml)
 # ===================================================================
 
-_config_path = os.path.join(os.path.dirname(__file__), "configuration.yaml")
-with open(_config_path, "r", encoding="utf-8") as _f:
+CONFIG_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "configuration.yaml")
+)
+
+# Config is parsed twice by design: once at module load without findings
+# (to populate the constants PLAIN_SCALAR_INDICATORS depends on), and
+# lazily on first get_config_findings() call with findings enabled.
+# Doing both in a single load would trigger a circular import because
+# _check_plain_scalar imports PLAIN_SCALAR_INDICATORS from this module.
+with open(CONFIG_PATH, "r", encoding="utf-8") as _f:
     _config = parse_yaml_subset(_f.read())
+
+_CONFIG_FINDINGS: list[str] | None = None
+
+
+def get_config_findings() -> list[str]:
+    """Return plain-scalar divergence findings from ``configuration.yaml``.
+
+    Lazily re-parses the config with a findings list on first call
+    and caches the result.  Findings carry the ``FAIL:`` / ``WARN:``
+    prefix produced by the YAML subset parser.  Returns a copy so
+    callers cannot mutate the cached list.
+    """
+    global _CONFIG_FINDINGS
+    if _CONFIG_FINDINGS is None:
+        collected: list[str] = []
+        with open(CONFIG_PATH, "r", encoding="utf-8") as fh:
+            parse_yaml_subset(fh.read(), collected)
+        _CONFIG_FINDINGS = collected
+    return list(_CONFIG_FINDINGS)
 
 # --- Skill Validation ---
 _skill = _config["skill"]
@@ -184,7 +211,7 @@ CODEX_KNOWN_DEPENDENCIES_KEYS = frozenset(_codex["known_dependencies_keys"])
 CODEX_KNOWN_TOOL_KEYS = frozenset(_codex["known_tool_keys"])
 
 # Clean up private names
-del _config_path, _f, _config
+del _f, _config
 del _skill, _skill_name, _skill_desc, _voice, _skill_body, _body_refs
 del _allowed_tools, _metadata, _plain_scalar, _WS_DECODE
 del _dep, _role, _bundle

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -49,9 +49,11 @@ def read_manifest(path: str, findings: list[str] | None = None) -> dict:
         text = f.read()
     if not text.strip():
         return {}
-    # Collect findings locally and only extend the caller-provided list
-    # on the success path so structural failures never mutate it.
-    local_findings: list[str] = []
+    # When the caller asks for findings, collect them into a local list
+    # and only extend the caller-provided list on the success path so
+    # structural failures never mutate it.  When findings is None,
+    # avoid allocating and skip plain-scalar checks entirely.
+    local_findings: list[str] | None = [] if findings is not None else None
     try:
         # Collect all top-level content lines for validation
         top_level_lines = [
@@ -105,7 +107,7 @@ def read_manifest(path: str, findings: list[str] | None = None) -> dict:
             f"Failed to parse {path}: {exc}"
         ) from exc
 
-    if findings is not None:
+    if findings is not None and local_findings:
         findings.extend(local_findings)
     return manifest
 

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -323,16 +323,18 @@ def update_manifest_for_skill(
     """Ensure *manifest_path* exists and append a skill entry.
 
     Returns ``(updated, warning, created_manifest, findings)`` where
-    *updated* is True when the manifest was modified, *warning* is a
-    human-readable message when a conflict prevented the update or
-    when the emit step produced structurally invalid YAML,
-    *created_manifest* is True when a new manifest file was
-    scaffolded, and *findings* is a list of plain-scalar divergence
-    findings produced while reading the existing manifest plus any
-    additional findings returned by ``append_skill_entry`` after the
-    new entry is written.  When the emitted manifest fails to parse,
-    *updated* is False and *warning* describes the corruption so
-    callers that ignore *findings* still see the failure.
+    *updated* is True only when the skill entry was appended and the
+    emitted manifest remained structurally valid (i.e., the manifest
+    is left in a usable state), *warning* is a human-readable message
+    when a conflict prevented the update or when the emit step
+    produced structurally invalid YAML, *created_manifest* is True
+    when a new manifest file was scaffolded, and *findings* is a list
+    of plain-scalar divergence findings produced while reading the
+    existing manifest plus any additional findings returned by
+    ``append_skill_entry`` after the write attempt.  When the emitted
+    manifest fails to parse, *updated* is False even though bytes were
+    written to disk, and *warning* describes the corruption so callers
+    that ignore *findings* still see the failure.
     """
     created_manifest = False
     # Treat non-existent or empty/whitespace-only files as missing.
@@ -377,16 +379,18 @@ def update_manifest_for_role(
     """Ensure *manifest_path* exists and append a role entry.
 
     Returns ``(updated, warning, created_manifest, findings)`` where
-    *updated* is True when the manifest was modified, *warning* is a
-    human-readable message when a conflict prevented the update or
-    when the emit step produced structurally invalid YAML,
-    *created_manifest* is True when a new manifest file was
-    scaffolded, and *findings* is a list of plain-scalar divergence
-    findings produced while reading the existing manifest plus any
-    additional findings returned by ``append_role_entry`` after the
-    new entry is written.  When the emitted manifest fails to parse,
-    *updated* is False and *warning* describes the corruption so
-    callers that ignore *findings* still see the failure.
+    *updated* is True only when the role entry was appended and the
+    emitted manifest remained structurally valid (i.e., the manifest
+    is left in a usable state), *warning* is a human-readable message
+    when a conflict prevented the update or when the emit step
+    produced structurally invalid YAML, *created_manifest* is True
+    when a new manifest file was scaffolded, and *findings* is a list
+    of plain-scalar divergence findings produced while reading the
+    existing manifest plus any additional findings returned by
+    ``append_role_entry`` after the write attempt.  When the emitted
+    manifest fails to parse, *updated* is False even though bytes were
+    written to disk, and *warning* describes the corruption so callers
+    that ignore *findings* still see the failure.
     """
     created_manifest = False
     # Treat non-existent or empty/whitespace-only files as missing.

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -20,11 +20,16 @@ class ManifestParseError(Exception):
     """Raised when a manifest file cannot be parsed."""
 
 
-def read_manifest(path: str) -> dict:
+def read_manifest(path: str, findings: list[str] | None = None) -> dict:
     """Read and parse a ``manifest.yaml`` file.
 
     Returns the parsed manifest as a dict.  Returns an empty dict
     when the file does not exist or is empty.
+
+    If *findings* is a list, plain-scalar divergence findings
+    produced by the YAML subset parser are appended to it on the
+    successful parse path.  Structural failures raise
+    ``ManifestParseError`` without touching *findings*.
 
     Raises:
         ManifestParseError: When the file exists but contains
@@ -53,7 +58,7 @@ def read_manifest(path: str) -> dict:
                 f"Failed to parse {path}: top-level YAML must be a mapping"
             )
 
-        manifest = parse_yaml_subset(text)
+        manifest = parse_yaml_subset(text, findings)
         if not isinstance(manifest, dict):
             raise ManifestParseError(
                 f"Failed to parse {path}: top-level YAML must be a mapping"
@@ -249,13 +254,15 @@ def update_manifest_for_skill(
     name: str,
     *,
     router: bool = False,
-) -> tuple[bool, str | None, bool]:
+) -> tuple[bool, str | None, bool, list[str]]:
     """Ensure *manifest_path* exists and append a skill entry.
 
-    Returns ``(updated, warning, created_manifest)`` where *updated*
-    is True when the manifest was modified, *warning* is a
-    human-readable message when a conflict prevented the update, and
-    *created_manifest* is True when a new manifest file was scaffolded.
+    Returns ``(updated, warning, created_manifest, findings)`` where
+    *updated* is True when the manifest was modified, *warning* is a
+    human-readable message when a conflict prevented the update,
+    *created_manifest* is True when a new manifest file was
+    scaffolded, and *findings* is a list of plain-scalar divergence
+    findings produced while reading the existing manifest.
     """
     created_manifest = False
     # Treat non-existent or empty/whitespace-only files as missing.
@@ -267,34 +274,37 @@ def update_manifest_for_skill(
         scaffold_empty_manifest(manifest_path)
         created_manifest = True
 
+    findings: list[str] = []
     try:
-        manifest = read_manifest(manifest_path)
+        manifest = read_manifest(manifest_path, findings)
     except ManifestParseError as exc:
         warning = f"{exc} — skipping manifest update"
-        return False, warning, created_manifest
+        return False, warning, created_manifest, findings
 
     if has_skill_conflict(manifest, name):
         warning = (
             f"Skill '{name}' already exists in "
             f"{manifest_path} — skipping manifest update"
         )
-        return False, warning, created_manifest
+        return False, warning, created_manifest, findings
 
     append_skill_entry(manifest_path, name, router=router)
-    return True, None, created_manifest
+    return True, None, created_manifest, findings
 
 
 def update_manifest_for_role(
     manifest_path: str,
     group: str,
     name: str,
-) -> tuple[bool, str | None, bool]:
+) -> tuple[bool, str | None, bool, list[str]]:
     """Ensure *manifest_path* exists and append a role entry.
 
-    Returns ``(updated, warning, created_manifest)`` where *updated*
-    is True when the manifest was modified, *warning* is a
-    human-readable message when a conflict prevented the update, and
-    *created_manifest* is True when a new manifest file was scaffolded.
+    Returns ``(updated, warning, created_manifest, findings)`` where
+    *updated* is True when the manifest was modified, *warning* is a
+    human-readable message when a conflict prevented the update,
+    *created_manifest* is True when a new manifest file was
+    scaffolded, and *findings* is a list of plain-scalar divergence
+    findings produced while reading the existing manifest.
     """
     created_manifest = False
     # Treat non-existent or empty/whitespace-only files as missing.
@@ -306,21 +316,22 @@ def update_manifest_for_role(
         scaffold_empty_manifest(manifest_path)
         created_manifest = True
 
+    findings: list[str] = []
     try:
-        manifest = read_manifest(manifest_path)
+        manifest = read_manifest(manifest_path, findings)
     except ManifestParseError as exc:
         warning = f"{exc} — skipping manifest update"
-        return False, warning, created_manifest
+        return False, warning, created_manifest, findings
 
     if has_role_conflict(manifest, group, name):
         warning = (
             f"Role '{name}' in group '{group}' already exists in "
             f"{manifest_path} — skipping manifest update"
         )
-        return False, warning, created_manifest
+        return False, warning, created_manifest, findings
 
     append_role_entry(manifest_path, group, name)
-    return True, None, created_manifest
+    return True, None, created_manifest, findings
 
 
 def scaffold_empty_manifest(manifest_path: str) -> None:

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -13,6 +13,7 @@ from .constants import (
     DIR_ROLES,
     FILE_SKILL_MD,
     EXT_MARKDOWN,
+    LEVEL_FAIL,
 )
 
 
@@ -191,11 +192,14 @@ def append_skill_entry(
     findings: list[str] = []
     try:
         parse_yaml_subset(text, findings)
-    except ValueError:
-        # Structural failures are already caught by read_manifest on
-        # the next read cycle; here we only care about plain-scalar
-        # divergences the caller would not otherwise see.
-        pass
+    except ValueError as exc:
+        # Surface emit-site structural corruption immediately — the
+        # manifest has already been written and callers need to know
+        # the file is no longer parseable.
+        findings.append(
+            f"{LEVEL_FAIL}: manifest emit produced unparseable YAML "
+            f"at {manifest_path}: {exc}"
+        )
     return findings
 
 
@@ -269,8 +273,11 @@ def append_role_entry(
     findings: list[str] = []
     try:
         parse_yaml_subset(text, findings)
-    except ValueError:
-        pass
+    except ValueError as exc:
+        findings.append(
+            f"{LEVEL_FAIL}: manifest emit produced unparseable YAML "
+            f"at {manifest_path}: {exc}"
+        )
     return findings
 
 
@@ -287,7 +294,9 @@ def update_manifest_for_skill(
     human-readable message when a conflict prevented the update,
     *created_manifest* is True when a new manifest file was
     scaffolded, and *findings* is a list of plain-scalar divergence
-    findings produced while reading the existing manifest.
+    findings produced while reading the existing manifest plus any
+    additional findings returned by ``append_skill_entry`` after the
+    new entry is written.
     """
     created_manifest = False
     # Treat non-existent or empty/whitespace-only files as missing.
@@ -330,7 +339,9 @@ def update_manifest_for_role(
     human-readable message when a conflict prevented the update,
     *created_manifest* is True when a new manifest file was
     scaffolded, and *findings* is a list of plain-scalar divergence
-    findings produced while reading the existing manifest.
+    findings produced while reading the existing manifest plus any
+    additional findings returned by ``append_role_entry`` after the
+    new entry is written.
     """
     created_manifest = False
     # Treat non-existent or empty/whitespace-only files as missing.

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -16,6 +16,19 @@ from .constants import (
     LEVEL_FAIL,
 )
 
+__all__ = [
+    "ManifestParseError",
+    "read_manifest",
+    "has_skill_conflict",
+    "has_role_conflict",
+    "append_skill_entry",
+    "append_role_entry",
+    "update_manifest_for_skill",
+    "update_manifest_for_role",
+    "scaffold_empty_manifest",
+    "has_emit_corruption",
+]
+
 
 class ManifestParseError(Exception):
     """Raised when a manifest file cannot be parsed."""
@@ -146,9 +159,11 @@ def append_skill_entry(
     The entry is appended after the last non-blank line in the
     ``skills:`` block.
 
-    Returns a list of plain-scalar divergence findings produced by
-    re-parsing the post-write manifest text; empty when the emitted
-    YAML is clean.
+    Returns a list of findings produced by re-validating the post-write
+    manifest with :func:`read_manifest`: plain-scalar divergences when
+    the emitted YAML is parseable, or a single FAIL entry tagged with
+    ``_EMIT_CORRUPTION_MARKER`` when the emit step produced
+    structurally invalid YAML or violated manifest-shape invariants.
     """
     with open(manifest_path, "r", encoding="utf-8") as f:
         text = f.read()
@@ -204,18 +219,7 @@ def append_skill_entry(
     with open(manifest_path, "w", encoding="utf-8") as f:
         f.write(text)
 
-    findings: list[str] = []
-    try:
-        parse_yaml_subset(text, findings)
-    except ValueError as exc:
-        # Surface emit-site structural corruption immediately — the
-        # manifest has already been written and callers need to know
-        # the file is no longer parseable.
-        findings.append(
-            f"{LEVEL_FAIL}: {_EMIT_CORRUPTION_MARKER} "
-            f"at {manifest_path}: {exc}"
-        )
-    return findings
+    return _collect_emit_findings(manifest_path)
 
 
 def append_role_entry(
@@ -227,9 +231,11 @@ def append_role_entry(
 
     Creates the group sub-key if it does not exist.
 
-    Returns a list of plain-scalar divergence findings produced by
-    re-parsing the post-write manifest text; empty when the emitted
-    YAML is clean.
+    Returns a list of findings produced by re-validating the post-write
+    manifest with :func:`read_manifest`: plain-scalar divergences when
+    the emitted YAML is parseable, or a single FAIL entry tagged with
+    ``_EMIT_CORRUPTION_MARKER`` when the emit step produced
+    structurally invalid YAML or violated manifest-shape invariants.
     """
     with open(manifest_path, "r", encoding="utf-8") as f:
         text = f.read()
@@ -285,14 +291,26 @@ def append_role_entry(
     with open(manifest_path, "w", encoding="utf-8") as f:
         f.write(text)
 
+    return _collect_emit_findings(manifest_path)
+
+
+def _collect_emit_findings(manifest_path: str) -> list[str]:
+    """Re-validate the post-write manifest for divergences and shape.
+
+    Uses :func:`read_manifest` so manifest-shape invariants (top-level
+    mapping, ``skills``/``roles`` mappings, role groups as lists) are
+    enforced consistently with read-time validation — covering
+    structural corruption that ``parse_yaml_subset`` alone would miss.
+    Plain-scalar divergence findings flow through ``read_manifest``'s
+    success path; structural failures surface as a single FAIL finding
+    tagged with ``_EMIT_CORRUPTION_MARKER`` so callers can distinguish
+    emit corruption from pre-existing divergences.
+    """
     findings: list[str] = []
     try:
-        parse_yaml_subset(text, findings)
-    except ValueError as exc:
-        findings.append(
-            f"{LEVEL_FAIL}: {_EMIT_CORRUPTION_MARKER} "
-            f"at {manifest_path}: {exc}"
-        )
+        read_manifest(manifest_path, findings)
+    except ManifestParseError as exc:
+        findings.append(f"{LEVEL_FAIL}: {_EMIT_CORRUPTION_MARKER}: {exc}")
     return findings
 
 
@@ -342,7 +360,7 @@ def update_manifest_for_skill(
 
     emit_findings = append_skill_entry(manifest_path, name, router=router)
     findings.extend(emit_findings)
-    if _has_emit_corruption(emit_findings):
+    if has_emit_corruption(emit_findings):
         warning = (
             f"Manifest update wrote an invalid manifest at {manifest_path} "
             f"— inspect findings and repair the file"
@@ -396,7 +414,7 @@ def update_manifest_for_role(
 
     emit_findings = append_role_entry(manifest_path, group, name)
     findings.extend(emit_findings)
-    if _has_emit_corruption(emit_findings):
+    if has_emit_corruption(emit_findings):
         warning = (
             f"Manifest update wrote an invalid manifest at {manifest_path} "
             f"— inspect findings and repair the file"
@@ -405,12 +423,15 @@ def update_manifest_for_role(
     return True, None, created_manifest, findings
 
 
-def _has_emit_corruption(findings: list[str]) -> bool:
+def has_emit_corruption(findings: list[str]) -> bool:
     """Return True when *findings* contains an emit-corruption marker.
 
-    Distinguishes post-write structural corruption (emitted by the
-    append helpers via ``_EMIT_CORRUPTION_MARKER``) from pre-existing
-    plain-scalar divergences that may also carry a ``FAIL`` level.
+    Distinguishes post-write structural corruption (emitted by
+    ``_collect_emit_findings`` via ``_EMIT_CORRUPTION_MARKER``) from
+    pre-existing plain-scalar divergences that may also carry a
+    ``FAIL`` level.  Exposed publicly so CLI entry points
+    (e.g., ``scaffold``) can promote emit corruption to a hard
+    failure without re-implementing the marker string.
     """
     marker = f"{LEVEL_FAIL}: {_EMIT_CORRUPTION_MARKER}"
     return any(finding.startswith(marker) for finding in findings)

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -123,12 +123,16 @@ def append_skill_entry(
     name: str,
     *,
     router: bool = False,
-) -> None:
+) -> list[str]:
     """Append a skill entry to the ``skills:`` section of *manifest_path*.
 
     Uses text-based insertion since the YAML parser is read-only.
     The entry is appended after the last non-blank line in the
     ``skills:`` block.
+
+    Returns a list of plain-scalar divergence findings produced by
+    re-parsing the post-write manifest text; empty when the emitted
+    YAML is clean.
     """
     with open(manifest_path, "r", encoding="utf-8") as f:
         text = f.read()
@@ -184,15 +188,29 @@ def append_skill_entry(
     with open(manifest_path, "w", encoding="utf-8") as f:
         f.write(text)
 
+    findings: list[str] = []
+    try:
+        parse_yaml_subset(text, findings)
+    except ValueError:
+        # Structural failures are already caught by read_manifest on
+        # the next read cycle; here we only care about plain-scalar
+        # divergences the caller would not otherwise see.
+        pass
+    return findings
+
 
 def append_role_entry(
     manifest_path: str,
     group: str,
     name: str,
-) -> None:
+) -> list[str]:
     """Append a role entry to the ``roles:`` section of *manifest_path*.
 
     Creates the group sub-key if it does not exist.
+
+    Returns a list of plain-scalar divergence findings produced by
+    re-parsing the post-write manifest text; empty when the emitted
+    YAML is clean.
     """
     with open(manifest_path, "r", encoding="utf-8") as f:
         text = f.read()
@@ -248,6 +266,13 @@ def append_role_entry(
     with open(manifest_path, "w", encoding="utf-8") as f:
         f.write(text)
 
+    findings: list[str] = []
+    try:
+        parse_yaml_subset(text, findings)
+    except ValueError:
+        pass
+    return findings
+
 
 def update_manifest_for_skill(
     manifest_path: str,
@@ -288,7 +313,8 @@ def update_manifest_for_skill(
         )
         return False, warning, created_manifest, findings
 
-    append_skill_entry(manifest_path, name, router=router)
+    emit_findings = append_skill_entry(manifest_path, name, router=router)
+    findings.extend(emit_findings)
     return True, None, created_manifest, findings
 
 
@@ -330,7 +356,8 @@ def update_manifest_for_role(
         )
         return False, warning, created_manifest, findings
 
-    append_role_entry(manifest_path, group, name)
+    emit_findings = append_role_entry(manifest_path, group, name)
+    findings.extend(emit_findings)
     return True, None, created_manifest, findings
 
 

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -21,6 +21,13 @@ class ManifestParseError(Exception):
     """Raised when a manifest file cannot be parsed."""
 
 
+# Sentinel used by append helpers to mark post-write structural
+# corruption so ``update_manifest_for_*`` can distinguish emit
+# failure from pre-existing plain-scalar divergences that also
+# carry a FAIL level.
+_EMIT_CORRUPTION_MARKER = "manifest emit produced unparseable YAML"
+
+
 def read_manifest(path: str, findings: list[str] | None = None) -> dict:
     """Read and parse a ``manifest.yaml`` file.
 
@@ -203,7 +210,7 @@ def append_skill_entry(
         # manifest has already been written and callers need to know
         # the file is no longer parseable.
         findings.append(
-            f"{LEVEL_FAIL}: manifest emit produced unparseable YAML "
+            f"{LEVEL_FAIL}: {_EMIT_CORRUPTION_MARKER} "
             f"at {manifest_path}: {exc}"
         )
     return findings
@@ -281,7 +288,7 @@ def append_role_entry(
         parse_yaml_subset(text, findings)
     except ValueError as exc:
         findings.append(
-            f"{LEVEL_FAIL}: manifest emit produced unparseable YAML "
+            f"{LEVEL_FAIL}: {_EMIT_CORRUPTION_MARKER} "
             f"at {manifest_path}: {exc}"
         )
     return findings
@@ -297,12 +304,15 @@ def update_manifest_for_skill(
 
     Returns ``(updated, warning, created_manifest, findings)`` where
     *updated* is True when the manifest was modified, *warning* is a
-    human-readable message when a conflict prevented the update,
+    human-readable message when a conflict prevented the update or
+    when the emit step produced structurally invalid YAML,
     *created_manifest* is True when a new manifest file was
     scaffolded, and *findings* is a list of plain-scalar divergence
     findings produced while reading the existing manifest plus any
     additional findings returned by ``append_skill_entry`` after the
-    new entry is written.
+    new entry is written.  When the emitted manifest fails to parse,
+    *updated* is False and *warning* describes the corruption so
+    callers that ignore *findings* still see the failure.
     """
     created_manifest = False
     # Treat non-existent or empty/whitespace-only files as missing.
@@ -330,6 +340,12 @@ def update_manifest_for_skill(
 
     emit_findings = append_skill_entry(manifest_path, name, router=router)
     findings.extend(emit_findings)
+    if _has_emit_corruption(emit_findings):
+        warning = (
+            f"Manifest update wrote an invalid manifest at {manifest_path} "
+            f"— inspect findings and repair the file"
+        )
+        return False, warning, created_manifest, findings
     return True, None, created_manifest, findings
 
 
@@ -342,12 +358,15 @@ def update_manifest_for_role(
 
     Returns ``(updated, warning, created_manifest, findings)`` where
     *updated* is True when the manifest was modified, *warning* is a
-    human-readable message when a conflict prevented the update,
+    human-readable message when a conflict prevented the update or
+    when the emit step produced structurally invalid YAML,
     *created_manifest* is True when a new manifest file was
     scaffolded, and *findings* is a list of plain-scalar divergence
     findings produced while reading the existing manifest plus any
     additional findings returned by ``append_role_entry`` after the
-    new entry is written.
+    new entry is written.  When the emitted manifest fails to parse,
+    *updated* is False and *warning* describes the corruption so
+    callers that ignore *findings* still see the failure.
     """
     created_manifest = False
     # Treat non-existent or empty/whitespace-only files as missing.
@@ -375,7 +394,24 @@ def update_manifest_for_role(
 
     emit_findings = append_role_entry(manifest_path, group, name)
     findings.extend(emit_findings)
+    if _has_emit_corruption(emit_findings):
+        warning = (
+            f"Manifest update wrote an invalid manifest at {manifest_path} "
+            f"— inspect findings and repair the file"
+        )
+        return False, warning, created_manifest, findings
     return True, None, created_manifest, findings
+
+
+def _has_emit_corruption(findings: list[str]) -> bool:
+    """Return True when *findings* contains an emit-corruption marker.
+
+    Distinguishes post-write structural corruption (emitted by the
+    append helpers via ``_EMIT_CORRUPTION_MARKER``) from pre-existing
+    plain-scalar divergences that may also carry a ``FAIL`` level.
+    """
+    marker = f"{LEVEL_FAIL}: {_EMIT_CORRUPTION_MARKER}"
+    return any(finding.startswith(marker) for finding in findings)
 
 
 def scaffold_empty_manifest(manifest_path: str) -> None:

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -42,6 +42,9 @@ def read_manifest(path: str, findings: list[str] | None = None) -> dict:
         text = f.read()
     if not text.strip():
         return {}
+    # Collect findings locally and only extend the caller-provided list
+    # on the success path so structural failures never mutate it.
+    local_findings: list[str] = []
     try:
         # Collect all top-level content lines for validation
         top_level_lines = [
@@ -59,7 +62,7 @@ def read_manifest(path: str, findings: list[str] | None = None) -> dict:
                 f"Failed to parse {path}: top-level YAML must be a mapping"
             )
 
-        manifest = parse_yaml_subset(text, findings)
+        manifest = parse_yaml_subset(text, local_findings)
         if not isinstance(manifest, dict):
             raise ManifestParseError(
                 f"Failed to parse {path}: top-level YAML must be a mapping"
@@ -90,11 +93,14 @@ def read_manifest(path: str, findings: list[str] | None = None) -> dict:
                         f"Failed to parse {path}: "
                         f"role group '{group_name}' must be a list"
                     )
-        return manifest
     except ValueError as exc:
         raise ManifestParseError(
             f"Failed to parse {path}: {exc}"
         ) from exc
+
+    if findings is not None:
+        findings.extend(local_findings)
+    return manifest
 
 
 def has_skill_conflict(manifest: dict, name: str) -> bool:

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -104,6 +104,23 @@ def validate_name(name: str, json_output: bool = False) -> bool:
     return not any(e.startswith(LEVEL_FAIL) for e in errors)
 
 
+def _dedupe_preserving_order(items: list[str]) -> list[str]:
+    """Return *items* with duplicates removed, keeping first-seen order.
+
+    Read-time and emit-time manifest passes surface the same divergence
+    when an existing divergence survives the append; deduping here
+    keeps CI logs and JSON output clean without discarding distinct
+    findings.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
 def _collect_frontmatter_findings(path: str) -> list[str]:
     """Return plain-scalar divergence findings from the written entry file.
 
@@ -303,7 +320,7 @@ def scaffold_skill(
         if manifest_updated and not json_output:
             print(f"  Updated: {manifest_path}")
         if manifest_findings and not json_output:
-            for f in manifest_findings:
+            for f in _dedupe_preserving_order(list(manifest_findings)):
                 print(f"  {f}")
 
     if json_output:
@@ -320,7 +337,9 @@ def scaffold_skill(
         # warnings array so consumers see one list with level prefixes
         # intact (FAIL:/WARN:/INFO:) — matches the errors-array
         # convention in validate_skill / audit_skill_system JSON output.
-        combined_warnings = list(frontmatter_findings) + list(manifest_findings)
+        combined_warnings = _dedupe_preserving_order(
+            list(frontmatter_findings) + list(manifest_findings)
+        )
         if combined_warnings:
             result_dict["warnings"] = combined_warnings
         if update_manifest:
@@ -621,7 +640,7 @@ def scaffold_role(
         if manifest_updated and not json_output:
             print(f"  Updated: {manifest_path}")
         if manifest_findings and not json_output:
-            for f in manifest_findings:
+            for f in _dedupe_preserving_order(list(manifest_findings)):
                 print(f"  {f}")
 
     if json_output:
@@ -634,8 +653,9 @@ def scaffold_role(
             "path": os.path.abspath(role_path),
             "created": [os.path.abspath(p) for p in created_paths],
         }
-        if manifest_findings:
-            result_dict["warnings"] = list(manifest_findings)
+        deduped = _dedupe_preserving_order(list(manifest_findings))
+        if deduped:
+            result_dict["warnings"] = deduped
         if update_manifest:
             result_dict["manifest_updated"] = manifest_updated
             if manifest_warning:

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -39,6 +39,7 @@ _scripts_dir = os.path.dirname(os.path.abspath(__file__))
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
 
+from lib.frontmatter import load_frontmatter
 from lib.reporting import to_json_output
 from lib.validation import validate_name as _validate_name_detailed
 from lib.manifest import (
@@ -101,6 +102,20 @@ def validate_name(name: str, json_output: bool = False) -> bool:
                 message = e
             print(f"{level}: {message}")
     return not any(e.startswith(LEVEL_FAIL) for e in errors)
+
+
+def _collect_frontmatter_findings(path: str) -> list[str]:
+    """Return plain-scalar divergence findings from the written entry file.
+
+    Re-parses the rendered frontmatter so post-write divergences surface
+    even when they would otherwise bypass validate_name's gate (template
+    changes, programmatic callers, etc.).  Missing files and files
+    without frontmatter yield an empty list.
+    """
+    if not os.path.isfile(path):
+        return []
+    _fm, _body, findings = load_frontmatter(path)
+    return findings
 
 
 def read_template(template_name: str) -> str:
@@ -258,6 +273,13 @@ def scaffold_skill(
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
+    # --- Frontmatter re-parse of the written entry file ---
+    skill_md_full_path = os.path.join(skill_path, FILE_SKILL_MD)
+    frontmatter_findings = _collect_frontmatter_findings(skill_md_full_path)
+    if frontmatter_findings and not json_output:
+        for f in frontmatter_findings:
+            print(f"  {f}")
+
     # --- Manifest update ---
     manifest_updated = False
     manifest_warning: str | None = None
@@ -294,6 +316,8 @@ def scaffold_skill(
             "created": [os.path.abspath(p) for p in created_paths],
             "router": router,
         }
+        if frontmatter_findings:
+            result_dict["frontmatter_findings"] = frontmatter_findings
         if update_manifest:
             result_dict["manifest_updated"] = manifest_updated
             if manifest_warning:
@@ -424,6 +448,13 @@ def scaffold_capability(
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
+    # --- Frontmatter re-parse of the written entry file ---
+    cap_md_full_path = os.path.join(cap_path, FILE_CAPABILITY_MD)
+    frontmatter_findings = _collect_frontmatter_findings(cap_md_full_path)
+    if frontmatter_findings and not json_output:
+        for f in frontmatter_findings:
+            print(f"  {f}")
+
     # Capabilities are not added to the manifest directly — they
     # belong under their parent skill's ``capabilities:`` list.
     cap_manifest_msg = (
@@ -441,6 +472,8 @@ def scaffold_capability(
             "path": os.path.abspath(cap_path),
             "created": [os.path.abspath(p) for p in created_paths],
         }
+        if frontmatter_findings:
+            result_dict["frontmatter_findings"] = frontmatter_findings
         if update_manifest:
             result_dict["manifest_updated"] = False
             result_dict["manifest_warning"] = cap_manifest_msg

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -122,16 +122,25 @@ def _dedupe_preserving_order(items: list[str]) -> list[str]:
 
 
 def _collect_frontmatter_findings(path: str) -> list[str]:
-    """Return plain-scalar divergence findings from the written entry file.
+    """Return frontmatter findings from the written entry file.
 
     Re-parses the rendered frontmatter so post-write divergences surface
     even when they would otherwise bypass validate_name's gate (template
     changes, programmatic callers, etc.).  Missing files and files
-    without frontmatter yield an empty list.
+    without frontmatter yield an empty list.  Frontmatter structural
+    parse failures are surfaced as a FAIL finding so invalid rendered
+    YAML is not silently ignored.
     """
     if not os.path.isfile(path):
         return []
-    _fm, _body, findings = load_frontmatter(path)
+    frontmatter, _body, findings = load_frontmatter(path)
+    parse_error = (
+        frontmatter.get("_parse_error")
+        if isinstance(frontmatter, dict)
+        else None
+    )
+    if parse_error:
+        return [f"{LEVEL_FAIL}: Invalid frontmatter in {path}: {parse_error}"]
     return findings
 
 

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -122,6 +122,24 @@ def _dedupe_preserving_order(items: list[str]) -> list[str]:
     return out
 
 
+# Sentinel used by frontmatter parse-error findings so scaffold can
+# distinguish a structural parse failure (hard failure: success=False,
+# exit 1) from plain-scalar divergences (warnings only).
+_FRONTMATTER_PARSE_ERROR_MARKER = "Invalid frontmatter in"
+
+
+def _has_frontmatter_parse_error(findings: list[str]) -> bool:
+    """Return True when *findings* contains a frontmatter parse-error marker.
+
+    Distinguishes structural frontmatter parse failures (surfaced via
+    ``_FRONTMATTER_PARSE_ERROR_MARKER``) from plain-scalar divergences
+    that may also carry a ``FAIL`` level — only the former should
+    promote scaffold to a hard failure.
+    """
+    marker = f"{LEVEL_FAIL}: {_FRONTMATTER_PARSE_ERROR_MARKER}"
+    return any(f.startswith(marker) for f in findings)
+
+
 def _collect_frontmatter_findings(path: str) -> list[str]:
     """Return frontmatter findings from the written entry file.
 
@@ -129,8 +147,9 @@ def _collect_frontmatter_findings(path: str) -> list[str]:
     even when they would otherwise bypass validate_name's gate (template
     changes, programmatic callers, etc.).  Missing files and files
     without frontmatter yield an empty list.  Frontmatter structural
-    parse failures are surfaced as a FAIL finding so invalid rendered
-    YAML is not silently ignored.
+    parse failures are surfaced as a FAIL finding tagged with
+    ``_FRONTMATTER_PARSE_ERROR_MARKER`` so callers can promote them to
+    a hard failure via :func:`_has_frontmatter_parse_error`.
     """
     if not os.path.isfile(path):
         return []
@@ -141,7 +160,10 @@ def _collect_frontmatter_findings(path: str) -> list[str]:
         else None
     )
     if parse_error:
-        return [f"{LEVEL_FAIL}: Invalid frontmatter in {path}: {parse_error}"]
+        return [
+            f"{LEVEL_FAIL}: {_FRONTMATTER_PARSE_ERROR_MARKER} "
+            f"{path}: {parse_error}"
+        ]
     return findings
 
 
@@ -303,6 +325,7 @@ def scaffold_skill(
     # --- Frontmatter re-parse of the written entry file ---
     skill_md_full_path = os.path.join(skill_path, FILE_SKILL_MD)
     frontmatter_findings = _collect_frontmatter_findings(skill_md_full_path)
+    frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
     if frontmatter_findings and not json_output:
         for f in frontmatter_findings:
             print(f"  {f}")
@@ -336,12 +359,14 @@ def scaffold_skill(
             for f in _dedupe_preserving_order(list(manifest_findings)):
                 print(f"  {f}")
 
+    hard_failure = manifest_emit_corrupted or frontmatter_parse_error
+
     if json_output:
         result_dict: dict = {
             "tool": "scaffold",
             "component": "skill",
             "name": name,
-            "success": not manifest_emit_corrupted,
+            "success": not hard_failure,
             "path": os.path.abspath(skill_path),
             "created": [os.path.abspath(p) for p in created_paths],
             "router": router,
@@ -367,7 +392,7 @@ def scaffold_skill(
         print(f"  Next: edit {skill_md_path} and update {manifest_path}")
     else:
         print(f"  Next: edit {skill_md_path}")
-    if manifest_emit_corrupted:
+    if hard_failure:
         sys.exit(1)
     return None
 
@@ -488,6 +513,7 @@ def scaffold_capability(
     # --- Frontmatter re-parse of the written entry file ---
     cap_md_full_path = os.path.join(cap_path, FILE_CAPABILITY_MD)
     frontmatter_findings = _collect_frontmatter_findings(cap_md_full_path)
+    frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
     if frontmatter_findings and not json_output:
         for f in frontmatter_findings:
             print(f"  {f}")
@@ -505,7 +531,7 @@ def scaffold_capability(
             "component": "capability",
             "name": name,
             "domain": domain,
-            "success": True,
+            "success": not frontmatter_parse_error,
             "path": os.path.abspath(cap_path),
             "created": [os.path.abspath(p) for p in created_paths],
         }
@@ -524,6 +550,8 @@ def scaffold_capability(
         print(f"  {LEVEL_INFO}: {cap_manifest_msg}")
     else:
         print(f"  Next: update {manifest_path}")
+    if frontmatter_parse_error:
+        sys.exit(1)
     return None
 
 
@@ -634,6 +662,7 @@ def scaffold_role(
 
     # --- Frontmatter re-parse of the written role file ---
     frontmatter_findings = _collect_frontmatter_findings(role_path)
+    frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
     if frontmatter_findings and not json_output:
         for f in frontmatter_findings:
             print(f"  {f}")
@@ -667,13 +696,15 @@ def scaffold_role(
             for f in _dedupe_preserving_order(list(manifest_findings)):
                 print(f"  {f}")
 
+    hard_failure = manifest_emit_corrupted or frontmatter_parse_error
+
     if json_output:
         result_dict: dict = {
             "tool": "scaffold",
             "component": "role",
             "name": name,
             "group": group,
-            "success": not manifest_emit_corrupted,
+            "success": not hard_failure,
             "path": os.path.abspath(role_path),
             "created": [os.path.abspath(p) for p in created_paths],
         }
@@ -692,7 +723,7 @@ def scaffold_role(
     print(f"  Next: edit {role_path}")
     if not update_manifest:
         print(f"  Next: update {manifest_path}")
-    if manifest_emit_corrupted:
+    if hard_failure:
         sys.exit(1)
     return None
 

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -261,9 +261,15 @@ def scaffold_skill(
     # --- Manifest update ---
     manifest_updated = False
     manifest_warning: str | None = None
+    manifest_findings: list[str] = []
 
     if update_manifest:
-        manifest_updated, manifest_warning, created_manifest = update_manifest_for_skill(
+        (
+            manifest_updated,
+            manifest_warning,
+            created_manifest,
+            manifest_findings,
+        ) = update_manifest_for_skill(
             manifest_path, name, router=router,
         )
         if created_manifest and not json_output:
@@ -274,6 +280,9 @@ def scaffold_skill(
             print(f"  {LEVEL_WARN}: {manifest_warning}")
         if manifest_updated and not json_output:
             print(f"  Updated: {manifest_path}")
+        if manifest_findings and not json_output:
+            for f in manifest_findings:
+                print(f"  {f}")
 
     if json_output:
         result_dict: dict = {
@@ -289,6 +298,8 @@ def scaffold_skill(
             result_dict["manifest_updated"] = manifest_updated
             if manifest_warning:
                 result_dict["manifest_warning"] = manifest_warning
+            if manifest_findings:
+                result_dict["manifest_findings"] = manifest_findings
         return result_dict
 
     print(f"\n\u2713 Skill '{name}' scaffolded at {skill_path}")
@@ -554,9 +565,15 @@ def scaffold_role(
     # --- Manifest update ---
     manifest_updated = False
     manifest_warning: str | None = None
+    manifest_findings: list[str] = []
 
     if update_manifest:
-        manifest_updated, manifest_warning, created_manifest = update_manifest_for_role(
+        (
+            manifest_updated,
+            manifest_warning,
+            created_manifest,
+            manifest_findings,
+        ) = update_manifest_for_role(
             manifest_path, group, name,
         )
         if created_manifest and not json_output:
@@ -567,6 +584,9 @@ def scaffold_role(
             print(f"  {LEVEL_WARN}: {manifest_warning}")
         if manifest_updated and not json_output:
             print(f"  Updated: {manifest_path}")
+        if manifest_findings and not json_output:
+            for f in manifest_findings:
+                print(f"  {f}")
 
     if json_output:
         result_dict: dict = {
@@ -582,6 +602,8 @@ def scaffold_role(
             result_dict["manifest_updated"] = manifest_updated
             if manifest_warning:
                 result_dict["manifest_warning"] = manifest_warning
+            if manifest_findings:
+                result_dict["manifest_findings"] = manifest_findings
         return result_dict
 
     print(f"\n\u2713 Role '{name}' scaffolded at {role_path}")

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -45,6 +45,7 @@ from lib.validation import validate_name as _validate_name_detailed
 from lib.manifest import (
     update_manifest_for_skill,
     update_manifest_for_role,
+    has_emit_corruption,
 )
 from lib.constants import (
     DIR_SKILLS, DIR_CAPABILITIES, DIR_ROLES,
@@ -310,6 +311,7 @@ def scaffold_skill(
     manifest_updated = False
     manifest_warning: str | None = None
     manifest_findings: list[str] = []
+    manifest_emit_corrupted = False
 
     if update_manifest:
         (
@@ -320,12 +322,14 @@ def scaffold_skill(
         ) = update_manifest_for_skill(
             manifest_path, name, router=router,
         )
+        manifest_emit_corrupted = has_emit_corruption(manifest_findings)
         if created_manifest and not json_output:
             print(f"  Created: {manifest_path}")
         if created_manifest:
             created_paths.append(manifest_path)
         if manifest_warning and not json_output:
-            print(f"  {LEVEL_WARN}: {manifest_warning}")
+            level = LEVEL_FAIL if manifest_emit_corrupted else LEVEL_WARN
+            print(f"  {level}: {manifest_warning}")
         if manifest_updated and not json_output:
             print(f"  Updated: {manifest_path}")
         if manifest_findings and not json_output:
@@ -337,7 +341,7 @@ def scaffold_skill(
             "tool": "scaffold",
             "component": "skill",
             "name": name,
-            "success": True,
+            "success": not manifest_emit_corrupted,
             "path": os.path.abspath(skill_path),
             "created": [os.path.abspath(p) for p in created_paths],
             "router": router,
@@ -363,6 +367,8 @@ def scaffold_skill(
         print(f"  Next: edit {skill_md_path} and update {manifest_path}")
     else:
         print(f"  Next: edit {skill_md_path}")
+    if manifest_emit_corrupted:
+        sys.exit(1)
     return None
 
 
@@ -626,10 +632,17 @@ def scaffold_role(
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
+    # --- Frontmatter re-parse of the written role file ---
+    frontmatter_findings = _collect_frontmatter_findings(role_path)
+    if frontmatter_findings and not json_output:
+        for f in frontmatter_findings:
+            print(f"  {f}")
+
     # --- Manifest update ---
     manifest_updated = False
     manifest_warning: str | None = None
     manifest_findings: list[str] = []
+    manifest_emit_corrupted = False
 
     if update_manifest:
         (
@@ -640,12 +653,14 @@ def scaffold_role(
         ) = update_manifest_for_role(
             manifest_path, group, name,
         )
+        manifest_emit_corrupted = has_emit_corruption(manifest_findings)
         if created_manifest and not json_output:
             print(f"  Created: {manifest_path}")
         if created_manifest:
             created_paths.append(manifest_path)
         if manifest_warning and not json_output:
-            print(f"  {LEVEL_WARN}: {manifest_warning}")
+            level = LEVEL_FAIL if manifest_emit_corrupted else LEVEL_WARN
+            print(f"  {level}: {manifest_warning}")
         if manifest_updated and not json_output:
             print(f"  Updated: {manifest_path}")
         if manifest_findings and not json_output:
@@ -658,13 +673,15 @@ def scaffold_role(
             "component": "role",
             "name": name,
             "group": group,
-            "success": True,
+            "success": not manifest_emit_corrupted,
             "path": os.path.abspath(role_path),
             "created": [os.path.abspath(p) for p in created_paths],
         }
-        deduped = _dedupe_preserving_order(list(manifest_findings))
-        if deduped:
-            result_dict["warnings"] = deduped
+        combined_warnings = _dedupe_preserving_order(
+            list(frontmatter_findings) + list(manifest_findings)
+        )
+        if combined_warnings:
+            result_dict["warnings"] = combined_warnings
         if update_manifest:
             result_dict["manifest_updated"] = manifest_updated
             if manifest_warning:
@@ -675,6 +692,8 @@ def scaffold_role(
     print(f"  Next: edit {role_path}")
     if not update_manifest:
         print(f"  Next: update {manifest_path}")
+    if manifest_emit_corrupted:
+        sys.exit(1)
     return None
 
 

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -316,14 +316,17 @@ def scaffold_skill(
             "created": [os.path.abspath(p) for p in created_paths],
             "router": router,
         }
-        if frontmatter_findings:
-            result_dict["frontmatter_findings"] = frontmatter_findings
+        # All plain-scalar divergence findings merge into a single
+        # warnings array so consumers see one list with level prefixes
+        # intact (FAIL:/WARN:/INFO:) — matches the errors-array
+        # convention in validate_skill / audit_skill_system JSON output.
+        combined_warnings = list(frontmatter_findings) + list(manifest_findings)
+        if combined_warnings:
+            result_dict["warnings"] = combined_warnings
         if update_manifest:
             result_dict["manifest_updated"] = manifest_updated
             if manifest_warning:
                 result_dict["manifest_warning"] = manifest_warning
-            if manifest_findings:
-                result_dict["manifest_findings"] = manifest_findings
         return result_dict
 
     print(f"\n\u2713 Skill '{name}' scaffolded at {skill_path}")
@@ -473,7 +476,7 @@ def scaffold_capability(
             "created": [os.path.abspath(p) for p in created_paths],
         }
         if frontmatter_findings:
-            result_dict["frontmatter_findings"] = frontmatter_findings
+            result_dict["warnings"] = list(frontmatter_findings)
         if update_manifest:
             result_dict["manifest_updated"] = False
             result_dict["manifest_warning"] = cap_manifest_msg
@@ -631,12 +634,12 @@ def scaffold_role(
             "path": os.path.abspath(role_path),
             "created": [os.path.abspath(p) for p in created_paths],
         }
+        if manifest_findings:
+            result_dict["warnings"] = list(manifest_findings)
         if update_manifest:
             result_dict["manifest_updated"] = manifest_updated
             if manifest_warning:
                 result_dict["manifest_warning"] = manifest_warning
-            if manifest_findings:
-                result_dict["manifest_findings"] = manifest_findings
         return result_dict
 
     print(f"\n\u2713 Role '{name}' scaffolded at {role_path}")

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -38,6 +38,7 @@ from lib.validation import (
 )
 from lib.codex_config import validate_codex_config
 from lib.constants import (
+    CONFIG_PATH,
     MAX_DESCRIPTION_CHARS,
     MAX_BODY_LINES, MAX_COMPATIBILITY_CHARS,
     RE_XML_TAG, RE_FIRST_PERSON, RE_FIRST_PERSON_PLURAL,
@@ -47,7 +48,32 @@ from lib.constants import (
     FILE_SKILL_MD, FILE_CAPABILITY_MD, SEPARATOR_WIDTH,
     EXT_MARKDOWN,
     LEVEL_FAIL, LEVEL_WARN, LEVEL_INFO,
+    get_config_findings,
 )
+
+
+def _collect_foundry_config_findings(skill_path: str) -> list[str]:
+    """Return configuration.yaml divergence findings when *skill_path* is the foundry.
+
+    Detects the foundry by comparing ``<skill_path>/scripts/lib/configuration.yaml``
+    against the absolute path that ``constants.py`` loaded at import.  When
+    the paths match, each finding is retagged with a ``[foundry]`` prefix
+    and the relative config file path for reporting.  Third-party skills
+    never trigger this check because their configuration file (if any)
+    lives at a different absolute path.
+    """
+    candidate = os.path.abspath(
+        os.path.join(skill_path, "scripts", "lib", "configuration.yaml")
+    )
+    if candidate != CONFIG_PATH:
+        return []
+    retagged: list[str] = []
+    for f in get_config_findings():
+        level, _, detail = f.partition(": ")
+        retagged.append(
+            f"{level}: [foundry] scripts/lib/configuration.yaml {detail}"
+        )
+    return retagged
 
 
 def find_skill_root(start_dir: str) -> str | None:
@@ -403,6 +429,11 @@ def validate_skill(
         return errors, passes
 
     errors.extend(scalar_findings)
+
+    # When validating the foundry itself, surface divergences detected
+    # during configuration.yaml load so the meta-skill's own config is
+    # held to the same standard as integrator skills.
+    errors.extend(_collect_foundry_config_findings(skill_path))
 
     # Determine the skill root for reference resolution.
     # For regular skills, skill_path is the root (contains SKILL.md).

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -70,6 +70,7 @@ def _collect_foundry_config_findings(skill_path: str) -> list[str]:
     retagged: list[str] = []
     for f in get_config_findings():
         level, _, detail = f.partition(": ")
+        detail = detail.removeprefix("[spec] ").removeprefix("[spec]").lstrip()
         retagged.append(
             f"{level}: [foundry] scripts/lib/configuration.yaml {detail}"
         )

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -38,7 +38,6 @@ from lib.validation import (
 )
 from lib.codex_config import validate_codex_config
 from lib.constants import (
-    CONFIG_PATH,
     MAX_DESCRIPTION_CHARS,
     MAX_BODY_LINES, MAX_COMPATIBILITY_CHARS,
     RE_XML_TAG, RE_FIRST_PERSON, RE_FIRST_PERSON_PLURAL,
@@ -48,33 +47,8 @@ from lib.constants import (
     FILE_SKILL_MD, FILE_CAPABILITY_MD, SEPARATOR_WIDTH,
     EXT_MARKDOWN,
     LEVEL_FAIL, LEVEL_WARN, LEVEL_INFO,
-    get_config_findings,
+    collect_foundry_config_findings,
 )
-
-
-def _collect_foundry_config_findings(skill_path: str) -> list[str]:
-    """Return configuration.yaml divergence findings when *skill_path* is the foundry.
-
-    Detects the foundry by comparing ``<skill_path>/scripts/lib/configuration.yaml``
-    against the absolute path that ``constants.py`` loaded at import.  When
-    the paths match, each finding is retagged with a ``[foundry]`` prefix
-    and the relative config file path for reporting.  Third-party skills
-    never trigger this check because their configuration file (if any)
-    lives at a different absolute path.
-    """
-    candidate = os.path.abspath(
-        os.path.join(skill_path, "scripts", "lib", "configuration.yaml")
-    )
-    if candidate != CONFIG_PATH:
-        return []
-    retagged: list[str] = []
-    for f in get_config_findings():
-        level, _, detail = f.partition(": ")
-        detail = detail.removeprefix("[spec] ").removeprefix("[spec]").lstrip()
-        retagged.append(
-            f"{level}: [foundry] scripts/lib/configuration.yaml {detail}"
-        )
-    return retagged
 
 
 def find_skill_root(start_dir: str) -> str | None:
@@ -434,7 +408,7 @@ def validate_skill(
     # When validating the foundry itself, surface divergences detected
     # during configuration.yaml load so the meta-skill's own config is
     # held to the same standard as integrator skills.
-    errors.extend(_collect_foundry_config_findings(skill_path))
+    errors.extend(collect_foundry_config_findings(skill_path))
 
     # Determine the skill root for reference resolution.
     # For regular skills, skill_path is the root (contains SKILL.md).

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1458,6 +1458,35 @@ class MainFunctionInProcessTests(unittest.TestCase):
             self.assertIn("===", output)
 
 
+class AuditManifestFindingsJsonSchemaTests(unittest.TestCase):
+    """``audit_skill_system --json`` surfaces manifest findings in the errors array."""
+
+    def test_divergent_manifest_appears_in_json_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "skills"), exist_ok=True)
+            with open(
+                os.path.join(tmpdir, "manifest.yaml"), "w", encoding="utf-8",
+            ) as f:
+                f.write(
+                    "skills:\n"
+                    "  demo:\n"
+                    "    canonical: skills/demo/SKILL.md\n"
+                    "    note: runs tasks: quickly\n"
+                )
+            proc = _run([tmpdir, "--json"], cwd=REPO_ROOT)
+            data = json.loads(proc.stdout)
+        # Schema preserved: no new top-level keys introduced.
+        self.assertEqual(
+            set(data.keys()),
+            {"tool", "path", "success", "counts", "summary", "errors", "version"},
+        )
+        manifest_fails = [
+            entry for entry in data["errors"].get("failures", [])
+            if "[spec] manifest.yaml" in entry and "': '" in entry
+        ]
+        self.assertEqual(len(manifest_fails), 1)
+
+
 class AuditManifestScalarFindingsTests(unittest.TestCase):
     """``audit_skill_system`` surfaces manifest.yaml plain-scalar divergences."""
 

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1458,6 +1458,46 @@ class MainFunctionInProcessTests(unittest.TestCase):
             self.assertIn("===", output)
 
 
+class AuditManifestScalarFindingsTests(unittest.TestCase):
+    """``audit_skill_system`` surfaces manifest.yaml plain-scalar divergences."""
+
+    def _make_deployed_system(self, tmpdir: str, manifest_body: str) -> None:
+        skills_dir = os.path.join(tmpdir, "skills")
+        os.makedirs(skills_dir, exist_ok=True)
+        manifest_path = os.path.join(tmpdir, "manifest.yaml")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            f.write(manifest_body)
+
+    def test_divergent_manifest_surfaces_tagged_finding(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._make_deployed_system(
+                tmpdir,
+                "skills:\n"
+                "  demo:\n"
+                "    canonical: skills/demo/SKILL.md\n"
+                "    note: runs tasks: quickly\n",
+            )
+            errors = audit_skill_system(tmpdir, verbose=False)
+        tagged = [
+            e for e in errors
+            if e.startswith("FAIL: [spec] manifest.yaml") and "': '" in e
+        ]
+        self.assertEqual(len(tagged), 1)
+
+    def test_clean_manifest_produces_no_scalar_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._make_deployed_system(
+                tmpdir,
+                "skills:\n"
+                "  demo:\n"
+                "    canonical: skills/demo/SKILL.md\n"
+                "    type: standalone\n",
+            )
+            errors = audit_skill_system(tmpdir, verbose=False)
+        scalar = [e for e in errors if "[spec] manifest.yaml" in e]
+        self.assertEqual(scalar, [])
+
+
 class AuditFoundryConfigFindingsTests(unittest.TestCase):
     """``audit_skill_system`` surfaces configuration.yaml findings for the foundry."""
 

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1458,5 +1458,40 @@ class MainFunctionInProcessTests(unittest.TestCase):
             self.assertIn("===", output)
 
 
+class AuditFoundryConfigFindingsTests(unittest.TestCase):
+    """``audit_skill_system`` surfaces configuration.yaml findings for the foundry."""
+
+    def test_non_foundry_system_root_does_not_surface_findings(self) -> None:
+        """Arbitrary system roots never pull in configuration.yaml findings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            errors = audit_skill_system(tmpdir, verbose=False)
+        foundry_errors = [e for e in errors if "[foundry]" in e and "configuration.yaml" in e]
+        self.assertEqual(foundry_errors, [])
+
+    def test_foundry_system_root_clean_config_no_findings(self) -> None:
+        """The shipped foundry config is clean, so no findings surface today."""
+        foundry_path = os.path.join(REPO_ROOT, "skill-system-foundry")
+        errors = audit_skill_system(foundry_path, verbose=False)
+        config_findings = [
+            e for e in errors
+            if "[foundry]" in e and "scripts/lib/configuration.yaml" in e
+        ]
+        self.assertEqual(config_findings, [])
+
+    def test_foundry_system_root_retags_patched_findings(self) -> None:
+        """When findings exist they surface with a ``[foundry]`` tag."""
+        foundry_path = os.path.join(REPO_ROOT, "skill-system-foundry")
+        sample = ["FAIL: [spec] 'skill.name': unquoted value starts with '-' …"]
+        with mock.patch(
+            "audit_skill_system.get_config_findings", return_value=sample,
+        ):
+            errors = audit_skill_system(foundry_path, verbose=False)
+        tagged = [
+            e for e in errors
+            if e.startswith("FAIL: [foundry] scripts/lib/configuration.yaml")
+        ]
+        self.assertEqual(len(tagged), 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1552,7 +1552,7 @@ class AuditFoundryConfigFindingsTests(unittest.TestCase):
         foundry_path = os.path.join(REPO_ROOT, "skill-system-foundry")
         sample = ["FAIL: [spec] 'skill.name': unquoted value starts with '-' …"]
         with mock.patch(
-            "audit_skill_system.get_config_findings", return_value=sample,
+            "lib.constants.get_config_findings", return_value=sample,
         ):
             errors = audit_skill_system(foundry_path, verbose=False)
         tagged = [

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -959,5 +959,41 @@ class IsValidRelativePathEdgeTests(unittest.TestCase):
         self.assertEqual(len(warns), 1)
 
 
+class CodexConfigScalarFindingsTests(unittest.TestCase):
+    """``validate_codex_config`` surfaces plain-scalar divergence findings."""
+
+    def test_divergent_value_produces_tagged_finding(self) -> None:
+        """Unquoted ``: ``-bearing value surfaces a FAIL tagged [platform: OpenAI]."""
+        config = (
+            "interface:\n"
+            "  display_name: Demo Agent\n"
+            "  default_prompt: runs tasks: quickly\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, config)
+            errors, _ = validate_codex_config(tmpdir)
+        tagged = [
+            e for e in errors
+            if e.startswith("FAIL: [platform: OpenAI]")
+            and FILE_CODEX_CONFIG in e
+            and "': '" in e
+        ]
+        self.assertEqual(len(tagged), 1)
+
+    def test_clean_config_produces_no_scalar_findings(self) -> None:
+        config = (
+            "interface:\n"
+            '  display_name: "Demo Agent"\n'
+            '  default_prompt: "Safe prompt."\n'
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _write_codex_config(tmpdir, config)
+            errors, _ = validate_codex_config(tmpdir)
+        scalar_findings = [
+            e for e in errors if "': '" in e or "unquoted value" in e
+        ]
+        self.assertEqual(scalar_findings, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,73 @@
+"""Tests for lib.constants module-load behaviour.
+
+Covers the lazy divergence re-parse of ``configuration.yaml`` via
+``get_config_findings`` and verifies ``CONFIG_PATH`` is an absolute
+path pointing at the expected file.
+"""
+
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "skill-system-foundry", "scripts")
+)
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib import constants
+
+
+class ConfigPathTests(unittest.TestCase):
+    """``CONFIG_PATH`` exposes the absolute config file location."""
+
+    def test_config_path_is_absolute(self) -> None:
+        self.assertTrue(os.path.isabs(constants.CONFIG_PATH))
+
+    def test_config_path_ends_with_configuration_yaml(self) -> None:
+        self.assertTrue(
+            constants.CONFIG_PATH.endswith(
+                os.path.join("scripts", "lib", "configuration.yaml")
+            )
+        )
+
+    def test_config_path_points_at_existing_file(self) -> None:
+        self.assertTrue(os.path.isfile(constants.CONFIG_PATH))
+
+
+class GetConfigFindingsTests(unittest.TestCase):
+    """``get_config_findings`` lazily collects and caches findings."""
+
+    def setUp(self) -> None:
+        # Reset cache so each test exercises the first-call path.
+        constants._CONFIG_FINDINGS = None
+
+    def tearDown(self) -> None:
+        # Restore cache to avoid leaking state into other test modules.
+        constants._CONFIG_FINDINGS = None
+
+    def test_returns_list(self) -> None:
+        findings = constants.get_config_findings()
+        self.assertIsInstance(findings, list)
+
+    def test_returns_copy_not_internal_list(self) -> None:
+        first = constants.get_config_findings()
+        first.append("mutated")
+        second = constants.get_config_findings()
+        self.assertNotIn("mutated", second)
+
+    def test_memoized_after_first_call(self) -> None:
+        constants.get_config_findings()
+        cached = constants._CONFIG_FINDINGS
+        self.assertIsNotNone(cached)
+        constants.get_config_findings()
+        self.assertIs(constants._CONFIG_FINDINGS, cached)
+
+    def test_current_configuration_has_no_divergences(self) -> None:
+        """The shipped ``configuration.yaml`` must round-trip clean."""
+        findings = constants.get_config_findings()
+        self.assertEqual(findings, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -636,7 +636,7 @@ class InlineCommentTests(unittest.TestCase):
             path = os.path.join(tmpdir, "manifest.yaml")
             with open(path, "w", encoding="utf-8") as f:
                 f.write(self.MANIFEST_WITH_COMMENTS)
-            updated, warning, created = update_manifest_for_skill(path, "added")
+            updated, warning, created, _findings = update_manifest_for_skill(path, "added")
             self.assertTrue(updated)
             self.assertIsNone(warning)
             self.assertFalse(created)
@@ -649,7 +649,7 @@ class InlineCommentTests(unittest.TestCase):
             path = os.path.join(tmpdir, "manifest.yaml")
             with open(path, "w", encoding="utf-8") as f:
                 f.write(self.MANIFEST_WITH_COMMENTS)
-            updated, warning, created = update_manifest_for_role(
+            updated, warning, created, _findings = update_manifest_for_role(
                 path, "dev-group", "added-role",
             )
             self.assertTrue(updated)
@@ -665,7 +665,7 @@ class InlineCommentTests(unittest.TestCase):
             path = os.path.join(tmpdir, "manifest.yaml")
             with open(path, "w", encoding="utf-8") as f:
                 f.write(self.MANIFEST_WITH_COMMENTS)
-            updated, warning, _ = update_manifest_for_skill(path, "existing")
+            updated, warning, _, _findings = update_manifest_for_skill(path, "existing")
             self.assertFalse(updated)
             self.assertIn("already exists", warning)
 
@@ -903,7 +903,7 @@ class UpdateManifestForSkillTests(unittest.TestCase):
     def test_creates_manifest_and_appends(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "manifest.yaml")
-            updated, warning, created = update_manifest_for_skill(path, "my-skill")
+            updated, warning, created, _findings = update_manifest_for_skill(path, "my-skill")
             self.assertTrue(updated)
             self.assertIsNone(warning)
             self.assertTrue(created)
@@ -914,7 +914,7 @@ class UpdateManifestForSkillTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "manifest.yaml")
             scaffold_empty_manifest(path)
-            updated, warning, created = update_manifest_for_skill(path, "my-skill")
+            updated, warning, created, _findings = update_manifest_for_skill(path, "my-skill")
             self.assertTrue(updated)
             self.assertIsNone(warning)
             self.assertFalse(created)
@@ -924,7 +924,7 @@ class UpdateManifestForSkillTests(unittest.TestCase):
             path = os.path.join(tmpdir, "manifest.yaml")
             with open(path, "w", encoding="utf-8") as f:
                 f.write(SAMPLE_MANIFEST)
-            updated, warning, created = update_manifest_for_skill(
+            updated, warning, created, _findings = update_manifest_for_skill(
                 path, "existing-skill",
             )
             self.assertFalse(updated)
@@ -937,7 +937,7 @@ class UpdateManifestForSkillTests(unittest.TestCase):
             path = os.path.join(tmpdir, "manifest.yaml")
             with open(path, "w", encoding="utf-8") as f:
                 f.write("skills:\n  - item1\n  - item2\n")
-            updated, warning, created = update_manifest_for_skill(path, "x")
+            updated, warning, created, _findings = update_manifest_for_skill(path, "x")
             self.assertFalse(updated)
             self.assertIsNotNone(warning)
             self.assertIn("skipping manifest update", warning)
@@ -947,7 +947,7 @@ class UpdateManifestForSkillTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "manifest.yaml")
             scaffold_empty_manifest(path)
-            updated, warning, created = update_manifest_for_skill(
+            updated, warning, created, _findings = update_manifest_for_skill(
                 path, "my-router", router=True,
             )
             self.assertTrue(updated)
@@ -961,7 +961,7 @@ class UpdateManifestForSkillTests(unittest.TestCase):
             # Create empty file
             with open(path, "w", encoding="utf-8") as f:
                 f.write("")
-            updated, warning, created = update_manifest_for_skill(path, "my-skill")
+            updated, warning, created, _findings = update_manifest_for_skill(path, "my-skill")
             self.assertTrue(updated)
             self.assertIsNone(warning)
             self.assertTrue(created)  # Should report created_manifest=True
@@ -979,7 +979,7 @@ class UpdateManifestForRoleTests(unittest.TestCase):
     def test_creates_manifest_and_appends(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "manifest.yaml")
-            updated, warning, created = update_manifest_for_role(
+            updated, warning, created, _findings = update_manifest_for_role(
                 path, "my-group", "my-role",
             )
             self.assertTrue(updated)
@@ -992,7 +992,7 @@ class UpdateManifestForRoleTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "manifest.yaml")
             scaffold_empty_manifest(path)
-            updated, warning, created = update_manifest_for_role(
+            updated, warning, created, _findings = update_manifest_for_role(
                 path, "grp", "new-role",
             )
             self.assertTrue(updated)
@@ -1004,7 +1004,7 @@ class UpdateManifestForRoleTests(unittest.TestCase):
             path = os.path.join(tmpdir, "manifest.yaml")
             with open(path, "w", encoding="utf-8") as f:
                 f.write(SAMPLE_MANIFEST)
-            updated, warning, created = update_manifest_for_role(
+            updated, warning, created, _findings = update_manifest_for_role(
                 path, "dev-group", "existing-role",
             )
             self.assertFalse(updated)
@@ -1017,7 +1017,7 @@ class UpdateManifestForRoleTests(unittest.TestCase):
             path = os.path.join(tmpdir, "manifest.yaml")
             with open(path, "w", encoding="utf-8") as f:
                 f.write("roles: not-a-mapping\n")
-            updated, warning, created = update_manifest_for_role(
+            updated, warning, created, _findings = update_manifest_for_role(
                 path, "grp", "r",
             )
             self.assertFalse(updated)
@@ -1031,7 +1031,7 @@ class UpdateManifestForRoleTests(unittest.TestCase):
             path = os.path.join(tmpdir, "manifest.yaml")
             with open(path, "w", encoding="utf-8") as f:
                 f.write("skills:\n\nroles:\n  my-group: not-a-list\n")
-            updated, warning, created = update_manifest_for_role(
+            updated, warning, created, _findings = update_manifest_for_role(
                 path, "my-group", "new-role",
             )
             self.assertFalse(updated)
@@ -1046,7 +1046,7 @@ class UpdateManifestForRoleTests(unittest.TestCase):
             # Create empty file
             with open(path, "w", encoding="utf-8") as f:
                 f.write("")
-            updated, warning, created = update_manifest_for_role(path, "my-group", "my-role")
+            updated, warning, created, _findings = update_manifest_for_role(path, "my-group", "my-role")
             self.assertTrue(updated)
             self.assertIsNone(warning)
             self.assertTrue(created)  # Should report created_manifest=True
@@ -1056,6 +1056,120 @@ class UpdateManifestForRoleTests(unittest.TestCase):
             self.assertIn("# Skill System Manifest", text)
             self.assertIn("skills:", text)
             self.assertIn("roles:", text)
+
+
+class ReadManifestFindingsTests(unittest.TestCase):
+    """``read_manifest`` threads divergence findings to the caller."""
+
+    def test_clean_manifest_produces_no_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(SAMPLE_MANIFEST)
+            findings: list[str] = []
+            read_manifest(path, findings)
+        self.assertEqual(findings, [])
+
+    def test_divergent_value_surfaces_finding(self) -> None:
+        """An unquoted ``: ``-bearing value produces a FAIL finding."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "skills:\n"
+                    "  demo:\n"
+                    "    canonical: skills/demo/SKILL.md\n"
+                    "    note: runs tasks: quickly\n"
+                )
+            findings: list[str] = []
+            read_manifest(path, findings)
+        self.assertTrue(any("': '" in f for f in findings))
+        self.assertTrue(any(f.startswith("FAIL: ") for f in findings))
+
+    def test_findings_default_none_does_not_raise(self) -> None:
+        """Callers that omit *findings* keep the old behaviour."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(SAMPLE_MANIFEST)
+            manifest = read_manifest(path)
+        self.assertIn("skills", manifest)
+
+    def test_structural_failure_does_not_populate_findings(self) -> None:
+        """``ManifestParseError`` fires before findings are collected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("- top: level\n- is: a list\n")
+            findings: list[str] = []
+            with self.assertRaises(ManifestParseError):
+                read_manifest(path, findings)
+        self.assertEqual(findings, [])
+
+
+class UpdateManifestFindingsTests(unittest.TestCase):
+    """``update_manifest_for_*`` returns findings as the 4th tuple slot."""
+
+    def test_update_for_skill_returns_findings_on_divergent_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "skills:\n"
+                    "  demo:\n"
+                    "    canonical: skills/demo/SKILL.md\n"
+                    "    note: runs tasks: quickly\n"
+                )
+            updated, warning, created, findings = update_manifest_for_skill(
+                path, "added",
+            )
+        self.assertTrue(updated)
+        self.assertIsNone(warning)
+        self.assertFalse(created)
+        self.assertTrue(findings)
+        self.assertTrue(any(f.startswith("FAIL: ") for f in findings))
+
+    def test_update_for_role_returns_findings_on_divergent_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "skills:\n"
+                    "  demo:\n"
+                    "    canonical: skills/demo/SKILL.md\n"
+                    "    note: runs tasks: quickly\n"
+                    "roles:\n"
+                    "  dev-group:\n"
+                    "    - name: existing-role\n"
+                    "      path: roles/dev-group/existing-role.md\n"
+                )
+            updated, warning, created, findings = update_manifest_for_role(
+                path, "dev-group", "new-role",
+            )
+        self.assertTrue(updated)
+        self.assertIsNone(warning)
+        self.assertFalse(created)
+        self.assertTrue(findings)
+
+    def test_update_for_skill_structural_failure_returns_empty_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("- top: level\n")
+            updated, warning, created, findings = update_manifest_for_skill(
+                path, "x",
+            )
+        self.assertFalse(updated)
+        self.assertIsNotNone(warning)
+        self.assertEqual(findings, [])
+
+    def test_update_for_skill_clean_manifest_no_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(SAMPLE_MANIFEST)
+            _, _, _, findings = update_manifest_for_skill(path, "added")
+        self.assertEqual(findings, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1107,6 +1107,72 @@ class ReadManifestFindingsTests(unittest.TestCase):
         self.assertEqual(findings, [])
 
 
+class AppendEntryEmitFindingsTests(unittest.TestCase):
+    """Emit helpers re-parse the post-write manifest for divergences."""
+
+    def test_append_skill_entry_returns_empty_for_clean_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(SAMPLE_MANIFEST)
+            findings = append_skill_entry(path, "new-skill")
+        self.assertEqual(findings, [])
+
+    def test_append_skill_entry_surfaces_pre_existing_divergence(self) -> None:
+        """Re-parse catches divergences already present in the manifest."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "skills:\n"
+                    "  demo:\n"
+                    "    canonical: skills/demo/SKILL.md\n"
+                    "    note: runs tasks: quickly\n"
+                )
+            findings = append_skill_entry(path, "added")
+        self.assertTrue(any("': '" in f for f in findings))
+
+    def test_append_role_entry_returns_empty_for_clean_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(SAMPLE_MANIFEST)
+            findings = append_role_entry(path, "dev-group", "new-role")
+        self.assertEqual(findings, [])
+
+    def test_append_role_entry_surfaces_pre_existing_divergence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "skills:\n"
+                    "  demo:\n"
+                    "    canonical: skills/demo/SKILL.md\n"
+                    "    note: runs tasks: quickly\n"
+                    "roles:\n"
+                    "  dev-group:\n"
+                    "    - name: existing\n"
+                    "      path: roles/dev-group/existing.md\n"
+                )
+            findings = append_role_entry(path, "dev-group", "added")
+        self.assertTrue(any("': '" in f for f in findings))
+
+
+class ScaffoldEmptyManifestStaticTests(unittest.TestCase):
+    """The static scaffold body round-trips cleanly through the parser."""
+
+    def test_scaffold_produces_no_divergences(self) -> None:
+        from lib.yaml_parser import parse_yaml_subset
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            scaffold_empty_manifest(path)
+            with open(path, "r", encoding="utf-8") as f:
+                text = f.read()
+        findings: list[str] = []
+        parse_yaml_subset(text, findings)
+        self.assertEqual(findings, [])
+
+
 class UpdateManifestFindingsTests(unittest.TestCase):
     """``update_manifest_for_*`` returns findings as the 4th tuple slot."""
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -26,7 +26,9 @@ from lib.manifest import (
     scaffold_empty_manifest,
     update_manifest_for_skill,
     update_manifest_for_role,
+    has_emit_corruption,
 )
+from lib.manifest import _collect_emit_findings  # internal helper exercised in tests
 
 
 SAMPLE_MANIFEST = """\
@@ -1236,6 +1238,76 @@ class UpdateManifestFindingsTests(unittest.TestCase):
                 f.write(SAMPLE_MANIFEST)
             _, _, _, findings = update_manifest_for_skill(path, "added")
         self.assertEqual(findings, [])
+
+
+class EmitFindingsShapeValidationTests(unittest.TestCase):
+    """``_collect_emit_findings`` flags manifest-shape violations as emit corruption."""
+
+    def test_clean_manifest_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(SAMPLE_MANIFEST)
+            findings = _collect_emit_findings(path)
+        self.assertEqual(findings, [])
+
+    def test_skills_as_scalar_returns_emit_corruption(self) -> None:
+        """A post-write manifest where ``skills`` is a scalar surfaces FAIL."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("skills: scalar-not-a-mapping\nroles:\n")
+            findings = _collect_emit_findings(path)
+        self.assertTrue(has_emit_corruption(findings))
+        self.assertTrue(any("'skills'" in f for f in findings))
+
+    def test_role_group_as_scalar_returns_emit_corruption(self) -> None:
+        """A role group that is a scalar instead of a list surfaces FAIL."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "skills:\n"
+                    "  demo:\n"
+                    "    canonical: skills/demo/SKILL.md\n"
+                    "roles:\n"
+                    "  group: scalar-not-a-list\n"
+                )
+            findings = _collect_emit_findings(path)
+        self.assertTrue(has_emit_corruption(findings))
+
+    def test_pre_existing_divergence_does_not_signal_emit_corruption(self) -> None:
+        """Plain-scalar findings on a parseable manifest are not emit corruption."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "skills:\n"
+                    "  demo:\n"
+                    "    canonical: skills/demo/SKILL.md\n"
+                    "    note: runs tasks: quickly\n"
+                )
+            findings = _collect_emit_findings(path)
+        self.assertFalse(has_emit_corruption(findings))
+        self.assertTrue(any("': '" in f for f in findings))
+
+
+class HasEmitCorruptionTests(unittest.TestCase):
+    """``has_emit_corruption`` distinguishes emit failure from divergences."""
+
+    def test_empty_findings_returns_false(self) -> None:
+        self.assertFalse(has_emit_corruption([]))
+
+    def test_only_plain_scalar_findings_returns_false(self) -> None:
+        findings = ["FAIL: [spec] 'note': unquoted value … contains ': '"]
+        self.assertFalse(has_emit_corruption(findings))
+
+    def test_emit_marker_returns_true(self) -> None:
+        findings = [
+            "FAIL: manifest emit produced unparseable YAML: "
+            "Failed to parse /tmp/m.yaml: 'skills' must be a mapping"
+        ]
+        self.assertTrue(has_emit_corruption(findings))
 
 
 if __name__ == "__main__":

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -2205,8 +2205,17 @@ class ScaffoldBadNameReparseTests(unittest.TestCase):
     rejects these names upfront, but these tests exercise the real
     pipeline with validate_name patched to pass, so the rendered
     frontmatter is what actually exercises _collect_frontmatter_findings.
+
+    Colon-bearing names are skipped on Windows because ``:`` is
+    reserved in NTFS paths — the filesystem rejects the directory
+    before our re-parse runs.  The ``- foo`` case is POSIX-and-NTFS
+    compatible and runs everywhere.
     """
 
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "':' is not a valid Windows path character; tested on POSIX only.",
+    )
     def test_name_with_colon_space_triggers_real_finding(self) -> None:
         from unittest import mock
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2237,6 +2246,10 @@ class ScaffoldBadNameReparseTests(unittest.TestCase):
             msg=f"expected block-entry finding in warnings, got: {warnings}",
         )
 
+    @unittest.skipIf(
+        sys.platform == "win32",
+        "':' is not a valid Windows path character; tested on POSIX only.",
+    )
     def test_bad_name_file_remains_on_disk(self) -> None:
         """Re-parse warnings do not delete the scaffolded file."""
         from unittest import mock

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -2250,6 +2250,35 @@ class ScaffoldBadNameReparseTests(unittest.TestCase):
             self.assertTrue(os.path.isfile(skill_md))
 
 
+class ScaffoldWarningsDedupeTests(unittest.TestCase):
+    """Scaffold merges read-time + emit-time findings without duplicates."""
+
+    def test_repeated_finding_surfaces_once(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "skills:\n"
+                    "  demo:\n"
+                    "    canonical: skills/demo/SKILL.md\n"
+                    "    note: runs tasks: quickly\n"
+                )
+            proc = _run(
+                [
+                    "skill", "added", "--update-manifest", "--json",
+                    "--root", tmpdir,
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            data = json.loads(proc.stdout)
+        warnings = data.get("warnings", [])
+        # The pre-existing divergence is seen by read_manifest and again
+        # by the emit-site re-parse; dedupe keeps it once.
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("': '", warnings[0])
+
+
 class CollectFrontmatterFindingsTests(unittest.TestCase):
     """``_collect_frontmatter_findings`` helper edge cases."""
 

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -2048,7 +2048,7 @@ class ManifestFindingsSurfacedTests(unittest.TestCase):
             self.assertIn("FAIL:", proc.stdout)
             self.assertIn("': '", proc.stdout)
 
-    def test_json_mode_includes_manifest_findings_for_skill(self) -> None:
+    def test_json_mode_includes_warnings_for_skill(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             self._write_divergent_manifest(tmpdir)
             proc = _run(
@@ -2061,12 +2061,10 @@ class ManifestFindingsSurfacedTests(unittest.TestCase):
             self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
             data = json.loads(proc.stdout)
             self.assertTrue(data["success"])
-            self.assertIn("manifest_findings", data)
-            self.assertTrue(
-                any("FAIL" in f for f in data["manifest_findings"])
-            )
+            self.assertIn("warnings", data)
+            self.assertTrue(any("FAIL" in f for f in data["warnings"]))
 
-    def test_clean_manifest_omits_findings_key_in_json(self) -> None:
+    def test_clean_manifest_omits_warnings_key_in_json(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "manifest.yaml")
             with open(path, "w", encoding="utf-8") as f:
@@ -2080,9 +2078,9 @@ class ManifestFindingsSurfacedTests(unittest.TestCase):
             )
             self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
             data = json.loads(proc.stdout)
-            self.assertNotIn("manifest_findings", data)
+            self.assertNotIn("warnings", data)
 
-    def test_json_mode_includes_manifest_findings_for_role(self) -> None:
+    def test_json_mode_includes_warnings_for_role(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "manifest.yaml")
             with open(path, "w", encoding="utf-8") as f:
@@ -2106,7 +2104,7 @@ class ManifestFindingsSurfacedTests(unittest.TestCase):
             self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
             data = json.loads(proc.stdout)
             self.assertTrue(data["success"])
-            self.assertIn("manifest_findings", data)
+            self.assertIn("warnings", data)
 
 
 # ===================================================================
@@ -2125,7 +2123,7 @@ class ScaffoldFrontmatterReparseTests(unittest.TestCase):
             )
             self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
             data = json.loads(proc.stdout)
-            self.assertNotIn("frontmatter_findings", data)
+            self.assertNotIn("warnings", data)
 
     def test_capability_template_substitution_produces_no_findings(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -2142,7 +2140,7 @@ class ScaffoldFrontmatterReparseTests(unittest.TestCase):
             )
             self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
             data = json.loads(proc.stdout)
-            self.assertNotIn("frontmatter_findings", data)
+            self.assertNotIn("warnings", data)
 
     def test_divergent_frontmatter_surfaced_in_json(self) -> None:
         """Mock the re-parse helper to exercise the surfacing path."""
@@ -2158,7 +2156,7 @@ class ScaffoldFrontmatterReparseTests(unittest.TestCase):
                     "demo-skill", root=tmpdir, json_output=True,
                 )
         self.assertIsNotNone(result)
-        self.assertEqual(result["frontmatter_findings"], sample)
+        self.assertEqual(result["warnings"], sample)
 
     def test_divergent_frontmatter_surfaced_in_text_mode(self) -> None:
         """Text-mode scaffold prints findings after Created line."""
@@ -2197,7 +2195,59 @@ class ScaffoldFrontmatterReparseTests(unittest.TestCase):
                     "demo-domain", "demo-cap", root=tmpdir, json_output=True,
                 )
         self.assertIsNotNone(result)
-        self.assertEqual(result["frontmatter_findings"], sample)
+        self.assertEqual(result["warnings"], sample)
+
+
+class ScaffoldBadNameReparseTests(unittest.TestCase):
+    """Bypassing validate_name, the re-parse catches literal divergent names.
+
+    The re-parse path is defense-in-depth; validate_name normally
+    rejects these names upfront, but these tests exercise the real
+    pipeline with validate_name patched to pass, so the rendered
+    frontmatter is what actually exercises _collect_frontmatter_findings.
+    """
+
+    def test_name_with_colon_space_triggers_real_finding(self) -> None:
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch("scaffold.validate_name", return_value=True):
+                from scaffold import scaffold_skill
+                result = scaffold_skill(
+                    "foo: bar", root=tmpdir, json_output=True,
+                )
+        self.assertIsNotNone(result)
+        warnings = result.get("warnings", [])
+        self.assertTrue(
+            any("': '" in w and w.startswith("FAIL") for w in warnings),
+            msg=f"expected ': ' FAIL in warnings, got: {warnings}",
+        )
+
+    def test_name_with_leading_dash_space_triggers_real_finding(self) -> None:
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch("scaffold.validate_name", return_value=True):
+                from scaffold import scaffold_skill
+                result = scaffold_skill(
+                    "- foo", root=tmpdir, json_output=True,
+                )
+        self.assertIsNotNone(result)
+        warnings = result.get("warnings", [])
+        self.assertTrue(
+            any("block sequence" in w.lower() or "'-'" in w for w in warnings),
+            msg=f"expected block-entry finding in warnings, got: {warnings}",
+        )
+
+    def test_bad_name_file_remains_on_disk(self) -> None:
+        """Re-parse warnings do not delete the scaffolded file."""
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch("scaffold.validate_name", return_value=True):
+                from scaffold import scaffold_skill
+                scaffold_skill("foo: bar", root=tmpdir, json_output=True)
+            skill_md = os.path.join(
+                tmpdir, "skills", "foo: bar", "SKILL.md",
+            )
+            self.assertTrue(os.path.isfile(skill_md))
 
 
 class CollectFrontmatterFindingsTests(unittest.TestCase):

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -2197,6 +2197,190 @@ class ScaffoldFrontmatterReparseTests(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result["warnings"], sample)
 
+    def test_role_template_substitution_produces_no_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proc = _run(
+                [
+                    "role", "demo-group", "demo-role",
+                    "--json", "--root", tmpdir,
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            data = json.loads(proc.stdout)
+            self.assertNotIn("warnings", data)
+
+    def test_role_divergent_frontmatter_surfaced_in_json(self) -> None:
+        """scaffold_role surfaces frontmatter findings parallel to skill/capability."""
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sample = ["FAIL: [spec] 'name': unquoted value … contains ': '"]
+            with mock.patch(
+                "scaffold._collect_frontmatter_findings",
+                return_value=sample,
+            ):
+                from scaffold import scaffold_role
+                result = scaffold_role(
+                    "demo-group", "demo-role", root=tmpdir, json_output=True,
+                )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["warnings"], sample)
+
+    def test_role_divergent_frontmatter_surfaced_in_text_mode(self) -> None:
+        import io
+        from contextlib import redirect_stdout
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sample = ["FAIL: [spec] 'name': unquoted value … contains ': '"]
+            buf = io.StringIO()
+            with (
+                mock.patch(
+                    "scaffold._collect_frontmatter_findings",
+                    return_value=sample,
+                ),
+                redirect_stdout(buf),
+            ):
+                from scaffold import scaffold_role
+                scaffold_role(
+                    "demo-group", "demo-role", root=tmpdir, json_output=False,
+                )
+            self.assertIn("FAIL:", buf.getvalue())
+            self.assertIn("': '", buf.getvalue())
+
+
+class ScaffoldEmitCorruptionTests(unittest.TestCase):
+    """Scaffold treats manifest emit corruption as a hard failure."""
+
+    def test_skill_emit_corruption_returns_success_false_in_json(self) -> None:
+        from unittest import mock
+        emit_finding = (
+            "FAIL: manifest emit produced unparseable YAML: "
+            "Failed to parse /tmp/m.yaml: 'skills' must be a mapping"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "scaffold.update_manifest_for_skill",
+                return_value=(
+                    False,
+                    "Manifest update wrote an invalid manifest at /tmp/m.yaml",
+                    False,
+                    [emit_finding],
+                ),
+            ):
+                from scaffold import scaffold_skill
+                result = scaffold_skill(
+                    "demo-skill",
+                    root=tmpdir,
+                    json_output=True,
+                    update_manifest=True,
+                )
+        self.assertIsNotNone(result)
+        self.assertFalse(result["success"])
+        self.assertIn(emit_finding, result["warnings"])
+
+    def test_skill_emit_corruption_exits_one_in_text_mode(self) -> None:
+        from unittest import mock
+        emit_finding = (
+            "FAIL: manifest emit produced unparseable YAML: "
+            "Failed to parse /tmp/m.yaml: 'skills' must be a mapping"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "scaffold.update_manifest_for_skill",
+                return_value=(
+                    False,
+                    "Manifest update wrote an invalid manifest at /tmp/m.yaml",
+                    False,
+                    [emit_finding],
+                ),
+            ):
+                from scaffold import scaffold_skill
+                with self.assertRaises(SystemExit) as ctx:
+                    scaffold_skill(
+                        "demo-skill",
+                        root=tmpdir,
+                        json_output=False,
+                        update_manifest=True,
+                    )
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_role_emit_corruption_returns_success_false_in_json(self) -> None:
+        from unittest import mock
+        emit_finding = (
+            "FAIL: manifest emit produced unparseable YAML: "
+            "Failed to parse /tmp/m.yaml: 'roles' must be a mapping"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "scaffold.update_manifest_for_role",
+                return_value=(
+                    False,
+                    "Manifest update wrote an invalid manifest at /tmp/m.yaml",
+                    False,
+                    [emit_finding],
+                ),
+            ):
+                from scaffold import scaffold_role
+                result = scaffold_role(
+                    "demo-group", "demo-role",
+                    root=tmpdir,
+                    json_output=True,
+                    update_manifest=True,
+                )
+        self.assertIsNotNone(result)
+        self.assertFalse(result["success"])
+        self.assertIn(emit_finding, result["warnings"])
+
+    def test_role_emit_corruption_exits_one_in_text_mode(self) -> None:
+        from unittest import mock
+        emit_finding = (
+            "FAIL: manifest emit produced unparseable YAML: "
+            "Failed to parse /tmp/m.yaml: 'roles' must be a mapping"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "scaffold.update_manifest_for_role",
+                return_value=(
+                    False,
+                    "Manifest update wrote an invalid manifest at /tmp/m.yaml",
+                    False,
+                    [emit_finding],
+                ),
+            ):
+                from scaffold import scaffold_role
+                with self.assertRaises(SystemExit) as ctx:
+                    scaffold_role(
+                        "demo-group", "demo-role",
+                        root=tmpdir,
+                        json_output=False,
+                        update_manifest=True,
+                    )
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_name_conflict_warning_remains_warn_level(self) -> None:
+        """Pre-existing name conflict still surfaces as WARN, not FAIL."""
+        import io
+        from contextlib import redirect_stdout
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = os.path.join(tmpdir, "manifest.yaml")
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                f.write(
+                    "skills:\n"
+                    "  demo-skill:\n"
+                    "    canonical: skills/demo-skill/SKILL.md\n"
+                    "    type: standalone\n"
+                )
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                from scaffold import scaffold_skill
+                scaffold_skill(
+                    "demo-skill", root=tmpdir,
+                    json_output=False, update_manifest=True,
+                )
+            output = buf.getvalue()
+        self.assertIn("WARN:", output)
+        self.assertNotIn("FAIL:", output)
+
 
 class ScaffoldBadNameReparseTests(unittest.TestCase):
     """Bypassing validate_name, the re-parse catches literal divergent names.

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -2109,5 +2109,131 @@ class ManifestFindingsSurfacedTests(unittest.TestCase):
             self.assertIn("manifest_findings", data)
 
 
+# ===================================================================
+# Frontmatter re-parse (issue #89 stage 6)
+# ===================================================================
+
+
+class ScaffoldFrontmatterReparseTests(unittest.TestCase):
+    """Scaffold re-parses the written entry file for divergences."""
+
+    def test_skill_template_substitution_produces_no_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proc = _run(
+                ["skill", "demo-skill", "--json", "--root", tmpdir],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            data = json.loads(proc.stdout)
+            self.assertNotIn("frontmatter_findings", data)
+
+    def test_capability_template_substitution_produces_no_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _run(
+                ["skill", "demo-domain", "--router", "--root", tmpdir],
+                cwd=REPO_ROOT,
+            )
+            proc = _run(
+                [
+                    "capability", "demo-domain", "demo-cap",
+                    "--json", "--root", tmpdir,
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            data = json.loads(proc.stdout)
+            self.assertNotIn("frontmatter_findings", data)
+
+    def test_divergent_frontmatter_surfaced_in_json(self) -> None:
+        """Mock the re-parse helper to exercise the surfacing path."""
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sample = ["FAIL: [spec] 'name': unquoted value … contains ': '"]
+            with mock.patch(
+                "scaffold._collect_frontmatter_findings",
+                return_value=sample,
+            ):
+                from scaffold import scaffold_skill
+                result = scaffold_skill(
+                    "demo-skill", root=tmpdir, json_output=True,
+                )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["frontmatter_findings"], sample)
+
+    def test_divergent_frontmatter_surfaced_in_text_mode(self) -> None:
+        """Text-mode scaffold prints findings after Created line."""
+        import io
+        from contextlib import redirect_stdout
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sample = ["FAIL: [spec] 'name': unquoted value … contains ': '"]
+            buf = io.StringIO()
+            with (
+                mock.patch(
+                    "scaffold._collect_frontmatter_findings",
+                    return_value=sample,
+                ),
+                redirect_stdout(buf),
+            ):
+                from scaffold import scaffold_skill
+                scaffold_skill("demo-skill", root=tmpdir, json_output=False)
+            self.assertIn("FAIL:", buf.getvalue())
+            self.assertIn("': '", buf.getvalue())
+
+    def test_capability_divergent_frontmatter_surfaced_in_json(self) -> None:
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _run(
+                ["skill", "demo-domain", "--router", "--root", tmpdir],
+                cwd=REPO_ROOT,
+            )
+            sample = ["WARN: [spec] 'name': unquoted value starts with '&'"]
+            with mock.patch(
+                "scaffold._collect_frontmatter_findings",
+                return_value=sample,
+            ):
+                from scaffold import scaffold_capability
+                result = scaffold_capability(
+                    "demo-domain", "demo-cap", root=tmpdir, json_output=True,
+                )
+        self.assertIsNotNone(result)
+        self.assertEqual(result["frontmatter_findings"], sample)
+
+
+class CollectFrontmatterFindingsTests(unittest.TestCase):
+    """``_collect_frontmatter_findings`` helper edge cases."""
+
+    def test_missing_file_returns_empty(self) -> None:
+        from scaffold import _collect_frontmatter_findings
+        with tempfile.TemporaryDirectory() as tmpdir:
+            findings = _collect_frontmatter_findings(
+                os.path.join(tmpdir, "nope.md"),
+            )
+        self.assertEqual(findings, [])
+
+    def test_file_without_frontmatter_returns_empty(self) -> None:
+        from scaffold import _collect_frontmatter_findings
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "note.md")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("# Just markdown\n")
+            findings = _collect_frontmatter_findings(path)
+        self.assertEqual(findings, [])
+
+    def test_divergent_frontmatter_surfaces_finding(self) -> None:
+        from scaffold import _collect_frontmatter_findings
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "bad.md")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "---\n"
+                    "name: demo\n"
+                    "description: runs tasks: quickly\n"
+                    "---\n\n# Body\n",
+                )
+            findings = _collect_frontmatter_findings(path)
+        self.assertTrue(any("': '" in f for f in findings))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -2357,6 +2357,91 @@ class ScaffoldEmitCorruptionTests(unittest.TestCase):
                     )
         self.assertEqual(ctx.exception.code, 1)
 
+    def test_skill_frontmatter_parse_error_returns_success_false_in_json(self) -> None:
+        from unittest import mock
+        sample = ["FAIL: Invalid frontmatter in /tmp/SKILL.md: malformed YAML"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "scaffold._collect_frontmatter_findings",
+                return_value=sample,
+            ):
+                from scaffold import scaffold_skill
+                result = scaffold_skill(
+                    "demo-skill", root=tmpdir, json_output=True,
+                )
+        self.assertIsNotNone(result)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["warnings"], sample)
+
+    def test_skill_frontmatter_parse_error_exits_one_in_text_mode(self) -> None:
+        from unittest import mock
+        sample = ["FAIL: Invalid frontmatter in /tmp/SKILL.md: malformed YAML"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "scaffold._collect_frontmatter_findings",
+                return_value=sample,
+            ):
+                from scaffold import scaffold_skill
+                with self.assertRaises(SystemExit) as ctx:
+                    scaffold_skill(
+                        "demo-skill", root=tmpdir, json_output=False,
+                    )
+        self.assertEqual(ctx.exception.code, 1)
+
+    def test_capability_frontmatter_parse_error_returns_success_false_in_json(self) -> None:
+        from unittest import mock
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _run(
+                ["skill", "demo-domain", "--router", "--root", tmpdir],
+                cwd=REPO_ROOT,
+            )
+            sample = ["FAIL: Invalid frontmatter in /tmp/cap.md: malformed YAML"]
+            with mock.patch(
+                "scaffold._collect_frontmatter_findings",
+                return_value=sample,
+            ):
+                from scaffold import scaffold_capability
+                result = scaffold_capability(
+                    "demo-domain", "demo-cap", root=tmpdir, json_output=True,
+                )
+        self.assertIsNotNone(result)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["warnings"], sample)
+
+    def test_role_frontmatter_parse_error_returns_success_false_in_json(self) -> None:
+        from unittest import mock
+        sample = ["FAIL: Invalid frontmatter in /tmp/role.md: malformed YAML"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "scaffold._collect_frontmatter_findings",
+                return_value=sample,
+            ):
+                from scaffold import scaffold_role
+                result = scaffold_role(
+                    "demo-group", "demo-role",
+                    root=tmpdir, json_output=True,
+                )
+        self.assertIsNotNone(result)
+        self.assertFalse(result["success"])
+        self.assertEqual(result["warnings"], sample)
+
+    def test_plain_scalar_finding_does_not_trigger_hard_failure(self) -> None:
+        """Pre-existing divergence FAIL findings must not promote to hard fail."""
+        from unittest import mock
+        sample = ["FAIL: [spec] 'name': unquoted value … contains ': '"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "scaffold._collect_frontmatter_findings",
+                return_value=sample,
+            ):
+                from scaffold import scaffold_skill
+                result = scaffold_skill(
+                    "demo-skill", root=tmpdir, json_output=True,
+                )
+        self.assertIsNotNone(result)
+        self.assertTrue(result["success"])
+        self.assertEqual(result["warnings"], sample)
+
     def test_name_conflict_warning_remains_warn_level(self) -> None:
         """Pre-existing name conflict still surfaces as WARN, not FAIL."""
         import io

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -2017,5 +2017,97 @@ class ParseOptionalDirsDeduplicationTests(unittest.TestCase):
         self.assertEqual(dirs[0], DIR_REFERENCES)
 
 
+# ===================================================================
+# Manifest divergence findings (issue #89 stage 2)
+# ===================================================================
+
+
+class ManifestFindingsSurfacedTests(unittest.TestCase):
+    """--update-manifest surfaces divergences in the existing manifest."""
+
+    def _write_divergent_manifest(self, tmpdir: str) -> str:
+        path = os.path.join(tmpdir, "manifest.yaml")
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(
+                "skills:\n"
+                "  demo:\n"
+                "    canonical: skills/demo/SKILL.md\n"
+                "    note: runs tasks: quickly\n"
+                "\nroles:\n"
+            )
+        return path
+
+    def test_text_mode_prints_findings_for_skill_update(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_divergent_manifest(tmpdir)
+            proc = _run(
+                ["skill", "added", "--update-manifest", "--root", tmpdir],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            self.assertIn("FAIL:", proc.stdout)
+            self.assertIn("': '", proc.stdout)
+
+    def test_json_mode_includes_manifest_findings_for_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_divergent_manifest(tmpdir)
+            proc = _run(
+                [
+                    "skill", "added", "--update-manifest", "--json",
+                    "--root", tmpdir,
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            data = json.loads(proc.stdout)
+            self.assertTrue(data["success"])
+            self.assertIn("manifest_findings", data)
+            self.assertTrue(
+                any("FAIL" in f for f in data["manifest_findings"])
+            )
+
+    def test_clean_manifest_omits_findings_key_in_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("# Manifest\n\nskills:\n\nroles:\n")
+            proc = _run(
+                [
+                    "skill", "added", "--update-manifest", "--json",
+                    "--root", tmpdir,
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            data = json.loads(proc.stdout)
+            self.assertNotIn("manifest_findings", data)
+
+    def test_json_mode_includes_manifest_findings_for_role(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(
+                    "skills:\n"
+                    "  demo:\n"
+                    "    canonical: skills/demo/SKILL.md\n"
+                    "    note: runs tasks: quickly\n"
+                    "\nroles:\n"
+                    "  dev-group:\n"
+                    "    - name: existing\n"
+                    "      path: roles/dev-group/existing.md\n"
+                )
+            proc = _run(
+                [
+                    "role", "dev-group", "added", "--update-manifest",
+                    "--json", "--root", tmpdir,
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            data = json.loads(proc.stdout)
+            self.assertTrue(data["success"])
+            self.assertIn("manifest_findings", data)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -28,7 +28,6 @@ if SCRIPTS_DIR not in sys.path:
 
 from validate_skill import (
     _build_parser,
-    _collect_foundry_config_findings,
     find_skill_root,
     validate_body,
     validate_description,
@@ -36,6 +35,7 @@ from validate_skill import (
     validate_skill,
     validate_skill_references,
 )
+from lib.constants import collect_foundry_config_findings
 from lib.validation import (
     validate_allowed_tools,
     validate_metadata,
@@ -2756,18 +2756,18 @@ class CodexConfigFindingsPropagationTests(unittest.TestCase):
 
 
 class CollectFoundryConfigFindingsTests(unittest.TestCase):
-    """``_collect_foundry_config_findings`` fires only for foundry targets."""
+    """``collect_foundry_config_findings`` fires only for foundry targets."""
 
     def test_non_foundry_path_returns_empty(self) -> None:
         """Arbitrary skill paths never surface configuration.yaml findings."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            findings = _collect_foundry_config_findings(tmpdir)
+            findings = collect_foundry_config_findings(tmpdir)
         self.assertEqual(findings, [])
 
     def test_foundry_path_with_clean_config_returns_empty(self) -> None:
         """The real foundry config has no divergences today."""
         foundry_path = os.path.join(REPO_ROOT, "skill-system-foundry")
-        findings = _collect_foundry_config_findings(foundry_path)
+        findings = collect_foundry_config_findings(foundry_path)
         self.assertEqual(findings, [])
 
     def test_foundry_path_retags_findings_with_foundry_prefix(self) -> None:
@@ -2778,9 +2778,9 @@ class CollectFoundryConfigFindingsTests(unittest.TestCase):
             "WARN: [spec] 'skill.description': unquoted anchor …",
         ]
         with mock.patch(
-            "validate_skill.get_config_findings", return_value=sample,
+            "lib.constants.get_config_findings", return_value=sample,
         ):
-            retagged = _collect_foundry_config_findings(foundry_path)
+            retagged = collect_foundry_config_findings(foundry_path)
         self.assertEqual(len(retagged), 2)
         for line in retagged:
             self.assertIn("[foundry] scripts/lib/configuration.yaml", line)
@@ -2791,10 +2791,10 @@ class CollectFoundryConfigFindingsTests(unittest.TestCase):
         """Detection gates on path equality, not on findings content."""
         with tempfile.TemporaryDirectory() as tmpdir:
             with mock.patch(
-                "validate_skill.get_config_findings",
+                "lib.constants.get_config_findings",
                 return_value=["FAIL: [spec] 'x': bad"],
             ):
-                findings = _collect_foundry_config_findings(tmpdir)
+                findings = collect_foundry_config_findings(tmpdir)
         self.assertEqual(findings, [])
 
 

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -28,6 +28,7 @@ if SCRIPTS_DIR not in sys.path:
 
 from validate_skill import (
     _build_parser,
+    _collect_foundry_config_findings,
     find_skill_root,
     validate_body,
     validate_description,
@@ -2702,6 +2703,49 @@ class ValidateSkillOptionalFieldsTests(unittest.TestCase):
             if e.startswith(LEVEL_INFO) and "typo-field" in e
         ]
         self.assertEqual(key_infos, [])
+
+
+class CollectFoundryConfigFindingsTests(unittest.TestCase):
+    """``_collect_foundry_config_findings`` fires only for foundry targets."""
+
+    def test_non_foundry_path_returns_empty(self) -> None:
+        """Arbitrary skill paths never surface configuration.yaml findings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            findings = _collect_foundry_config_findings(tmpdir)
+        self.assertEqual(findings, [])
+
+    def test_foundry_path_with_clean_config_returns_empty(self) -> None:
+        """The real foundry config has no divergences today."""
+        foundry_path = os.path.join(REPO_ROOT, "skill-system-foundry")
+        findings = _collect_foundry_config_findings(foundry_path)
+        self.assertEqual(findings, [])
+
+    def test_foundry_path_retags_findings_with_foundry_prefix(self) -> None:
+        """When divergences exist, messages are retagged ``[foundry]``."""
+        foundry_path = os.path.join(REPO_ROOT, "skill-system-foundry")
+        sample = [
+            "FAIL: [spec] 'skill.name': unquoted value starts with '-' …",
+            "WARN: [spec] 'skill.description': unquoted anchor …",
+        ]
+        with mock.patch(
+            "validate_skill.get_config_findings", return_value=sample,
+        ):
+            retagged = _collect_foundry_config_findings(foundry_path)
+        self.assertEqual(len(retagged), 2)
+        for line in retagged:
+            self.assertIn("[foundry] scripts/lib/configuration.yaml", line)
+        self.assertTrue(retagged[0].startswith("FAIL: "))
+        self.assertTrue(retagged[1].startswith("WARN: "))
+
+    def test_non_foundry_path_ignores_patched_findings(self) -> None:
+        """Detection gates on path equality, not on findings content."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch(
+                "validate_skill.get_config_findings",
+                return_value=["FAIL: [spec] 'x': bad"],
+            ):
+                findings = _collect_foundry_config_findings(tmpdir)
+        self.assertEqual(findings, [])
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2705,6 +2705,27 @@ class ValidateSkillOptionalFieldsTests(unittest.TestCase):
         self.assertEqual(key_infos, [])
 
 
+class CodexConfigFindingsPropagationTests(unittest.TestCase):
+    """Codex plain-scalar findings reach ``validate_skill`` output."""
+
+    def test_divergent_codex_config_surfaces_in_validate_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_skill_md(skill_dir)
+            write_text(
+                os.path.join(skill_dir, "agents", "openai.yaml"),
+                "interface:\n"
+                "  display_name: Demo\n"
+                "  default_prompt: runs tasks: quickly\n",
+            )
+            errors, _ = validate_skill(skill_dir)
+        tagged = [
+            e for e in errors
+            if e.startswith("FAIL: [platform: OpenAI]") and "': '" in e
+        ]
+        self.assertEqual(len(tagged), 1)
+
+
 class CollectFoundryConfigFindingsTests(unittest.TestCase):
     """``_collect_foundry_config_findings`` fires only for foundry targets."""
 

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2705,6 +2705,35 @@ class ValidateSkillOptionalFieldsTests(unittest.TestCase):
         self.assertEqual(key_infos, [])
 
 
+class CodexFindingsJsonSchemaTests(unittest.TestCase):
+    """``validate_skill --json`` surfaces Codex findings in the errors array."""
+
+    def test_divergent_codex_config_appears_in_json_errors(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "demo-skill")
+            write_skill_md(skill_dir)
+            write_text(
+                os.path.join(skill_dir, "agents", "openai.yaml"),
+                "interface:\n"
+                "  display_name: Demo\n"
+                "  default_prompt: runs tasks: quickly\n",
+            )
+            proc = _run([skill_dir, "--json"], cwd=REPO_ROOT)
+            data = json.loads(proc.stdout)
+        self.assertFalse(data["success"])
+        self.assertIn("errors", data)
+        # Schema preserved: no new top-level keys introduced.
+        self.assertEqual(
+            set(data.keys()),
+            {"tool", "path", "type", "success", "summary", "errors", "version"},
+        )
+        codex_fails = [
+            entry for entry in data["errors"].get("failures", [])
+            if "[platform: OpenAI]" in entry and "': '" in entry
+        ]
+        self.assertEqual(len(codex_fails), 1)
+
+
 class CodexConfigFindingsPropagationTests(unittest.TestCase):
     """Codex plain-scalar findings reach ``validate_skill`` output."""
 


### PR DESCRIPTION
## Summary

- Thread plain-scalar divergence findings through every YAML parse and emit site in the meta-skill so divergences surface consistently across the develop → review → update → fix loop.
- Close all four silent-drop parse sites (`constants.py`, `manifest.read_manifest`, `codex_config.validate_codex_config`, `audit_skill_system` system-manifest block) and re-parse both emit sites (`append_skill_entry` / `append_role_entry` and `scaffold.py` frontmatter substitution).
- Keep the `--json` schema stable for `validate_skill` / `audit_skill_system`; consolidate scaffold findings under a single deduped `warnings` array alongside the existing `manifest_warning` key.

Closes #89.

## Details

### Part 1 — parse sites

| Site | Change |
|---|---|
| `lib/constants.py` | `CONFIG_PATH` + lazy `get_config_findings()` (dual-parse by design, documented inline, avoids circular import with `yaml_parser._check_plain_scalar`) |
| `lib/manifest.read_manifest` | `findings: list[str] \| None = None` parameter; structural failures still raise without touching findings |
| `lib/codex_config.validate_codex_config` | Locally collects findings and retags them `[platform: OpenAI] agents/openai.yaml …` |
| `scripts/audit_skill_system.py` system-manifest block | Threads findings into `parse_yaml_subset` and retags `[spec] manifest.yaml …` |

Foundry self-detection: `validate_skill` and `audit_skill_system` fire `configuration.yaml` findings only when the target's candidate path equals `CONFIG_PATH`; third-party skills never trigger the check.

### Part 2 — emit sites

| Site | Change |
|---|---|
| `lib/manifest.append_skill_entry` / `append_role_entry` | Re-parse post-write text and return findings; wrappers merge into the `update_manifest_for_*` tuple |
| `lib/manifest.scaffold_empty_manifest` | Static content; compile-time round-trip assertion rather than runtime re-parse |
| `scripts/scaffold.py` | `_collect_frontmatter_findings` re-parses the rendered entry file; file stays on disk either way; findings surface in both text mode and JSON |

### `--json` output

- `validate_skill` / `audit_skill_system`: schema unchanged. Findings ride the existing `errors` stream via their `FAIL:` / `WARN:` / `INFO:` level prefixes, consumed by `categorize_errors_for_json`. Covered by top-level key-set assertions.
- `scaffold.py`: single `warnings` array carries every finding (frontmatter re-parse + manifest read-time + manifest emit-time), deduped with order preserved so a pre-existing divergence that survives the append collapses to one entry. Level prefixes are intact, matching the validator convention.

### Return-type changes

- `update_manifest_for_skill` and `update_manifest_for_role` now return `(updated, warning, created_manifest, findings)` (4-tuple) instead of the prior 3-tuple. All in-tree callers and tests updated.

## Non-goals (per issue)

- No `yaml_parser.py` grammar changes.
- No `configuration.yaml` schema changes.
- No auto-fixer / auto-quoter — findings reuse the existing `_quote_advice` / `suggest_quoted_form` messages.
- No `assets/` template changes.
- No `yaml_conformance` JSON slot (scoped to #90).

## Test plan

- [x] Unit tests per affected module — `test_constants.py` (new), `test_manifest.py`, `test_codex_config.py`, `test_scaffold_cli.py`, `test_audit_skill_system.py`
- [x] Integration assertions in `test_validate_skill.py` and `test_audit_skill_system.py` confirming Codex and manifest findings propagate end-to-end
- [x] \`--json\` CLI assertions proving findings appear in \`errors.failures\` and the top-level key set is unchanged
- [x] Scaffold tests with literal \`: \`-bearing and leading-\`-\` names via mocked \`validate_name\`, exercising the real re-parse pipeline and confirming the file remains on disk
- [x] \`python -m coverage run -m unittest discover -s tests -p "test_*.py"\` passes 1233/1233, total coverage 97% (threshold 70%)
- [x] \`python skill-system-foundry/scripts/validate_skill.py . --allow-nested-references\` clean
- [x] \`python skill-system-foundry/scripts/audit_skill_system.py .\` clean (only the expected distribution-repo WARN)