### PR TITLE
Add prose-YAML fence validation to validate_skill and audit_skill_system

### DIFF
--- a/.agents/skills/markdown-docs/SKILL.md
+++ b/.agents/skills/markdown-docs/SKILL.md
@@ -42,6 +42,12 @@ Do not explain general programming concepts, standard library APIs, or well-know
 
 Each piece of knowledge has a single authoritative location. If the same concept appears in multiple files, one file owns the definition and others reference it. Do not copy content between `SKILL.md`, reference files, templates, or `CONTRIBUTING.md`.
 
+### Line Wrapping
+
+Do not hard-wrap prose lines to a fixed width. One paragraph is one logical line — let the renderer (GitHub, the IDE preview, or the consumer's terminal) handle wrapping. Hard-wrapped paragraphs produce noisy diffs when a single word changes mid-paragraph and force every editor to honour the same column limit.
+
+Lists, tables, code fences, and frontmatter values keep their natural line structure (one item per line, one fence per line, etc.). Wrapping rules apply to flowing prose only.
+
 ## Frontmatter Rules
 
 ### Required Fields
@@ -155,3 +161,4 @@ When creating or editing any Markdown file, verify:
 - Unquoted value containing special characters (`:`, `#`, `{`, `}`)
 - Missing table of contents in files over 100 lines
 - Placeholder markers removed from templates
+- Hard-wrapped prose lines instead of one-paragraph-per-line

--- a/.agents/skills/markdown-docs/SKILL.md
+++ b/.agents/skills/markdown-docs/SKILL.md
@@ -44,9 +44,7 @@ Each piece of knowledge has a single authoritative location. If the same concept
 
 ### Line Wrapping
 
-Do not hard-wrap prose lines to a fixed width. One paragraph is one logical line — let the renderer (GitHub, the IDE preview, or the consumer's terminal) handle wrapping. Hard-wrapped paragraphs produce noisy diffs when a single word changes mid-paragraph and force every editor to honour the same column limit.
-
-Lists, tables, code fences, and frontmatter values keep their natural line structure (one item per line, one fence per line, etc.). Wrapping rules apply to flowing prose only.
+Do not hard-wrap prose lines to a fixed width. See `skill-system-foundry/references/authoring-principles.md` (section "Line wrapping") for the full rule and rationale — this file intentionally does not duplicate it.
 
 ## Frontmatter Rules
 

--- a/.github/codex/review-reference.md
+++ b/.github/codex/review-reference.md
@@ -31,6 +31,15 @@ Apply these in addition to the standard workflow checklist:
 - Verify all actions are pinned to commit SHAs, not tags (e.g. `uses: actions/checkout@<sha> # @v6 as 6.0.2`).
 - Check that job permissions follow least-privilege (separate read/write jobs).
 
+## Markdown inside skills (`skill-system-foundry/**/*.md`)
+
+Apply these rules to file-reference links inside skill content (`SKILL.md`, `capabilities/**/*.md`, `references/**/*.md`). They override plain CommonMark expectations:
+
+- **Skill-root-relative paths, never parent traversals** — every markdown link target is written as if the file were standing at the skill root, regardless of the referencing file's physical location (e.g., from `capabilities/validation/capability.md` the correct link is `[...](references/authoring-principles.md)`, not `../../references/authoring-principles.md`). Do **not** flag these as broken links — the in-repo reference resolver (`lib/references.py::resolve_reference`) tries source-dir-relative first, then falls back to skill-root-relative, so skill-root paths always resolve.
+- **Forward slashes only** — no Windows-style backslashes in link targets.
+- **Role files are the exception** — files outside any `skills/` tree (the `roles/` tree) use system-root-relative paths (e.g., `skills/<domain>/SKILL.md`). Skill-internal links still use the skill-root-relative form.
+- Do flag a link as broken only after confirming the target does not exist **at the skill root** either; do not rely on `<source-dir>/<link>` existence alone.
+
 ## Review-specific focus areas
 
 Beyond code correctness, also evaluate:

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -14,6 +14,7 @@ Review changes as a **documentation quality reviewer**, ensuring all Markdown fi
 - **Actionable over explanatory** — prefer decision checklists, quick references, and step-by-step workflows over narrative prose
 - **Don't repeat yourself** — each piece of knowledge should have a single authoritative location. If the same concept appears in multiple files, one file should own the definition and others should reference it. Do not copy content between `SKILL.md`, reference files, templates, or `CONTRIBUTING.md`
 - **Simplicity** — prefer the simplest phrasing that conveys the full meaning. Avoid nested qualifications, double negatives, and multi-clause sentences when a direct statement works
+- **Do not hard-wrap prose** — one paragraph is one logical line; let the renderer handle wrapping. Hard-wrapping produces noisy diffs when a single word changes mid-paragraph and forces every editor to honour the same column limit. Lists, tables, code fences, and frontmatter values keep their natural line structure (one item per line)
 
 ## Description Quality
 
@@ -86,6 +87,7 @@ Include: what the skill does (verbs and nouns), when to trigger it (user intent 
 - Missing table of contents in files over 100 lines
 - Placeholder markers removed or overwritten in template files
 - Multi-line `description` without folded block scalar (`>`) or unquoted value containing special characters (`:`, `#`, `{`, `}`)
+- Hard-wrapped prose lines instead of one-paragraph-per-line — defer wrapping to the renderer
 
 ---
 

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -89,4 +89,14 @@ Include: what the skill does (verbs and nouns), when to trigger it (user intent 
 
 ---
 
+## Prose YAML fences
+
+When reviewing Markdown that contains ` ```yaml ` fenced code blocks inside the in-scope globs (`SKILL.md`, `capabilities/**/*.md`, `references/**/*.md`):
+
+- Apply the **counter-example convention** in `references/authoring-principles.md` — counter-examples must be opted out via the `<!-- yaml-ignore -->` HTML comment on the line immediately above the fence-open line, with no blank line between.
+- Confirm the fence shape matches: three backticks, lowercase `yaml` token, no whitespace between backticks and `yaml`, opener at byte offset 0.
+- Avoid embedding column-0 ` ``` ` lines inside YAML block scalars — the extractor terminates the fence at the first column-0 ` ``` ` per CommonMark.
+
+---
+
 **Remember:** Review as a documentation quality reviewer. Prioritize conciseness, structural clarity, and consistency.

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -93,11 +93,11 @@ Include: what the skill does (verbs and nouns), when to trigger it (user intent 
 
 ## Prose YAML fences
 
-When reviewing Markdown that contains ` ```yaml ` fenced code blocks inside the in-scope globs (`SKILL.md`, `capabilities/**/*.md`, `references/**/*.md`):
+When reviewing Markdown that contains ```` ```yaml ```` fenced code blocks inside the in-scope globs (`SKILL.md`, `capabilities/**/*.md`, `references/**/*.md`):
 
 - Apply the **counter-example convention** in `references/authoring-principles.md` — counter-examples must be opted out via the `<!-- yaml-ignore -->` HTML comment on the line immediately above the fence-open line, with no blank line between.
 - Confirm the fence shape matches: three backticks, lowercase `yaml` token, no whitespace between backticks and `yaml`, opener at byte offset 0.
-- Avoid embedding column-0 ` ``` ` lines inside YAML block scalars — the extractor terminates the fence at the first column-0 ` ``` ` per CommonMark.
+- Avoid embedding column-0 ```` ``` ```` lines inside YAML block scalars — the extractor terminates the fence at the first column-0 ```` ``` ```` per CommonMark.
 
 ---
 

--- a/.github/scripts/check-per-file-coverage.py
+++ b/.github/scripts/check-per-file-coverage.py
@@ -249,13 +249,15 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
 def _run(args: argparse.Namespace) -> int:
     """Execute the coverage check using parsed *args*.  Returns exit code."""
     # Parse and validate per-file overrides before any coverage measurement.
+    # Malformed --file-threshold is an argparse-style usage error: exit
+    # code 2, matching the contract documented on ``main``.
     file_thresholds: dict[str, float] = {}
     for raw in args.file_threshold:
         try:
             path, pct = parse_file_threshold(raw)
         except ValueError as exc:
             print(f"Error: {exc}", file=sys.stderr)
-            return 1
+            return 2
         file_thresholds[path] = pct
 
     # Determine threshold

--- a/.github/scripts/check-per-file-coverage.py
+++ b/.github/scripts/check-per-file-coverage.py
@@ -17,6 +17,21 @@ def _is_number(value: object) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool)
 
 
+def _normalize_path(path: str) -> str:
+    """Canonicalise a path so lookups are robust across form variants.
+
+    Normalises ``.``, ``..`` and redundant separators via
+    ``os.path.normpath``, drops the leading ``./`` that Windows'
+    ``normpath`` leaves on and then rewrites backslashes to forward
+    slashes so the result is comparable regardless of which platform
+    produced either side of the comparison.
+    """
+    normalised = os.path.normpath(path).replace("\\", "/")
+    if normalised.startswith("./"):
+        normalised = normalised[2:]
+    return normalised
+
+
 def load_threshold(coveragerc_path: str) -> float:
     """Read ``fail_under`` from a ``.coveragerc`` file.
 
@@ -128,7 +143,9 @@ def check_per_file(
     structure is malformed (missing ``files`` dict, or a file entry lacks
     branch coverage data that can be used or computed).
     """
-    overrides = file_thresholds or {}
+    overrides = {
+        _normalize_path(k): v for k, v in (file_thresholds or {}).items()
+    }
     with open(json_path, encoding="utf-8") as fh:
         data = json.load(fh)
 
@@ -190,7 +207,7 @@ def check_per_file(
                 f"coverage.json malformed entry for '{filename}': "
                 f"branch coverage {pct:.2f}% is outside the 0–100 range"
             )
-        effective = overrides.get(filename, threshold)
+        effective = overrides.get(_normalize_path(filename), threshold)
         if pct < effective:
             failures.append((filename, pct))
         else:
@@ -250,7 +267,9 @@ def _run(args: argparse.Namespace) -> int:
     """Execute the coverage check using parsed *args*.  Returns exit code."""
     # Parse and validate per-file overrides before any coverage measurement.
     # Malformed --file-threshold is an argparse-style usage error: exit
-    # code 2, matching the contract documented on ``main``.
+    # code 2, matching the contract documented on ``main``.  Override
+    # paths are normalised up-front so ``./x.py`` and backslash forms
+    # still match the form ``coverage.json`` emits.
     file_thresholds: dict[str, float] = {}
     for raw in args.file_threshold:
         try:
@@ -258,7 +277,7 @@ def _run(args: argparse.Namespace) -> int:
         except ValueError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 2
-        file_thresholds[path] = pct
+        file_thresholds[_normalize_path(path)] = pct
 
     # Determine threshold
     if args.threshold is not None:
@@ -308,7 +327,7 @@ def _run(args: argparse.Namespace) -> int:
 
     any_override_failed = False
     for filename, pct in failures:
-        effective = file_thresholds.get(filename, threshold)
+        effective = file_thresholds.get(_normalize_path(filename), threshold)
         if effective != threshold:
             any_override_failed = True
             print(

--- a/.github/scripts/check-per-file-coverage.py
+++ b/.github/scripts/check-per-file-coverage.py
@@ -73,14 +73,50 @@ def load_threshold(coveragerc_path: str) -> float:
         raise SystemExit(1)
 
 
+def parse_file_threshold(raw: str) -> tuple[str, float]:
+    """Parse a single ``--file-threshold PATH=PCT`` argument.
+
+    Splits on the **last** ``=`` so path values may contain ``=``.  ``PCT``
+    must be a non-negative integer between 0 and 100 inclusive.  Raises
+    ``ValueError`` with the offending argument in the message when the
+    form is invalid (no ``=``, empty path, non-integer or out-of-range
+    percentage).
+    """
+    sep_index = raw.rfind("=")
+    if sep_index < 0:
+        raise ValueError(
+            f"--file-threshold requires PATH=PCT form: {raw!r}"
+        )
+    path = raw[:sep_index]
+    pct_text = raw[sep_index + 1:]
+    if not path:
+        raise ValueError(
+            f"--file-threshold path is empty in {raw!r}"
+        )
+    if not pct_text.isdigit():
+        raise ValueError(
+            f"--file-threshold percentage must be an integer 0-100 in {raw!r}"
+        )
+    pct = int(pct_text)
+    if pct < 0 or pct > 100:
+        raise ValueError(
+            f"--file-threshold percentage must be 0-100 in {raw!r}"
+        )
+    return path, float(pct)
+
+
 def check_per_file(
-    json_path: str, threshold: float
+    json_path: str,
+    threshold: float,
+    file_thresholds: dict[str, float] | None = None,
 ) -> tuple[list[tuple[str, float]], list[tuple[str, float]]]:
     """Return ``(failures, passes)`` for per-file branch coverage.
 
     *json_path* is the path to a ``coverage.json`` file produced by
     ``python -m coverage json``.  Each file's
-    ``summary.percent_branches_covered`` is compared against *threshold*.
+    ``summary.percent_branches_covered`` is compared against the
+    matching threshold: per-file overrides from *file_thresholds* take
+    precedence over the global *threshold*.
 
     When ``percent_branches_covered`` is absent (coverage < 7.7), the
     percentage is computed from ``covered_branches / num_branches``.
@@ -92,6 +128,7 @@ def check_per_file(
     structure is malformed (missing ``files`` dict, or a file entry lacks
     branch coverage data that can be used or computed).
     """
+    overrides = file_thresholds or {}
     with open(json_path, encoding="utf-8") as fh:
         data = json.load(fh)
 
@@ -153,7 +190,8 @@ def check_per_file(
                 f"coverage.json malformed entry for '{filename}': "
                 f"branch coverage {pct:.2f}% is outside the 0–100 range"
             )
-        if pct < threshold:
+        effective = overrides.get(filename, threshold)
+        if pct < effective:
             failures.append((filename, pct))
         else:
             passes.append((filename, pct))
@@ -194,11 +232,32 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         default=".coveragerc",
         help="Path to .coveragerc (default: .coveragerc)",
     )
+    parser.add_argument(
+        "--file-threshold",
+        action="append",
+        default=[],
+        metavar="PATH=PCT",
+        help=(
+            "Per-file override of the coverage threshold (repeatable). "
+            "PCT is an integer 0-100. Paths may contain '=' (split on the "
+            "last '=')."
+        ),
+    )
     return parser.parse_args(argv)
 
 
 def _run(args: argparse.Namespace) -> int:
     """Execute the coverage check using parsed *args*.  Returns exit code."""
+    # Parse and validate per-file overrides before any coverage measurement.
+    file_thresholds: dict[str, float] = {}
+    for raw in args.file_threshold:
+        try:
+            path, pct = parse_file_threshold(raw)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        file_thresholds[path] = pct
+
     # Determine threshold
     if args.threshold is not None:
         threshold = args.threshold
@@ -225,7 +284,9 @@ def _run(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        failures, passes = check_per_file(args.coverage_json, threshold)
+        failures, passes = check_per_file(
+            args.coverage_json, threshold, file_thresholds
+        )
     except (OSError, json.JSONDecodeError) as exc:
         print(
             f"Error: failed to read/parse coverage.json at {args.coverage_json}: {exc}",

--- a/.github/scripts/check-per-file-coverage.py
+++ b/.github/scripts/check-per-file-coverage.py
@@ -304,15 +304,30 @@ def _run(args: argparse.Namespace) -> int:
     for filename, pct in passes:
         print(f"  PASS  {pct:6.1f}%  {filename}")
 
+    any_override_failed = False
     for filename, pct in failures:
-        print(f"  FAIL  {pct:6.1f}%  {filename}")
+        effective = file_thresholds.get(filename, threshold)
+        if effective != threshold:
+            any_override_failed = True
+            print(
+                f"  FAIL  {pct:6.1f}%  {filename}  "
+                f"(below override threshold {effective:.1f}%)"
+            )
+        else:
+            print(f"  FAIL  {pct:6.1f}%  {filename}")
 
     print("-" * 60)
 
     if failures:
-        print(
-            f"{len(failures)} file(s) below {threshold:.1f}% branch coverage threshold"
-        )
+        if any_override_failed:
+            print(
+                f"{len(failures)} file(s) below their branch coverage threshold "
+                f"(floor {threshold:.1f}%, plus per-file overrides)"
+            )
+        else:
+            print(
+                f"{len(failures)} file(s) below {threshold:.1f}% branch coverage threshold"
+            )
         return 1
 
     print(f"All {len(passes)} file(s) meet the {threshold:.1f}% threshold")

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -40,7 +40,13 @@ jobs:
         run: python -m coverage json
 
       - name: Check per-file coverage
-        run: python .github/scripts/check-per-file-coverage.py
+        # Coverage thresholds are enforced against the Ubuntu run only;
+        # Windows numbers are advisory because branch coverage can vary
+        # with platform-conditional code paths.
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          python .github/scripts/check-per-file-coverage.py \
+            --file-threshold skill-system-foundry/scripts/lib/prose_yaml.py=90
 
       - name: Generate coverage HTML report
         if: always() && steps.run-tests.outcome != 'skipped'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,11 +140,20 @@ Coverage threshold: 70% branch coverage (configured in `.coveragerc`). CI runs t
 
 ```bash
 cd skill-system-foundry
-python scripts/validate_skill.py . --allow-nested-references --verbose
+python scripts/validate_skill.py . --allow-nested-references --foundry-self --verbose
 python scripts/audit_skill_system.py .
 ```
 
 The `--allow-nested-references` flag is needed because this meta-skill intentionally uses nested references. One warning about a missing `skills/` directory from the audit is expected in this distribution repository.
+
+#### Flag behavior
+
+| Flag | Effect | When to use |
+|---|---|---|
+| `--check-prose-yaml` | Validates ` ```yaml ` fences in `SKILL.md`, `capabilities/**/*.md`, and `references/**/*.md`. Findings route to the existing FAIL/WARN/INFO stream and the `yaml_conformance.doc_snippets` JSON slot. | When fixing or adding documentation that contains YAML examples. |
+| `--foundry-self` | Implies `--check-prose-yaml`. Runs the target skill the way the foundry runs itself. On `audit_skill_system` it is a mode switch — the prose check runs across every scanned skill. | Self-validation of the meta-skill, or to run an integrator skill with foundry-equivalent strictness. |
+| `--allow-nested-references` | Suppresses the nested-reference depth warning. Required for skills that intentionally cross-reference their own reference files. | Any meta-skill or template-rich skill where reference graphs span more than one level. |
+| `--verbose` | Prints per-file progress messages for the prose check (`Checking prose YAML: <path> (<N> fences)`) and shows passing checks otherwise. Silent under `--json`. | Local debugging / triage. |
 
 ### Linting Shell Scripts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ The `--allow-nested-references` flag is needed because this meta-skill intention
 
 | Flag | Effect | When to use |
 |---|---|---|
-| `--check-prose-yaml` | Validates ` ```yaml ` fences in `SKILL.md`, `capabilities/**/*.md`, and `references/**/*.md`. Findings route to the existing FAIL/WARN/INFO stream and the `yaml_conformance.doc_snippets` JSON slot. | When fixing or adding documentation that contains YAML examples. |
+| `--check-prose-yaml` | Validates ```` ```yaml ```` fences in `SKILL.md`, `capabilities/**/*.md`, and `references/**/*.md`. Findings route to the existing FAIL/WARN/INFO stream and the `yaml_conformance.doc_snippets` JSON slot. | When fixing or adding documentation that contains YAML examples. |
 | `--foundry-self` | Implies `--check-prose-yaml`. Runs the target skill the way the foundry runs itself. On `audit_skill_system` it is a mode switch — the prose check runs across every scanned skill. | Self-validation of the meta-skill, or to run an integrator skill with foundry-equivalent strictness. |
 | `--allow-nested-references` | Suppresses the nested-reference depth warning. Required for skills that intentionally cross-reference their own reference files. | Any meta-skill or template-rich skill where reference graphs span more than one level. |
 | `--verbose` | Prints per-file progress messages for the prose check (`Checking prose YAML: <path> (<N> fences)`) and shows passing checks otherwise. Silent under `--json`. | Local debugging / triage. |

--- a/skill-system-foundry/capabilities/validation/capability.md
+++ b/skill-system-foundry/capabilities/validation/capability.md
@@ -14,7 +14,7 @@ python scripts/validate_skill.py <skill-path> [--capability] [--verbose] [--allo
 - `--verbose`: Show all checks, not just failures
 - `--allow-nested-references`: Suppress nested-reference warnings (needed for skills that intentionally cross-reference their own reference files)
 - `--json`: Machine-readable output
-- `--check-prose-yaml`: Validate ` ```yaml ` fences in `SKILL.md`, `capabilities/**/*.md`, and `references/**/*.md`. See [authoring-principles.md](references/authoring-principles.md) for the counter-example convention.
+- `--check-prose-yaml`: Validate ```` ```yaml ```` fences in `SKILL.md`, `capabilities/**/*.md`, and `references/**/*.md`. See [authoring-principles.md](references/authoring-principles.md) for the counter-example convention.
 - `--foundry-self`: Run this skill the way the foundry runs itself (currently implies `--check-prose-yaml`).
 
 For registered skills, the validator checks: frontmatter fields (`name`, `description`), naming conventions (lowercase + hyphens, max 64 chars, matches directory), line counts (recommended max 500 lines), and resource directory structure. In `--capability` mode it only validates the body (line counts, nested-reference rules) and, if frontmatter is present, reports name/description as informational notes without enforcing frontmatter or directory checks.

--- a/skill-system-foundry/capabilities/validation/capability.md
+++ b/skill-system-foundry/capabilities/validation/capability.md
@@ -14,6 +14,8 @@ python scripts/validate_skill.py <skill-path> [--capability] [--verbose] [--allo
 - `--verbose`: Show all checks, not just failures
 - `--allow-nested-references`: Suppress nested-reference warnings (needed for skills that intentionally cross-reference their own reference files)
 - `--json`: Machine-readable output
+- `--check-prose-yaml`: Validate ` ```yaml ` fences in `SKILL.md`, `capabilities/**/*.md`, and `references/**/*.md`. See [authoring-principles.md](references/authoring-principles.md) for the counter-example convention.
+- `--foundry-self`: Run this skill the way the foundry runs itself (currently implies `--check-prose-yaml`).
 
 For registered skills, the validator checks: frontmatter fields (`name`, `description`), naming conventions (lowercase + hyphens, max 64 chars, matches directory), line counts (recommended max 500 lines), and resource directory structure. In `--capability` mode it only validates the body (line counts, nested-reference rules) and, if frontmatter is present, reports name/description as informational notes without enforcing frontmatter or directory checks.
 

--- a/skill-system-foundry/references/authoring-principles.md
+++ b/skill-system-foundry/references/authoring-principles.md
@@ -348,7 +348,7 @@ Skills act as additions to models. What works for Opus/o3 might need more detail
 
 ## Counter-example convention for prose YAML fences
 
-Skills sometimes ship intentional examples of YAML that the in-repo parser would reject — counter-examples illustrating divergences. The doc-snippet validator (`validate_skill --check-prose-yaml`) treats every ```` ```yaml ```` fence in scope as live input by default; counter-examples need an opt-out.
+Skills sometimes ship intentional examples of YAML that the in-repo parser would reject — counter-examples illustrating divergences. The doc-snippet validator (`python scripts/validate_skill.py <skill-path> --check-prose-yaml`) treats every ```` ```yaml ```` fence in scope as live input by default; counter-examples need an opt-out.
 
 **Opt-out marker.** The HTML comment `<!-- yaml-ignore -->` on the line immediately above the fence-open line — with no blank line between — opts the fence out of validation. The marker is reviewer-visible by design: a waiver, not silent acceptance.
 

--- a/skill-system-foundry/references/authoring-principles.md
+++ b/skill-system-foundry/references/authoring-principles.md
@@ -357,7 +357,7 @@ Skills sometimes ship intentional examples of YAML that the in-repo parser would
 - Three backticks (no more, no fewer); tilde fences are invisible.
 - Lowercase literal `yaml` immediately after the backticks (no whitespace between).
 - The opening backticks at byte offset 0 (column 0); indented fences are invisible.
-- A column-0 ```` ``` ```` close marker before end of file.
+- A close marker line that is exactly ```` ``` ```` at byte offset 0 (column 0), with no trailing whitespace or other characters, before end of file.
 
 **Avoid column-0 ```` ``` ```` inside a YAML block scalar.** The markdown extractor terminates the fence at the first column-0 ```` ``` ```` line per CommonMark, even when that line is inside a literal-block content region. If a YAML example needs a literal triple-backtick, indent the line so it is no longer at column 0.
 

--- a/skill-system-foundry/references/authoring-principles.md
+++ b/skill-system-foundry/references/authoring-principles.md
@@ -33,6 +33,7 @@ Skill System Foundry maintains these principles as a unified reference because t
 - [Scripts and Executable Code](#scripts-and-executable-code)
 - [Workflows and Feedback Loops](#workflows-and-feedback-loops)
 - [Evaluation and Iteration](#evaluation-and-iteration)
+- [Counter-example convention for prose YAML fences](#counter-example-convention-for-prose-yaml-fences)
 
 ---
 
@@ -347,7 +348,7 @@ Skills act as additions to models. What works for Opus/o3 might need more detail
 
 ## Counter-example convention for prose YAML fences
 
-Skills sometimes ship intentional examples of YAML that the in-repo parser would reject — counter-examples illustrating divergences. The doc-snippet validator (`validate_skill --check-prose-yaml`) treats every ```yaml` fence in scope as live input by default; counter-examples need an opt-out.
+Skills sometimes ship intentional examples of YAML that the in-repo parser would reject — counter-examples illustrating divergences. The doc-snippet validator (`validate_skill --check-prose-yaml`) treats every ```` ```yaml ```` fence in scope as live input by default; counter-examples need an opt-out.
 
 **Opt-out marker.** The HTML comment `<!-- yaml-ignore -->` on the line immediately above the fence-open line — with no blank line between — opts the fence out of validation. The marker is reviewer-visible by design: a waiver, not silent acceptance.
 
@@ -356,9 +357,9 @@ Skills sometimes ship intentional examples of YAML that the in-repo parser would
 - Three backticks (no more, no fewer); tilde fences are invisible.
 - Lowercase literal `yaml` immediately after the backticks (no whitespace between).
 - The opening backticks at byte offset 0 (column 0); indented fences are invisible.
-- A column-0 ` ``` ` close marker before end of file.
+- A column-0 ```` ``` ```` close marker before end of file.
 
-**Avoid column-0 ` ``` ` inside a YAML block scalar.** The markdown extractor terminates the fence at the first column-0 ` ``` ` line per CommonMark, even when that line is inside a literal-block content region. If a YAML example needs a literal triple-backtick, indent the line so it is no longer at column 0.
+**Avoid column-0 ```` ``` ```` inside a YAML block scalar.** The markdown extractor terminates the fence at the first column-0 ```` ``` ```` line per CommonMark, even when that line is inside a literal-block content region. If a YAML example needs a literal triple-backtick, indent the line so it is no longer at column 0.
 
-**Commented-out fences.** HTML comments are not parsed by the extractor — a column-0 ```yaml` line inside an `<!-- ... -->` block is still recognised. Wrap it in `<!-- yaml-ignore -->` (one fence per marker) or indent the fence to hide it.
+**Commented-out fences.** HTML comments are not parsed by the extractor — a column-0 ```` ```yaml ```` line inside an `<!-- ... -->` block is still recognised. Wrap it in `<!-- yaml-ignore -->` (one fence per marker) or indent the fence to hide it.
 

--- a/skill-system-foundry/references/authoring-principles.md
+++ b/skill-system-foundry/references/authoring-principles.md
@@ -337,3 +337,21 @@ Watch for unexpected exploration paths, missed connections, overreliance on cert
 ### Test Across Models
 
 Skills act as additions to models. What works for Opus/o3 might need more detail for Haiku/mini. Test with all models you plan to use.
+
+## Counter-example convention for prose YAML fences
+
+Skills sometimes ship intentional examples of YAML that the in-repo parser would reject — counter-examples illustrating divergences. The doc-snippet validator (`validate_skill --check-prose-yaml`) treats every ```yaml` fence in scope as live input by default; counter-examples need an opt-out.
+
+**Opt-out marker.** The HTML comment `<!-- yaml-ignore -->` on the line immediately above the fence-open line — with no blank line between — opts the fence out of validation. The marker is reviewer-visible by design: a waiver, not silent acceptance.
+
+**Fence shape rules.** The validator only sees fences that match all of:
+
+- Three backticks (no more, no fewer); tilde fences are invisible.
+- Lowercase literal `yaml` immediately after the backticks (no whitespace between).
+- The opening backticks at byte offset 0 (column 0); indented fences are invisible.
+- A column-0 ` ``` ` close marker before end of file.
+
+**Avoid column-0 ` ``` ` inside a YAML block scalar.** The markdown extractor terminates the fence at the first column-0 ` ``` ` line per CommonMark, even when that line is inside a literal-block content region. If a YAML example needs a literal triple-backtick, indent the line so it is no longer at column 0.
+
+**Commented-out fences.** HTML comments are not parsed by the extractor — a column-0 ```yaml` line inside an `<!-- ... -->` block is still recognised. Wrap it in `<!-- yaml-ignore -->` (one fence per marker) or indent the fence to hide it.
+

--- a/skill-system-foundry/references/authoring-principles.md
+++ b/skill-system-foundry/references/authoring-principles.md
@@ -23,6 +23,7 @@ Skill System Foundry maintains these principles as a unified reference because t
 
 ## Table of Contents
 
+- [Line wrapping](#line-wrapping)
 - [Conciseness](#conciseness)
 - [Writing Descriptions](#writing-descriptions)
 - [Degrees of Freedom](#degrees-of-freedom)
@@ -34,6 +35,12 @@ Skill System Foundry maintains these principles as a unified reference because t
 - [Evaluation and Iteration](#evaluation-and-iteration)
 
 ---
+
+## Line wrapping
+
+Do not hard-wrap prose to a fixed column width. One paragraph is one logical line; the renderer (GitHub, the IDE preview, or the consumer's terminal) handles wrapping. Hard-wrapped paragraphs produce noisy diffs when a single word changes mid-paragraph and force every editor to honour the same column limit.
+
+Lists, tables, code fences, and frontmatter values keep their natural line structure (one item per line, one fence per line, etc.). The rule applies to flowing prose only.
 
 ## Conciseness
 

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -71,6 +71,7 @@ from lib.constants import (
     LEVEL_FAIL, LEVEL_WARN, LEVEL_INFO,
     collect_foundry_config_findings,
 )
+from lib.prose_yaml import collect_prose_findings, format_finding_as_string
 
 
 def check_upward_references(content: str, component_type: str, allow_orchestration: bool = False) -> list[tuple[str, str]]:
@@ -493,6 +494,26 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="json_output",
         help="Output results as machine-readable JSON.",
     )
+    parser.add_argument(
+        "--check-prose-yaml",
+        action="store_true",
+        dest="check_prose_yaml",
+        help=(
+            "Run the doc-snippet ```yaml validation across every "
+            "scanned skill (SKILL.md + capabilities/**/*.md + "
+            "references/**/*.md)."
+        ),
+    )
+    parser.add_argument(
+        "--foundry-self",
+        action="store_true",
+        dest="foundry_self",
+        help=(
+            "Mode switch: run every scanned skill the way the foundry "
+            "runs itself.  Currently implies --check-prose-yaml across "
+            "all skills (G64)."
+        ),
+    )
     return parser
 
 
@@ -531,6 +552,8 @@ def main() -> None:
     verbose: bool = args.verbose
     allow_orchestration: bool = args.allow_orchestration
     json_output: bool = args.json_output
+    # G64 — --foundry-self is a mode switch across every scanned skill.
+    check_prose: bool = args.check_prose_yaml or args.foundry_self
 
     if not os.path.isdir(system_root):
         if json_output:
@@ -560,6 +583,40 @@ def main() -> None:
         allow_orchestration=allow_orchestration,
     )
 
+    # Aggregate prose-YAML doc-snippet findings across every scanned
+    # skill (G64).  Always populate the yaml_conformance JSON slot so
+    # consumers don't need a nullability branch (G25 / G67).
+    prose_findings: list[dict] = []
+    prose_checked = 0
+    if check_prose:
+        all_skills = find_skill_dirs(system_root)
+        for skill in all_skills:
+            if skill["type"] != "registered":
+                continue
+            skill_name = os.path.basename(skill["path"])
+            audit_prefix = f"{DIR_SKILLS}/{skill_name}"
+            findings, checked, per_file = collect_prose_findings(
+                skill["path"], audit_prefix=audit_prefix
+            )
+            prose_checked += checked
+            prose_findings.extend(findings)
+            if effective_verbose:
+                for path, fence_count in per_file:
+                    print(
+                        f"Checking prose YAML: {path} ({fence_count} fences)"
+                    )
+        for finding in prose_findings:
+            errors.append(format_finding_as_string(finding))
+    yaml_conformance_slot = {
+        "corpus": {
+            "total": 0, "passed": 0, "failed": 0, "failures": [],
+        },
+        "doc_snippets": {
+            "checked": prose_checked,
+            "findings": prose_findings,
+        },
+    }
+
     if json_output:
         # Compute component counts directly for JSON output (the
         # public API intentionally returns only errors for backward
@@ -583,6 +640,7 @@ def main() -> None:
                 "info": len(infos),
             },
             "errors": categorize_errors_for_json(errors),
+            "yaml_conformance": yaml_conformance_slot,
         }
         print(to_json_output(result))
         sys.exit(1 if fails else 0)

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -501,7 +501,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Run the doc-snippet ```yaml validation across every "
             "scanned skill (SKILL.md + capabilities/**/*.md + "
-            "references/**/*.md)."
+            "references/**/*.md).  See "
+            "references/authoring-principles.md for the convention."
         ),
     )
     parser.add_argument(
@@ -511,7 +512,7 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Mode switch: run every scanned skill the way the foundry "
             "runs itself.  Currently implies --check-prose-yaml across "
-            "all skills (G64)."
+            "all skills."
         ),
     )
     return parser
@@ -552,7 +553,7 @@ def main() -> None:
     verbose: bool = args.verbose
     allow_orchestration: bool = args.allow_orchestration
     json_output: bool = args.json_output
-    # G64 — --foundry-self is a mode switch across every scanned skill.
+    # --foundry-self is a mode switch across every scanned skill.
     check_prose: bool = args.check_prose_yaml or args.foundry_self
 
     if not os.path.isdir(system_root):
@@ -584,8 +585,8 @@ def main() -> None:
     )
 
     # Aggregate prose-YAML doc-snippet findings across every scanned
-    # skill (G64).  Always populate the yaml_conformance JSON slot so
-    # consumers don't need a nullability branch (G25 / G67).
+    # skill.  Always populate the yaml_conformance JSON slot so
+    # consumers don't need a nullability branch.
     prose_findings: list[dict] = []
     prose_checked = 0
     if check_prose:

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -151,6 +151,25 @@ plain_scalar:
     - TAB
 
 # ============================================================
+# Prose YAML Validation (in-Markdown ```yaml fences)
+# ============================================================
+# Settings for the doc-snippet validator (validate_prose_yaml).  See
+# references/yaml-support.md and authoring-principles.md for the
+# author-facing convention.
+prose_yaml:
+  # HTML-comment marker that opts a fence out of validation when it
+  # appears on the line immediately above the fence-open line (no
+  # blank line between).  Strict adjacency.
+  opt_out_marker: "<!-- yaml-ignore -->"
+  # Globs (relative to the skill root) that the prose check walks.
+  # Other markdown files inside the skill (CLAUDE.md, README.md,
+  # CHANGELOG.md, assets/**) are out of scope by design.
+  in_scope_globs:
+    - SKILL.md
+    - capabilities/**/*.md
+    - references/**/*.md
+
+# ============================================================
 # Codex Configuration (agents/openai.yaml)
 # ============================================================
 codex_config:

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -154,8 +154,8 @@ plain_scalar:
 # Prose YAML Validation (in-Markdown ```yaml fences)
 # ============================================================
 # Settings for the doc-snippet validator (validate_prose_yaml).  See
-# references/yaml-support.md and authoring-principles.md for the
-# author-facing convention.
+# references/authoring-principles.md (section "Counter-example
+# convention for prose YAML fences") for the author-facing convention.
 prose_yaml:
   # HTML-comment marker that opts a fence out of validation when it
   # appears on the line immediately above the fence-open line (no

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -228,6 +228,18 @@ BUNDLE_EXCLUDE_PATTERNS = _bundle["exclude_patterns"]
 BUNDLE_VALID_TARGETS = tuple(_bundle["valid_targets"])
 BUNDLE_DEFAULT_TARGET = _bundle["default_target"]
 
+# --- Prose YAML Validation ---
+# Fail-fast: a stale checkout missing this section produces a clear
+# error at import rather than a subtle KeyError later.
+if "prose_yaml" not in _config:
+    raise RuntimeError(
+        "configuration.yaml is missing required section 'prose_yaml'; "
+        "this foundry build is incomplete."
+    )
+_prose = _config["prose_yaml"]
+PROSE_YAML_OPT_OUT_MARKER = _prose["opt_out_marker"]
+PROSE_YAML_IN_SCOPE_GLOBS = tuple(_prose["in_scope_globs"])
+
 # --- Codex Configuration (agents/openai.yaml) ---
 _codex = _config["codex_config"]
 _codex_iface = _codex["interface"]
@@ -251,3 +263,4 @@ del _skill, _skill_name, _skill_desc, _voice, _skill_body, _body_refs
 del _allowed_tools, _metadata, _plain_scalar, _WS_DECODE
 del _dep, _role, _bundle
 del _codex, _codex_iface, _codex_deps
+del _prose

--- a/skill-system-foundry/scripts/lib/frontmatter.py
+++ b/skill-system-foundry/scripts/lib/frontmatter.py
@@ -3,6 +3,26 @@
 from .yaml_parser import parse_yaml_subset
 
 
+def split_frontmatter(content: str) -> tuple[str | None, str]:
+    """Split *content* into ``(frontmatter_text, body_text)``.
+
+    Returns ``(None, content)`` when the text does not start with the
+    ``---`` open marker.  When the open marker is present but the
+    closing marker is missing, returns ``(content[3:], "")`` so the
+    caller can surface the malformed block as a structured finding.
+
+    This is the one true frontmatter splitter: ``load_frontmatter`` and
+    the prose-YAML check both use it so delimiter rules cannot drift.
+    """
+    if not content.startswith("---"):
+        return None, content
+    try:
+        end = content.index("---", 3)
+    except ValueError:
+        return content[3:], ""
+    return content[3:end], content[end + 3:]
+
+
 def load_frontmatter(filepath: str) -> tuple[dict | None, str, list[str]]:
     """Extract YAML frontmatter from a SKILL.md file.
 
@@ -16,16 +36,18 @@ def load_frontmatter(filepath: str) -> tuple[dict | None, str, list[str]]:
     with open(filepath, "r", encoding="utf-8") as f:
         content = f.read()
 
-    if not content.startswith("---"):
+    frontmatter_raw, body_raw = split_frontmatter(content)
+    if frontmatter_raw is None:
         return None, content, []
+    if body_raw == "":
+        return (
+            {"_parse_error": "No closing '---' delimiter in frontmatter"},
+            frontmatter_raw,
+            [],
+        )
 
-    try:
-        end = content.index("---", 3)
-    except ValueError:
-        return {"_parse_error": "No closing '---' delimiter in frontmatter"}, content[3:], []
-
-    frontmatter_str = content[3:end].strip()
-    body = content[end + 3 :].strip()
+    frontmatter_str = frontmatter_raw.strip()
+    body = body_raw.strip()
 
     try:
         findings: list[str] = []

--- a/skill-system-foundry/scripts/lib/frontmatter.py
+++ b/skill-system-foundry/scripts/lib/frontmatter.py
@@ -3,7 +3,7 @@
 from .yaml_parser import parse_yaml_subset
 
 
-def split_frontmatter(content: str) -> tuple[str | None, str]:
+def split_frontmatter(content: str) -> tuple[str | None, str | None]:
     """Split *content* into ``(frontmatter_text, body_text)``.
 
     Delimiter detection is line-based: the first line must be exactly
@@ -11,11 +11,16 @@ def split_frontmatter(content: str) -> tuple[str | None, str]:
     line.  This avoids matching a ``---`` substring inside the YAML
     value space (for example, inside a block scalar).
 
-    Returns ``(None, content)`` when the first line is not the ``---``
-    open marker.  When the open marker is present but the closing
-    marker is missing, returns the text after the opening line with an
-    empty body so the caller can surface the malformed block as a
-    structured finding.
+    Returns:
+    - ``(None, content)`` when the first line is not the ``---`` open
+      marker (no frontmatter present).
+    - ``(frontmatter_text, body_text)`` when both delimiters are
+      present; ``body_text`` may be the empty string when the closing
+      delimiter is the final line and there is no body content.
+    - ``(frontmatter_text, None)`` when the opening marker is present
+      but the closing marker is missing.  ``body_text`` is ``None``
+      (not ``""``) so callers can distinguish this malformed case from
+      a legitimately empty body.
 
     This is the one true frontmatter splitter: ``load_frontmatter`` and
     the prose-YAML check both use it so delimiter rules cannot drift.
@@ -27,7 +32,7 @@ def split_frontmatter(content: str) -> tuple[str | None, str]:
     for index in range(1, len(lines)):
         if lines[index].rstrip("\r\n") == "---":
             return "".join(lines[1:index]), "".join(lines[index + 1:])
-    return "".join(lines[1:]), ""
+    return "".join(lines[1:]), None
 
 
 def load_frontmatter(filepath: str) -> tuple[dict | None, str, list[str]]:
@@ -46,7 +51,7 @@ def load_frontmatter(filepath: str) -> tuple[dict | None, str, list[str]]:
     frontmatter_raw, body_raw = split_frontmatter(content)
     if frontmatter_raw is None:
         return None, content, []
-    if body_raw == "":
+    if body_raw is None:
         return (
             {"_parse_error": "No closing '---' delimiter in frontmatter"},
             frontmatter_raw,

--- a/skill-system-foundry/scripts/lib/frontmatter.py
+++ b/skill-system-foundry/scripts/lib/frontmatter.py
@@ -6,21 +6,28 @@ from .yaml_parser import parse_yaml_subset
 def split_frontmatter(content: str) -> tuple[str | None, str]:
     """Split *content* into ``(frontmatter_text, body_text)``.
 
-    Returns ``(None, content)`` when the text does not start with the
-    ``---`` open marker.  When the open marker is present but the
-    closing marker is missing, returns ``(content[3:], "")`` so the
-    caller can surface the malformed block as a structured finding.
+    Delimiter detection is line-based: the first line must be exactly
+    ``---`` and the closing delimiter must be a standalone ``---``
+    line.  This avoids matching a ``---`` substring inside the YAML
+    value space (for example, inside a block scalar).
+
+    Returns ``(None, content)`` when the first line is not the ``---``
+    open marker.  When the open marker is present but the closing
+    marker is missing, returns the text after the opening line with an
+    empty body so the caller can surface the malformed block as a
+    structured finding.
 
     This is the one true frontmatter splitter: ``load_frontmatter`` and
     the prose-YAML check both use it so delimiter rules cannot drift.
+    CRLF input is handled transparently via ``splitlines(keepends=True)``.
     """
-    if not content.startswith("---"):
+    lines = content.splitlines(keepends=True)
+    if not lines or lines[0].rstrip("\r\n") != "---":
         return None, content
-    try:
-        end = content.index("---", 3)
-    except ValueError:
-        return content[3:], ""
-    return content[3:end], content[end + 3:]
+    for index in range(1, len(lines)):
+        if lines[index].rstrip("\r\n") == "---":
+            return "".join(lines[1:index]), "".join(lines[index + 1:])
+    return "".join(lines[1:]), ""
 
 
 def load_frontmatter(filepath: str) -> tuple[dict | None, str, list[str]]:

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -22,6 +22,7 @@ from .constants import (
     LEVEL_FAIL, LEVEL_INFO, LEVEL_WARN,
     PROSE_YAML_IN_SCOPE_GLOBS, PROSE_YAML_OPT_OUT_MARKER,
 )
+from .frontmatter import split_frontmatter
 from .reporting import parse_finding_string, to_posix
 from .yaml_parser import parse_yaml_subset
 
@@ -34,21 +35,32 @@ def _strip_frontmatter(markdown_text: str) -> str:
 
     The prose-YAML check promises that frontmatter is not scanned —
     without this, a ``yaml`` fence embedded in a folded description
-    would be validated as if it were body content.  We only recognise
-    the canonical ``---``-on-its-own-line form that ``load_frontmatter``
-    already handles elsewhere.
+    would be validated as if it were body content.
+
+    Delegates to :func:`lib.frontmatter.split_frontmatter` so delimiter
+    rules stay in sync with ``load_frontmatter``.  To avoid misreading
+    a Markdown thematic break (``---`` at column 0) as frontmatter,
+    the candidate block is validated by ``parse_yaml_subset`` — only
+    content that parses as a YAML mapping is treated as frontmatter
+    and stripped.
     """
-    if not markdown_text.startswith("---"):
+    frontmatter_raw, body_raw = split_frontmatter(markdown_text)
+    if frontmatter_raw is None:
         return markdown_text
-    lines = markdown_text.split("\n")
-    if not lines or lines[0].strip() != "---":
+    if body_raw == "":
+        # No closing delimiter — leave the text untouched so existing
+        # error handling paths (unterminated fences, frontmatter
+        # _parse_error) still fire on the original content.
         return markdown_text
-    for idx in range(1, len(lines)):
-        if lines[idx].strip() == "---":
-            return "\n".join(lines[idx + 1:])
-    # No closing fence — be conservative and return the original text
-    # so existing error handling (unterminated fences) still fires.
-    return markdown_text
+    try:
+        parsed = parse_yaml_subset(frontmatter_raw.strip(), [])
+    except (ValueError, KeyError):
+        return markdown_text
+    if not isinstance(parsed, dict) or not parsed:
+        # A thematic break produces empty/non-mapping content between
+        # the two ``---`` lines; refuse to strip in that case.
+        return markdown_text
+    return body_raw
 
 
 def extract_yaml_fences(markdown_text: str) -> list[dict]:

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -98,21 +98,21 @@ def extract_yaml_fences(markdown_text: str) -> list[dict]:
                 }
             )
             return records
-        if opener == "wrong-case":
+        if is_ignored:
+            records.append(
+                {
+                    "ordinal": ordinal,
+                    "text": body_text,
+                    "state": "ignored",
+                }
+            )
+        elif opener == "wrong-case":
             records.append(
                 {
                     "ordinal": ordinal,
                     "text": body_text,
                     "state": "wrong-case",
                     "language": _open_language(line),
-                }
-            )
-        elif is_ignored:
-            records.append(
-                {
-                    "ordinal": ordinal,
-                    "text": body_text,
-                    "state": "ignored",
                 }
             )
         else:

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -187,8 +187,18 @@ def validate_prose_yaml(file_path: str, markdown_text: str) -> list[dict]:
     Frontmatter blocks are **not** scanned; this function only
     inspects fenced code in the body.
     """
+    return _validate_records(file_path, extract_yaml_fences(markdown_text))
+
+
+def _validate_records(file_path: str, records: list[dict]) -> list[dict]:
+    """Produce structured findings from already-extracted fence records.
+
+    Separated so ``collect_prose_findings`` can reuse the result of a
+    single ``extract_yaml_fences`` call instead of parsing each file
+    twice.
+    """
     findings: list[dict] = []
-    for record in extract_yaml_fences(markdown_text):
+    for record in records:
         ordinal = record["ordinal"]
         state = record["state"]
         if state == "ignored":
@@ -330,13 +340,26 @@ def collect_prose_findings(
         display_path = (
             f"{audit_prefix}/{relative}" if audit_prefix else relative
         )
-        with open(absolute, "r", encoding="utf-8") as fh:
-            text = fh.read()
+        try:
+            with open(absolute, "r", encoding="utf-8") as fh:
+                text = fh.read()
+        except (OSError, UnicodeDecodeError) as exc:
+            # An unreadable in-scope file must not crash the walk —
+            # surface it as a structured FAIL so the caller routes it
+            # through the existing finding stream.
+            findings.append(
+                _structured_finding(
+                    display_path, 0, "fail", "[spec]",
+                    f"could not read file for prose YAML check: {exc}",
+                )
+            )
+            per_file_counts.append((display_path, 0))
+            continue
         records = extract_yaml_fences(text)
         parsed_count = sum(1 for r in records if r["state"] == "parsed")
         checked += parsed_count
         per_file_counts.append((display_path, len(records)))
-        findings.extend(validate_prose_yaml(display_path, text))
+        findings.extend(_validate_records(display_path, records))
     return findings, checked, per_file_counts
 
 

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -178,8 +178,10 @@ def _classify_open_line(line: str) -> str | None:
 
     ``"parsed"`` — column-0 ``` ```yaml ``` open with the literal
     lowercase token.  ``"wrong-case"`` — column-0 backtick fence open
-    with a known YAML-spelled token (``yml`` / ``YAML`` / ``Yaml``).
-    ``None`` — not an opener this extractor recognises.
+    with any case variant of ``yaml`` or ``yml`` that is not the
+    canonical lowercase ``yaml`` (e.g. ``YAML``, ``Yaml``, ``yAmL``,
+    ``YML``, ``Yml``).  ``None`` — not an opener this extractor
+    recognises.
     """
     if not line.startswith("```"):
         return None
@@ -194,7 +196,7 @@ def _classify_open_line(line: str) -> str | None:
     token = rest.split(" ", 1)[0].split("\t", 1)[0]
     if token == "yaml":
         return "parsed"
-    if token in ("yml", "YAML", "Yaml"):
+    if token.lower() in ("yaml", "yml"):
         return "wrong-case"
     return None
 

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -48,10 +48,11 @@ def _strip_frontmatter(markdown_text: str) -> str:
     if frontmatter_raw is None:
         return markdown_text
     if body_raw == "":
-        # No closing delimiter — leave the text untouched so existing
-        # error handling paths (unterminated fences, frontmatter
-        # _parse_error) still fire on the original content.
-        return markdown_text
+        # No closing delimiter — the frontmatter block is malformed.
+        # Skip prose scanning entirely rather than letting fences
+        # inside that block leak into body validation.  The frontmatter
+        # parse error is surfaced separately by ``load_frontmatter``.
+        return ""
     try:
         parsed = parse_yaml_subset(frontmatter_raw.strip(), [])
     except (ValueError, KeyError):
@@ -73,9 +74,12 @@ def extract_yaml_fences(markdown_text: str) -> list[dict]:
     Each record dict::
 
         {
-            "ordinal": int,   # 1-based across all matched fences
-            "text":   str,    # fence body, LF-only
-            "state":  "parsed" | "ignored" | "unterminated" | "wrong-case"
+            "ordinal":  int,   # 1-based across all matched fences
+            "text":     str,   # fence body, LF-only
+            "state":    "parsed" | "ignored" | "unterminated" | "wrong-case",
+            "language": str,   # only present when state=="wrong-case";
+                               # the literal language token the author
+                               # wrote (e.g. "YAML", "yml")
         }
 
     Fence shape rules:

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -29,6 +29,28 @@ from .yaml_parser import parse_yaml_subset
 _FENCE_CLOSE_LITERAL = "```"
 
 
+def _strip_frontmatter(markdown_text: str) -> str:
+    """Drop a leading ``---``-delimited frontmatter block if present.
+
+    The prose-YAML check promises that frontmatter is not scanned —
+    without this, a ``yaml`` fence embedded in a folded description
+    would be validated as if it were body content.  We only recognise
+    the canonical ``---``-on-its-own-line form that ``load_frontmatter``
+    already handles elsewhere.
+    """
+    if not markdown_text.startswith("---"):
+        return markdown_text
+    lines = markdown_text.split("\n")
+    if not lines or lines[0].strip() != "---":
+        return markdown_text
+    for idx in range(1, len(lines)):
+        if lines[idx].strip() == "---":
+            return "\n".join(lines[idx + 1:])
+    # No closing fence — be conservative and return the original text
+    # so existing error handling (unterminated fences) still fires.
+    return markdown_text
+
+
 def extract_yaml_fences(markdown_text: str) -> list[dict]:
     """Return one record per ```yaml fence found in *markdown_text*.
 
@@ -173,10 +195,13 @@ def validate_prose_yaml(file_path: str, markdown_text: str) -> list[dict]:
     Returns a list of structured finding dicts::
 
         {
-            "file":          str,    # echoed verbatim from *file_path*
-            "block_ordinal": int,    # 1-based, stable across all fences
+            "file":          str,          # echoed from *file_path*
+            "block_ordinal": int | None,    # 1-based when a fence is
+                                            # implicated; ``None`` for
+                                            # file-level findings
+                                            # (e.g. unreadable source)
             "severity":      "fail" | "warn" | "info",
-            "tag":           str,    # bracketed token, may be empty
+            "tag":           str,           # bracketed token, may be empty
             "message":       str,
         }
 
@@ -187,7 +212,8 @@ def validate_prose_yaml(file_path: str, markdown_text: str) -> list[dict]:
     Frontmatter blocks are **not** scanned; this function only
     inspects fenced code in the body.
     """
-    return _validate_records(file_path, extract_yaml_fences(markdown_text))
+    body = _strip_frontmatter(markdown_text)
+    return _validate_records(file_path, extract_yaml_fences(body))
 
 
 def _validate_records(file_path: str, records: list[dict]) -> list[dict]:
@@ -258,7 +284,7 @@ def _validate_records(file_path: str, records: list[dict]) -> list[dict]:
 
 def _structured_finding(
     file_path: str,
-    ordinal: int,
+    ordinal: int | None,
     severity: str,
     tag: str,
     message: str,
@@ -349,13 +375,13 @@ def collect_prose_findings(
             # through the existing finding stream.
             findings.append(
                 _structured_finding(
-                    display_path, 0, "fail", "[spec]",
+                    display_path, None, "fail", "[spec]",
                     f"could not read file for prose YAML check: {exc}",
                 )
             )
             per_file_counts.append((display_path, 0))
             continue
-        records = extract_yaml_fences(text)
+        records = extract_yaml_fences(_strip_frontmatter(text))
         parsed_count = sum(1 for r in records if r["state"] == "parsed")
         checked += parsed_count
         per_file_counts.append((display_path, len(records)))
@@ -378,9 +404,13 @@ def format_finding_as_string(finding: dict) -> str:
     }[finding["severity"]]
     tag = finding["tag"] or "[spec]"
     file_part = finding["file"]
-    block_part = f"block {finding['block_ordinal']}"
+    ordinal = finding["block_ordinal"]
+    # File-level findings (no implicated fence) omit the ``block N``
+    # segment — ``block 0`` / ``block None`` would be nonsensical.
+    if ordinal is None:
+        return f"{severity_token}: {tag} {file_part}: {finding['message']}"
     return (
-        f"{severity_token}: {tag} {file_part} {block_part}: "
+        f"{severity_token}: {tag} {file_part} block {ordinal}: "
         f"{finding['message']}"
     )
 

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -26,7 +26,6 @@ from .reporting import parse_finding_string, to_posix
 from .yaml_parser import parse_yaml_subset
 
 
-_FENCE_OPEN_LITERAL = "```yaml"
 _FENCE_CLOSE_LITERAL = "```"
 
 
@@ -201,7 +200,7 @@ def validate_prose_yaml(file_path: str, markdown_text: str) -> list[dict]:
                     ordinal,
                     "fail",
                     "[spec]",
-                    f"unterminated yaml fence (block ordinal {ordinal})",
+                    "unterminated yaml fence",
                 )
             )
             continue
@@ -284,9 +283,9 @@ def find_in_scope_files(skill_root: str) -> list[str]:
 
     Scope is the three globs from ``PROSE_YAML_IN_SCOPE_GLOBS``
     (``SKILL.md``, ``capabilities/**/*.md``, ``references/**/*.md``).
-    Returns a sorted, de-duplicated list with POSIX separators
-    preserved as on-disk; callers normalise via ``to_posix`` when
-    constructing finding paths.
+    Returns a sorted, de-duplicated list using the native path
+    separators produced on the current platform; callers normalise via
+    ``to_posix`` when constructing finding paths.
     """
     seen: set[str] = set()
     matches: list[str] = []

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -1,0 +1,285 @@
+"""Doc-snippet validation for ```yaml fences in skill prose.
+
+Scope (§4.1 of the design plan):
+- Extract fenced ```yaml blocks from markdown text per the strict
+  fence rules in §4.2.
+- Parse each block with ``parse_yaml_subset`` and convert findings to
+  structured dicts via ``parse_finding_string``.
+- Frontmatter is **not** scanned (G26).  ``load_frontmatter`` already
+  handles the ``---``-delimited block; this module only sees fenced
+  code in the body.
+
+Import discipline (G112): this module imports ``parse_yaml_subset``
+from ``lib.yaml_parser`` and ``parse_finding_string`` / ``to_posix``
+from ``lib.reporting``.  ``reporting`` is a pure string helper and
+does not import this module — no cycle.
+"""
+
+import os
+
+from .constants import LEVEL_FAIL, PROSE_YAML_OPT_OUT_MARKER
+from .reporting import parse_finding_string, to_posix
+from .yaml_parser import parse_yaml_subset
+
+
+_FENCE_OPEN_LITERAL = "```yaml"
+_FENCE_CLOSE_LITERAL = "```"
+
+
+def extract_yaml_fences(markdown_text: str) -> list[dict]:
+    """Return one record per ```yaml fence found in *markdown_text*.
+
+    Each record dict::
+
+        {
+            "ordinal": int,   # 1-based across all matched fences
+            "text":   str,    # fence body, LF-only
+            "state":  "parsed" | "ignored" | "unterminated" | "wrong-case"
+        }
+
+    Fence shape rules (§4.2 / G69 / G70):
+
+    - Backtick fences only.  Tilde fences are invisible.
+    - Exactly three opening backticks at byte offset 0.
+    - Case-sensitive literal ``yaml`` immediately after the backticks
+      (no whitespace between).  ``yml`` / ``YAML`` / ``Yaml`` open
+      lines surface as ``state="wrong-case"`` records.
+    - Anything after ``yaml`` on the open line (an info-string suffix)
+      is discarded.
+    - The block closes on the next line that is exactly ``` `` ` ``` ``
+      at byte offset 0; if no close marker is found before EOF the
+      fence is reported as ``state="unterminated"``.
+
+    Opt-out (§4.3, G42): if the line immediately above the fence-open
+    line — with no blank line between — exactly matches the configured
+    opt-out marker (whitespace around it allowed), the record's
+    ``state`` is ``"ignored"``.
+
+    Empty markdown input is a valid no-op — returns ``[]`` (G136).
+    """
+    if not markdown_text:
+        return []
+    text = markdown_text.replace("\r\n", "\n").replace("\r", "\n")
+    lines = text.split("\n")
+
+    records: list[dict] = []
+    i = 0
+    ordinal = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        opener = _classify_open_line(line)
+        if opener is None:
+            i += 1
+            continue
+        ordinal += 1
+        is_ignored = _has_opt_out_marker(lines, i)
+        # Collect body lines until a column-0 closing fence or EOF.
+        body: list[str] = []
+        j = i + 1
+        terminated = False
+        while j < n:
+            if lines[j] == _FENCE_CLOSE_LITERAL:
+                terminated = True
+                break
+            body.append(lines[j])
+            j += 1
+        body_text = "\n".join(body)
+        if not terminated:
+            records.append(
+                {
+                    "ordinal": ordinal,
+                    "text": body_text,
+                    "state": "unterminated",
+                }
+            )
+            return records
+        if opener == "wrong-case":
+            records.append(
+                {
+                    "ordinal": ordinal,
+                    "text": body_text,
+                    "state": "wrong-case",
+                    "language": _open_language(line),
+                }
+            )
+        elif is_ignored:
+            records.append(
+                {
+                    "ordinal": ordinal,
+                    "text": body_text,
+                    "state": "ignored",
+                }
+            )
+        else:
+            records.append(
+                {
+                    "ordinal": ordinal,
+                    "text": body_text,
+                    "state": "parsed",
+                }
+            )
+        i = j + 1
+    return records
+
+
+def _classify_open_line(line: str) -> str | None:
+    """Return ``"parsed"`` / ``"wrong-case"`` / ``None`` for *line*.
+
+    ``"parsed"`` — column-0 ``` ```yaml ``` open with the literal
+    lowercase token.  ``"wrong-case"`` — column-0 backtick fence open
+    with a known YAML-spelled token (``yml`` / ``YAML`` / ``Yaml``).
+    ``None`` — not an opener this extractor recognises.
+    """
+    if not line.startswith("```"):
+        return None
+    # Must be exactly three backticks (G69 — exclude ``` ```` ``` etc.).
+    if line.startswith("````"):
+        return None
+    rest = line[3:]
+    # No leading whitespace before the language token (G69).
+    if not rest:
+        return None
+    # Strip info-string suffix at the first whitespace.
+    token = rest.split(" ", 1)[0].split("\t", 1)[0]
+    if token == "yaml":
+        return "parsed"
+    if token in ("yml", "YAML", "Yaml"):
+        return "wrong-case"
+    return None
+
+
+def _open_language(line: str) -> str:
+    """Return the language token of a column-0 backtick fence opener."""
+    rest = line[3:]
+    return rest.split(" ", 1)[0].split("\t", 1)[0]
+
+
+def _has_opt_out_marker(lines: list[str], fence_index: int) -> bool:
+    """Return ``True`` when the line immediately above *fence_index*
+    matches the opt-out marker exactly (G42)."""
+    if fence_index == 0:
+        return False
+    above = lines[fence_index - 1].strip()
+    return above == PROSE_YAML_OPT_OUT_MARKER
+
+
+def validate_prose_yaml(file_path: str, markdown_text: str) -> list[dict]:
+    """Validate every ```yaml fence in *markdown_text*.
+
+    Returns a list of structured finding dicts::
+
+        {
+            "file":          str,    # echoed verbatim from *file_path*
+            "block_ordinal": int,    # 1-based, stable across all fences
+            "severity":      "fail" | "warn" | "info",
+            "tag":           str,    # bracketed token, may be empty
+            "message":       str,
+        }
+
+    *file_path* is echoed into each finding's ``file`` field verbatim
+    (G120) — callers pre-normalise to skill-root-relative POSIX form
+    (use :func:`lib.reporting.to_posix` if needed).
+
+    Frontmatter blocks are **not** scanned (G26); this function only
+    inspects fenced code in the body.
+    """
+    findings: list[dict] = []
+    for record in extract_yaml_fences(markdown_text):
+        ordinal = record["ordinal"]
+        state = record["state"]
+        if state == "ignored":
+            continue
+        if state == "unterminated":
+            findings.append(
+                _structured_finding(
+                    file_path,
+                    ordinal,
+                    "fail",
+                    "[spec]",
+                    f"unterminated yaml fence (block ordinal {ordinal})",
+                )
+            )
+            continue
+        if state == "wrong-case":
+            actual = record.get("language", "")
+            findings.append(
+                _structured_finding(
+                    file_path,
+                    ordinal,
+                    "info",
+                    "[spec]",
+                    f"fence language identifier {actual!r} is not "
+                    "recognized — did you mean 'yaml'?",
+                )
+            )
+            continue
+        # state == "parsed"
+        try:
+            parser_findings: list[str] = []
+            parse_yaml_subset(record["text"], parser_findings)
+        except ValueError as exc:
+            findings.append(
+                _structured_finding(
+                    file_path,
+                    ordinal,
+                    "fail",
+                    "[spec]",
+                    f"structural parse error: {exc}",
+                )
+            )
+            continue
+        for raw in parser_findings:
+            parsed = parse_finding_string(raw)
+            findings.append(
+                {
+                    "file": file_path,
+                    "block_ordinal": ordinal,
+                    "severity": parsed["severity"],
+                    "tag": parsed["tag"],
+                    "message": parsed["message"],
+                }
+            )
+    return findings
+
+
+def _structured_finding(
+    file_path: str,
+    ordinal: int,
+    severity: str,
+    tag: str,
+    message: str,
+) -> dict:
+    return {
+        "file": file_path,
+        "block_ordinal": ordinal,
+        "severity": severity,
+        "tag": tag,
+        "message": message,
+    }
+
+
+def read_and_validate(path: str) -> list[dict]:
+    """Convenience wrapper: read *path* (UTF-8) and validate its fences.
+
+    OS errors (``FileNotFoundError``, ``PermissionError``) and decode
+    errors (``UnicodeDecodeError``) propagate unchanged (G61).  Callers
+    that want structured handling should use :func:`validate_prose_yaml`
+    directly with their own I/O.
+
+    The file path is normalised to POSIX separators so finding ``file``
+    fields are platform-independent (G68).
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        text = fh.read()
+    return validate_prose_yaml(to_posix(path), text)
+
+
+# Re-export ``LEVEL_FAIL`` so callers building human output don't need
+# to import constants separately.
+__all__ = (
+    "LEVEL_FAIL",
+    "extract_yaml_fences",
+    "validate_prose_yaml",
+    "read_and_validate",
+)

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -55,11 +55,15 @@ def _strip_frontmatter(markdown_text: str) -> str:
     try:
         parsed = parse_yaml_subset(frontmatter_raw.strip(), [])
     except (ValueError, KeyError):
+        # Content between the two ``---`` lines is not valid YAML —
+        # most likely a thematic break with prose in between rather
+        # than real frontmatter.  Leave the source untouched.
         return markdown_text
-    if not isinstance(parsed, dict) or not parsed:
-        # A thematic break produces empty/non-mapping content between
-        # the two ``---`` lines; refuse to strip in that case.
+    if not isinstance(parsed, dict):
         return markdown_text
+    # Empty frontmatter (``---\\n---\\n``) parses to ``{}`` and is
+    # still a frontmatter block for scope purposes — strip it so its
+    # absence / presence does not change prose-scan results.
     return body_raw
 
 

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -15,9 +15,13 @@ from ``lib.reporting``.  ``reporting`` is a pure string helper and
 does not import this module — no cycle.
 """
 
+import glob
 import os
 
-from .constants import LEVEL_FAIL, PROSE_YAML_OPT_OUT_MARKER
+from .constants import (
+    LEVEL_FAIL, LEVEL_INFO, LEVEL_WARN,
+    PROSE_YAML_IN_SCOPE_GLOBS, PROSE_YAML_OPT_OUT_MARKER,
+)
 from .reporting import parse_finding_string, to_posix
 from .yaml_parser import parse_yaml_subset
 
@@ -275,6 +279,91 @@ def read_and_validate(path: str) -> list[dict]:
     return validate_prose_yaml(to_posix(path), text)
 
 
+def find_in_scope_files(skill_root: str) -> list[str]:
+    """Return absolute paths of in-scope Markdown files under *skill_root*.
+
+    Scope is the three globs from ``PROSE_YAML_IN_SCOPE_GLOBS``
+    (``SKILL.md``, ``capabilities/**/*.md``, ``references/**/*.md``).
+    Returns a sorted, de-duplicated list with POSIX separators
+    preserved as on-disk; callers normalise via ``to_posix`` when
+    constructing finding paths (G68 / G116).
+    """
+    seen: set[str] = set()
+    matches: list[str] = []
+    for pattern in PROSE_YAML_IN_SCOPE_GLOBS:
+        for absolute in glob.glob(
+            os.path.join(skill_root, pattern), recursive=True
+        ):
+            if not os.path.isfile(absolute):
+                continue
+            if absolute in seen:
+                continue
+            seen.add(absolute)
+            matches.append(absolute)
+    matches.sort()
+    return matches
+
+
+def collect_prose_findings(
+    skill_root: str, *, audit_prefix: str = ""
+) -> tuple[list[dict], int, list[tuple[str, int]]]:
+    """Walk *skill_root* and validate every in-scope Markdown file.
+
+    Returns ``(findings, checked, per_file_counts)``:
+
+    - ``findings`` — flat list of structured finding dicts (file paths
+      already prefixed when *audit_prefix* is non-empty).
+    - ``checked`` — count of fences in state ``"parsed"`` summed across
+      every in-scope file (G43).
+    - ``per_file_counts`` — list of ``(relative_path, fence_count)``
+      pairs in iteration order; verbose callers print one line per
+      entry.
+
+    *audit_prefix* — when set, every finding's ``file`` field becomes
+    ``<audit_prefix>/<relative-path>`` so multi-skill aggregation in
+    ``audit_skill_system`` is unambiguous (G23).
+    """
+    findings: list[dict] = []
+    checked = 0
+    per_file_counts: list[tuple[str, int]] = []
+    for absolute in find_in_scope_files(skill_root):
+        relative = to_posix(os.path.relpath(absolute, skill_root))
+        display_path = (
+            f"{audit_prefix}/{relative}" if audit_prefix else relative
+        )
+        with open(absolute, "r", encoding="utf-8") as fh:
+            text = fh.read()
+        records = extract_yaml_fences(text)
+        parsed_count = sum(1 for r in records if r["state"] == "parsed")
+        checked += parsed_count
+        per_file_counts.append((display_path, len(records)))
+        findings.extend(validate_prose_yaml(display_path, text))
+    return findings, checked, per_file_counts
+
+
+def format_finding_as_string(finding: dict) -> str:
+    """Format a structured finding dict as a parser-style finding string.
+
+    Reuses the existing ``SEVERITY: [tag] body`` shape so consumers that
+    already iterate ``errors[]`` and call ``categorize_errors`` /
+    ``print_error_line`` work without modification.  G45 — selects
+    key-scoped vs. non-key-scoped form by looking at the message body.
+    """
+    severity_token = {
+        "fail": LEVEL_FAIL, "warn": LEVEL_WARN, "info": LEVEL_INFO,
+    }[finding["severity"]]
+    tag = finding["tag"] or "[spec]"
+    file_part = finding["file"]
+    block_part = f"block {finding['block_ordinal']}"
+    msg = finding["message"]
+    if msg.startswith("'") and "':" in msg:
+        # Key-scoped — keep the original "'key': body; advice" shape.
+        body = f"{file_part} {block_part}: {msg}"
+    else:
+        body = f"{file_part} {block_part}: {msg}"
+    return f"{severity_token}: {tag} {body}"
+
+
 # Re-export ``LEVEL_FAIL`` so callers building human output don't need
 # to import constants separately.
 __all__ = (
@@ -282,4 +371,7 @@ __all__ = (
     "extract_yaml_fences",
     "validate_prose_yaml",
     "read_and_validate",
+    "find_in_scope_files",
+    "collect_prose_findings",
+    "format_finding_as_string",
 )

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -47,11 +47,12 @@ def _strip_frontmatter(markdown_text: str) -> str:
     frontmatter_raw, body_raw = split_frontmatter(markdown_text)
     if frontmatter_raw is None:
         return markdown_text
-    if body_raw == "":
-        # No closing delimiter — the frontmatter block is malformed.
-        # Skip prose scanning entirely rather than letting fences
-        # inside that block leak into body validation.  The frontmatter
-        # parse error is surfaced separately by ``load_frontmatter``.
+    if body_raw is None:
+        # Opener present but no closing delimiter — the frontmatter
+        # block is malformed.  Skip prose scanning entirely rather
+        # than letting fences inside that block leak into body
+        # validation.  The frontmatter parse error is surfaced
+        # separately by ``load_frontmatter``.
         return ""
     try:
         parsed = parse_yaml_subset(frontmatter_raw.strip(), [])

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -1,18 +1,18 @@
 """Doc-snippet validation for ```yaml fences in skill prose.
 
-Scope (§4.1 of the design plan):
+Scope:
 - Extract fenced ```yaml blocks from markdown text per the strict
-  fence rules in §4.2.
+  fence rules described under ``extract_yaml_fences``.
 - Parse each block with ``parse_yaml_subset`` and convert findings to
   structured dicts via ``parse_finding_string``.
-- Frontmatter is **not** scanned (G26).  ``load_frontmatter`` already
+- Frontmatter is **not** scanned.  ``load_frontmatter`` already
   handles the ``---``-delimited block; this module only sees fenced
   code in the body.
 
-Import discipline (G112): this module imports ``parse_yaml_subset``
-from ``lib.yaml_parser`` and ``parse_finding_string`` / ``to_posix``
-from ``lib.reporting``.  ``reporting`` is a pure string helper and
-does not import this module — no cycle.
+Import discipline: this module imports ``parse_yaml_subset`` from
+``lib.yaml_parser`` and ``parse_finding_string`` / ``to_posix`` from
+``lib.reporting``.  ``reporting`` is a pure string helper and does not
+import this module — no cycle.
 """
 
 import glob
@@ -41,7 +41,7 @@ def extract_yaml_fences(markdown_text: str) -> list[dict]:
             "state":  "parsed" | "ignored" | "unterminated" | "wrong-case"
         }
 
-    Fence shape rules (§4.2 / G69 / G70):
+    Fence shape rules:
 
     - Backtick fences only.  Tilde fences are invisible.
     - Exactly three opening backticks at byte offset 0.
@@ -54,12 +54,12 @@ def extract_yaml_fences(markdown_text: str) -> list[dict]:
       at byte offset 0; if no close marker is found before EOF the
       fence is reported as ``state="unterminated"``.
 
-    Opt-out (§4.3, G42): if the line immediately above the fence-open
-    line — with no blank line between — exactly matches the configured
-    opt-out marker (whitespace around it allowed), the record's
-    ``state`` is ``"ignored"``.
+    Opt-out: if the line immediately above the fence-open line — with
+    no blank line between — exactly matches the configured opt-out
+    marker (whitespace around it allowed), the record's ``state`` is
+    ``"ignored"``.
 
-    Empty markdown input is a valid no-op — returns ``[]`` (G136).
+    Empty markdown input is a valid no-op — returns ``[]``.
     """
     if not markdown_text:
         return []
@@ -137,11 +137,11 @@ def _classify_open_line(line: str) -> str | None:
     """
     if not line.startswith("```"):
         return None
-    # Must be exactly three backticks (G69 — exclude ``` ```` ``` etc.).
+    # Must be exactly three backticks (exclude ``` ```` ``` etc.).
     if line.startswith("````"):
         return None
     rest = line[3:]
-    # No leading whitespace before the language token (G69).
+    # No leading whitespace before the language token.
     if not rest:
         return None
     # Strip info-string suffix at the first whitespace.
@@ -161,7 +161,7 @@ def _open_language(line: str) -> str:
 
 def _has_opt_out_marker(lines: list[str], fence_index: int) -> bool:
     """Return ``True`` when the line immediately above *fence_index*
-    matches the opt-out marker exactly (G42)."""
+    matches the opt-out marker exactly."""
     if fence_index == 0:
         return False
     above = lines[fence_index - 1].strip()
@@ -182,10 +182,10 @@ def validate_prose_yaml(file_path: str, markdown_text: str) -> list[dict]:
         }
 
     *file_path* is echoed into each finding's ``file`` field verbatim
-    (G120) — callers pre-normalise to skill-root-relative POSIX form
-    (use :func:`lib.reporting.to_posix` if needed).
+    — callers pre-normalise to skill-root-relative POSIX form (use
+    :func:`lib.reporting.to_posix` if needed).
 
-    Frontmatter blocks are **not** scanned (G26); this function only
+    Frontmatter blocks are **not** scanned; this function only
     inspects fenced code in the body.
     """
     findings: list[dict] = []
@@ -267,12 +267,12 @@ def read_and_validate(path: str) -> list[dict]:
     """Convenience wrapper: read *path* (UTF-8) and validate its fences.
 
     OS errors (``FileNotFoundError``, ``PermissionError``) and decode
-    errors (``UnicodeDecodeError``) propagate unchanged (G61).  Callers
-    that want structured handling should use :func:`validate_prose_yaml`
+    errors (``UnicodeDecodeError``) propagate unchanged.  Callers that
+    want structured handling should use :func:`validate_prose_yaml`
     directly with their own I/O.
 
     The file path is normalised to POSIX separators so finding ``file``
-    fields are platform-independent (G68).
+    fields are platform-independent.
     """
     with open(path, "r", encoding="utf-8") as fh:
         text = fh.read()
@@ -286,7 +286,7 @@ def find_in_scope_files(skill_root: str) -> list[str]:
     (``SKILL.md``, ``capabilities/**/*.md``, ``references/**/*.md``).
     Returns a sorted, de-duplicated list with POSIX separators
     preserved as on-disk; callers normalise via ``to_posix`` when
-    constructing finding paths (G68 / G116).
+    constructing finding paths.
     """
     seen: set[str] = set()
     matches: list[str] = []
@@ -314,14 +314,14 @@ def collect_prose_findings(
     - ``findings`` — flat list of structured finding dicts (file paths
       already prefixed when *audit_prefix* is non-empty).
     - ``checked`` — count of fences in state ``"parsed"`` summed across
-      every in-scope file (G43).
+      every in-scope file.
     - ``per_file_counts`` — list of ``(relative_path, fence_count)``
       pairs in iteration order; verbose callers print one line per
       entry.
 
     *audit_prefix* — when set, every finding's ``file`` field becomes
     ``<audit_prefix>/<relative-path>`` so multi-skill aggregation in
-    ``audit_skill_system`` is unambiguous (G23).
+    ``audit_skill_system`` is unambiguous.
     """
     findings: list[dict] = []
     checked = 0
@@ -346,10 +346,10 @@ def format_finding_as_string(finding: dict) -> str:
 
     Reuses the existing ``SEVERITY: [tag] body`` shape so consumers
     that already iterate ``errors[]`` and call ``categorize_errors`` /
-    ``print_error_line`` work without modification.  Per G45 the body
-    is the same regardless of whether the message is key-scoped — the
-    parser's ``'key': body; advice`` chunk already begins with ``'key':``
-    when applicable, so no caller-side branching is needed.
+    ``print_error_line`` work without modification.  The body is the
+    same regardless of whether the message is key-scoped — the
+    parser's ``'key': body; advice`` chunk already begins with
+    ``'key':`` when applicable, so no caller-side branching is needed.
     """
     severity_token = {
         "fail": LEVEL_FAIL, "warn": LEVEL_WARN, "info": LEVEL_INFO,

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -344,10 +344,12 @@ def collect_prose_findings(
 def format_finding_as_string(finding: dict) -> str:
     """Format a structured finding dict as a parser-style finding string.
 
-    Reuses the existing ``SEVERITY: [tag] body`` shape so consumers that
-    already iterate ``errors[]`` and call ``categorize_errors`` /
-    ``print_error_line`` work without modification.  G45 — selects
-    key-scoped vs. non-key-scoped form by looking at the message body.
+    Reuses the existing ``SEVERITY: [tag] body`` shape so consumers
+    that already iterate ``errors[]`` and call ``categorize_errors`` /
+    ``print_error_line`` work without modification.  Per G45 the body
+    is the same regardless of whether the message is key-scoped — the
+    parser's ``'key': body; advice`` chunk already begins with ``'key':``
+    when applicable, so no caller-side branching is needed.
     """
     severity_token = {
         "fail": LEVEL_FAIL, "warn": LEVEL_WARN, "info": LEVEL_INFO,
@@ -355,13 +357,10 @@ def format_finding_as_string(finding: dict) -> str:
     tag = finding["tag"] or "[spec]"
     file_part = finding["file"]
     block_part = f"block {finding['block_ordinal']}"
-    msg = finding["message"]
-    if msg.startswith("'") and "':" in msg:
-        # Key-scoped — keep the original "'key': body; advice" shape.
-        body = f"{file_part} {block_part}: {msg}"
-    else:
-        body = f"{file_part} {block_part}: {msg}"
-    return f"{severity_token}: {tag} {body}"
+    return (
+        f"{severity_token}: {tag} {file_part} {block_part}: "
+        f"{finding['message']}"
+    )
 
 
 # Re-export ``LEVEL_FAIL`` so callers building human output don't need

--- a/skill-system-foundry/scripts/lib/prose_yaml.py
+++ b/skill-system-foundry/scripts/lib/prose_yaml.py
@@ -48,24 +48,28 @@ def _strip_frontmatter(markdown_text: str) -> str:
     if frontmatter_raw is None:
         return markdown_text
     if body_raw is None:
-        # Opener present but no closing delimiter — the frontmatter
-        # block is malformed.  Skip prose scanning entirely rather
-        # than letting fences inside that block leak into body
-        # validation.  The frontmatter parse error is surfaced
-        # separately by ``load_frontmatter``.
-        return ""
+        # Opener present but no closing delimiter.  The block is
+        # ambiguous — malformed frontmatter vs a thematic break at
+        # line 1 of a file that happens not to have another ``---``.
+        # Stay conservative and scan the original text so body fences
+        # still reach the validator; ``load_frontmatter`` surfaces the
+        # parse error separately when frontmatter was in fact intended.
+        return markdown_text
+    frontmatter_str = frontmatter_raw.strip()
+    if frontmatter_str == "":
+        # Explicitly-empty frontmatter (``---\\n---\\n``) is still
+        # frontmatter for scope purposes — strip it.
+        return body_raw
     try:
-        parsed = parse_yaml_subset(frontmatter_raw.strip(), [])
+        parsed = parse_yaml_subset(frontmatter_str, [])
     except (ValueError, KeyError):
-        # Content between the two ``---`` lines is not valid YAML —
-        # most likely a thematic break with prose in between rather
-        # than real frontmatter.  Leave the source untouched.
         return markdown_text
-    if not isinstance(parsed, dict):
+    # ``parse_yaml_subset`` returns ``{}`` for prose-like content too
+    # (lines with no ``key:`` pairs), so an empty dict is not enough
+    # evidence that the block is frontmatter.  Require at least one
+    # parsed key before stripping.
+    if not isinstance(parsed, dict) or not parsed:
         return markdown_text
-    # Empty frontmatter (``---\\n---\\n``) parses to ``{}`` and is
-    # still a frontmatter block for scope purposes — strip it so its
-    # absence / presence does not change prose-scan results.
     return body_raw
 
 

--- a/skill-system-foundry/scripts/lib/reporting.py
+++ b/skill-system-foundry/scripts/lib/reporting.py
@@ -20,11 +20,80 @@ back to ``"errors"`` for full validation results.
 Every tool result dict includes a ``"version"`` key (injected
 automatically by ``to_json_output``) for forward-compatible schema
 evolution.
+
+Finding-string contract
+-----------------------
+Parser modules emit findings as strings shaped ``"SEVERITY: [tag] body"``
+where ``SEVERITY`` is one of ``FAIL`` / ``WARN`` / ``INFO``, ``[tag]`` is
+an optional bracketed token (e.g. ``[spec]``), and ``body`` is the
+human-readable message.  ``parse_finding_string`` consumes this shape
+without importing the producer module — it operates on the documented
+string contract only.  Any producer adding a new tag must keep the
+``"SEVERITY: [tag] body"`` shape; consumers that care about specific
+tags filter them downstream.
 """
 
 import json
+import os
 
 from .constants import ERROR_SYMBOLS, LEVEL_FAIL, LEVEL_WARN, LEVEL_INFO, JSON_SCHEMA_VERSION
+
+
+_SEVERITY_TO_LOWER = {
+    LEVEL_FAIL: "fail",
+    LEVEL_WARN: "warn",
+    LEVEL_INFO: "info",
+}
+
+
+def to_posix(path: str) -> str:
+    """Return *path* with the platform separator replaced by ``/``.
+
+    Used to keep the ``file`` field of structured findings consistent
+    across Linux, macOS, and Windows runners.  No path normalization or
+    canonicalization is performed — only the separator is rewritten.
+    """
+    return path.replace(os.sep, "/")
+
+
+def parse_finding_string(raw: str) -> dict:
+    """Parse a parser finding string into a structured dict.
+
+    Input contract: ``"SEVERITY: [tag] body"`` where ``SEVERITY`` is one
+    of ``FAIL`` / ``WARN`` / ``INFO``.  The bracketed ``[tag]`` is
+    optional; any bracketed token is accepted verbatim (the helper is
+    tag-agnostic — see module docstring).
+
+    Returns ``{"severity": str, "tag": str, "message": str}`` where
+    ``severity`` is the lowercase form (``"fail"`` / ``"warn"`` /
+    ``"info"``) and ``tag`` includes the surrounding brackets (empty
+    string when no tag is present).  The advice tail (after ``;``) is
+    preserved verbatim in ``message``.
+
+    Raises ``ValueError`` on malformed input — missing ``": "``
+    separator or unrecognized severity token.
+    """
+    sep = ": "
+    sep_index = raw.find(sep)
+    if sep_index < 0:
+        raise ValueError(
+            f"malformed finding string (missing '{sep}' separator): {raw!r}"
+        )
+    severity_token = raw[:sep_index]
+    body = raw[sep_index + len(sep):]
+    if severity_token not in _SEVERITY_TO_LOWER:
+        raise ValueError(
+            f"unrecognized severity {severity_token!r} in finding: {raw!r}"
+        )
+    severity = _SEVERITY_TO_LOWER[severity_token]
+    tag = ""
+    message = body
+    if body.startswith("["):
+        end = body.find("]")
+        if end > 0:
+            tag = body[: end + 1]
+            message = body[end + 1:].lstrip()
+    return {"severity": severity, "tag": tag, "message": message}
 
 
 def categorize_errors(errors: list[str]) -> tuple[list[str], list[str], list[str]]:

--- a/skill-system-foundry/scripts/lib/reporting.py
+++ b/skill-system-foundry/scripts/lib/reporting.py
@@ -47,13 +47,19 @@ _SEVERITY_TO_LOWER = {
 
 
 def to_posix(path: str) -> str:
-    """Return *path* with the platform separator replaced by ``/``.
+    """Return *path* with path separators rewritten as ``/``.
 
     Used to keep the ``file`` field of structured findings consistent
-    across Linux, macOS, and Windows runners.  No path normalization or
-    canonicalization is performed — only the separator is rewritten.
+    across Linux, macOS, and Windows runners.  Both Windows-style
+    backslashes and the native ``os.sep`` are normalised so callers get
+    POSIX output regardless of which platform produced the input.  No
+    path normalization or canonicalization is performed — only
+    separator characters are rewritten.
     """
-    return path.replace(os.sep, "/")
+    path = path.replace("\\", "/")
+    if os.sep != "/":
+        path = path.replace(os.sep, "/")
+    return path
 
 
 def parse_finding_string(raw: str) -> dict:

--- a/skill-system-foundry/scripts/lib/reporting.py
+++ b/skill-system-foundry/scripts/lib/reporting.py
@@ -77,7 +77,9 @@ def parse_finding_string(raw: str) -> dict:
     preserved verbatim in ``message``.
 
     Raises ``ValueError`` on malformed input — missing ``": "``
-    separator or unrecognized severity token.
+    separator, unrecognized severity token, or an unmatched opening
+    ``[`` in the body (an unterminated tag is a producer bug, not a
+    zero-tag message).
     """
     sep = ": "
     sep_index = raw.find(sep)
@@ -96,9 +98,12 @@ def parse_finding_string(raw: str) -> dict:
     message = body
     if body.startswith("["):
         end = body.find("]")
-        if end > 0:
-            tag = body[: end + 1]
-            message = body[end + 1:].lstrip()
+        if end <= 0:
+            raise ValueError(
+                f"malformed finding tag (unterminated '[') in finding: {raw!r}"
+            )
+        tag = body[: end + 1]
+        message = body[end + 1:].lstrip()
     return {"severity": severity, "tag": tag, "message": message}
 
 

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -632,8 +632,8 @@ def main() -> None:
 
     errors, passes = validate_skill(skill_path, is_capability, allow_nested_refs)
 
-    # Prose-YAML doc-snippet check (Deliverable A).  Always populate the
-    # yaml_conformance JSON slot (G25 / G67) so consumers don't need a
+    # Prose-YAML doc-snippet check.  Always populate the
+    # yaml_conformance JSON slot so consumers don't need a
     # nullability branch.
     prose_findings: list[dict] = []
     prose_checked = 0

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -37,6 +37,7 @@ from lib.validation import (
     validate_known_keys,
 )
 from lib.codex_config import validate_codex_config
+from lib.prose_yaml import collect_prose_findings, format_finding_as_string
 from lib.constants import (
     MAX_DESCRIPTION_CHARS,
     MAX_BODY_LINES, MAX_COMPATIBILITY_CHARS,
@@ -553,6 +554,26 @@ def _build_parser() -> argparse.ArgumentParser:
         dest="json_output",
         help="Output results as machine-readable JSON.",
     )
+    parser.add_argument(
+        "--check-prose-yaml",
+        action="store_true",
+        dest="check_prose_yaml",
+        help=(
+            "Validate ```yaml fences in SKILL.md, capabilities/**/*.md, "
+            "and references/**/*.md.  See "
+            "references/authoring-principles.md for the convention."
+        ),
+    )
+    parser.add_argument(
+        "--foundry-self",
+        action="store_true",
+        dest="foundry_self",
+        help=(
+            "Run this skill as the foundry runs itself — currently "
+            "implies --check-prose-yaml.  Silently no-op when the flag "
+            "stack already includes the underlying check."
+        ),
+    )
     return parser
 
 
@@ -592,6 +613,10 @@ def main() -> None:
     verbose: bool = args.verbose
     allow_nested_refs: bool = args.allow_nested_refs
     json_output: bool = args.json_output
+    # --foundry-self is a superset trigger; passing both flags is a
+    # no-op (G58).  --foundry-self on a non-foundry target is silently
+    # equivalent to --check-prose-yaml (G8 / G55).
+    check_prose: bool = args.check_prose_yaml or args.foundry_self
 
     if not os.path.isdir(skill_path):
         if json_output:
@@ -607,6 +632,32 @@ def main() -> None:
 
     errors, passes = validate_skill(skill_path, is_capability, allow_nested_refs)
 
+    # Prose-YAML doc-snippet check (Deliverable A).  Always populate the
+    # yaml_conformance JSON slot (G25 / G67) so consumers don't need a
+    # nullability branch.
+    prose_findings: list[dict] = []
+    prose_checked = 0
+    if check_prose and not is_capability:
+        prose_findings, prose_checked, per_file = collect_prose_findings(
+            os.path.abspath(skill_path)
+        )
+        if verbose and not json_output:
+            for path, fence_count in per_file:
+                print(
+                    f"Checking prose YAML: {path} ({fence_count} fences)"
+                )
+        for finding in prose_findings:
+            errors.append(format_finding_as_string(finding))
+    yaml_conformance_slot = {
+        "corpus": {
+            "total": 0, "passed": 0, "failed": 0, "failures": [],
+        },
+        "doc_snippets": {
+            "checked": prose_checked,
+            "findings": prose_findings,
+        },
+    }
+
     if json_output:
         fails, warns, infos = categorize_errors(errors)
         result = {
@@ -621,6 +672,7 @@ def main() -> None:
                 "passes": len(passes),
             },
             "errors": categorize_errors_for_json(errors),
+            "yaml_conformance": yaml_conformance_slot,
         }
         if verbose:
             result["passes"] = passes

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -614,8 +614,8 @@ def main() -> None:
     allow_nested_refs: bool = args.allow_nested_refs
     json_output: bool = args.json_output
     # --foundry-self is a superset trigger; passing both flags is a
-    # no-op (G58).  --foundry-self on a non-foundry target is silently
-    # equivalent to --check-prose-yaml (G8 / G55).
+    # no-op.  --foundry-self on a non-foundry target is silently
+    # equivalent to --check-prose-yaml.
     check_prose: bool = args.check_prose_yaml or args.foundry_self
 
     if not os.path.isdir(skill_path):

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -637,7 +637,17 @@ def main() -> None:
     # nullability branch.
     prose_findings: list[dict] = []
     prose_checked = 0
-    if check_prose and not is_capability:
+    if check_prose and is_capability:
+        # Capability mode only sees a single ``capability.md`` body,
+        # so the skill-root glob walk the prose check needs does not
+        # apply.  Surface this as an INFO rather than silently
+        # dropping the flag.
+        errors.append(
+            "INFO: [foundry] --check-prose-yaml has no effect with "
+            "--capability; run against the parent skill root to scan "
+            "prose fences"
+        )
+    elif check_prose:
         prose_findings, prose_checked, per_file = collect_prose_findings(
             os.path.abspath(skill_path)
         )

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1476,8 +1476,8 @@ class AuditManifestFindingsJsonSchemaTests(unittest.TestCase):
             proc = _run([tmpdir, "--json"], cwd=REPO_ROOT)
             data = json.loads(proc.stdout)
         # Schema preserved: known top-level keys plus the additive
-        # ``yaml_conformance`` slot from #93 (always present, zero
-        # sentinel when checks did not run).
+        # ``yaml_conformance`` slot (always present, zero sentinel when
+        # checks did not run).
         self.assertEqual(
             set(data.keys()),
             {

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1567,5 +1567,66 @@ class AuditFoundryConfigFindingsTests(unittest.TestCase):
         self.assertEqual(len(tagged), 1)
 
 
+class AuditProseYamlAggregationTests(unittest.TestCase):
+    """``--check-prose-yaml`` and ``--foundry-self`` on audit_skill_system."""
+
+    def _build_system(self, tmpdir: str, *, planted_skills: list[str]) -> str:
+        """Plant minimal registered skills under <tmpdir>/skills/."""
+        system_root = tmpdir
+        skills_dir = os.path.join(system_root, "skills")
+        os.makedirs(skills_dir)
+        for name in planted_skills:
+            skill = os.path.join(skills_dir, name)
+            os.makedirs(skill)
+            write_skill_md(
+                skill,
+                name=name,
+                description=f"Demo skill {name} with a divergent fence.",
+                body=f"# {name}\n\n```yaml\nbad: *alias\n```\n",
+            )
+        return system_root
+
+    def test_flag_off_no_prose_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            system_root = self._build_system(tmpdir, planted_skills=["alpha"])
+            proc = _run([system_root, "--json"], cwd=REPO_ROOT)
+            data = json.loads(proc.stdout)
+        slot = data["yaml_conformance"]["doc_snippets"]
+        self.assertEqual(slot, {"checked": 0, "findings": []})
+
+    def test_foundry_self_runs_across_every_skill(self) -> None:
+        # The flag is a mode switch — every scanned skill gets the
+        # prose check, not just one named "foundry".
+        with tempfile.TemporaryDirectory() as tmpdir:
+            system_root = self._build_system(
+                tmpdir, planted_skills=["alpha", "beta"]
+            )
+            proc = _run(
+                [system_root, "--foundry-self", "--json"], cwd=REPO_ROOT
+            )
+            data = json.loads(proc.stdout)
+        slot = data["yaml_conformance"]["doc_snippets"]
+        self.assertEqual(slot["checked"], 2)
+        files = {f["file"] for f in slot["findings"]}
+        # Each finding's file is prefixed with skills/<name>/<rel>.
+        self.assertEqual(
+            files, {"skills/alpha/SKILL.md", "skills/beta/SKILL.md"}
+        )
+
+    def test_check_prose_yaml_alone_runs_across_every_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            system_root = self._build_system(
+                tmpdir, planted_skills=["alpha"]
+            )
+            proc = _run(
+                [system_root, "--check-prose-yaml", "--json"], cwd=REPO_ROOT
+            )
+            data = json.loads(proc.stdout)
+        findings = data["yaml_conformance"]["doc_snippets"]["findings"]
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["file"], "skills/alpha/SKILL.md")
+        self.assertIn("alias indicator", findings[0]["message"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1475,10 +1475,15 @@ class AuditManifestFindingsJsonSchemaTests(unittest.TestCase):
                 )
             proc = _run([tmpdir, "--json"], cwd=REPO_ROOT)
             data = json.loads(proc.stdout)
-        # Schema preserved: no new top-level keys introduced.
+        # Schema preserved: known top-level keys plus the additive
+        # ``yaml_conformance`` slot from #93 (always present, zero
+        # sentinel when checks did not run).
         self.assertEqual(
             set(data.keys()),
-            {"tool", "path", "success", "counts", "summary", "errors", "version"},
+            {
+                "tool", "path", "success", "counts", "summary",
+                "errors", "version", "yaml_conformance",
+            },
         )
         manifest_fails = [
             entry for entry in data["errors"].get("failures", [])

--- a/tests/test_check_per_file_coverage.py
+++ b/tests/test_check_per_file_coverage.py
@@ -943,7 +943,7 @@ class MainMalformedCoverageJsonTests(unittest.TestCase):
 
 
 class ParseFileThresholdTests(unittest.TestCase):
-    """Tests for ``parse_file_threshold`` PATH=PCT parsing per G107."""
+    """Tests for ``parse_file_threshold`` PATH=PCT parsing."""
 
     def test_simple_path_and_integer(self) -> None:
         self.assertEqual(
@@ -975,7 +975,7 @@ class ParseFileThresholdTests(unittest.TestCase):
             parse_file_threshold("a.py=ninety")
 
     def test_decimal_pct_raises(self) -> None:
-        # G107 — must be integer; decimals rejected.
+        # PCT must be an integer; decimals are rejected.
         with self.assertRaises(ValueError):
             parse_file_threshold("a.py=90.5")
 

--- a/tests/test_check_per_file_coverage.py
+++ b/tests/test_check_per_file_coverage.py
@@ -1105,6 +1105,32 @@ class MainFileThresholdTests(unittest.TestCase):
             import shutil
             shutil.rmtree(tmpdir)
 
+    def test_override_failure_reports_override_threshold(self) -> None:
+        # When a per-file override is the reason a file fails, the
+        # output must name the override threshold (not the global
+        # floor) so the CI log is actionable.
+        tmpdir = tempfile.mkdtemp()
+        try:
+            json_path = os.path.join(tmpdir, "coverage.json")
+            _write(json_path, _coverage_json({"a.py": 80.0}))
+            buf_out: list[str] = []
+            import contextlib
+            import io
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                code = main([
+                    "--coverage-json", json_path,
+                    "--threshold", "70",
+                    "--file-threshold", "a.py=90",
+                ])
+            buf_out.append(stdout.getvalue())
+            self.assertEqual(code, 1)
+            output = buf_out[0]
+            self.assertIn("override threshold 90.0%", output)
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir)
+
     def test_malformed_override_returns_one(self) -> None:
         tmpdir = tempfile.mkdtemp()
         try:

--- a/tests/test_check_per_file_coverage.py
+++ b/tests/test_check_per_file_coverage.py
@@ -1131,6 +1131,25 @@ class MainFileThresholdTests(unittest.TestCase):
             import shutil
             shutil.rmtree(tmpdir)
 
+    def test_override_path_normalisation_matches_coverage_filename(self) -> None:
+        # CLI input may use different equivalent path forms than what
+        # ``coverage.json`` stores (``./x.py`` prefix, backslashes on
+        # Windows, etc.).  Normalisation must make the override apply
+        # regardless.
+        tmpdir = tempfile.mkdtemp()
+        try:
+            json_path = os.path.join(tmpdir, "coverage.json")
+            _write(json_path, _coverage_json({"pkg/x.py": 80.0}))
+            result = main([
+                "--coverage-json", json_path,
+                "--threshold", "70",
+                "--file-threshold", "./pkg/x.py=90",
+            ])
+            self.assertEqual(result, 1)
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir)
+
     def test_malformed_override_returns_usage_error(self) -> None:
         # Usage errors follow argparse convention and exit with code 2,
         # matching the contract documented on ``main``.

--- a/tests/test_check_per_file_coverage.py
+++ b/tests/test_check_per_file_coverage.py
@@ -1131,7 +1131,9 @@ class MainFileThresholdTests(unittest.TestCase):
             import shutil
             shutil.rmtree(tmpdir)
 
-    def test_malformed_override_returns_one(self) -> None:
+    def test_malformed_override_returns_usage_error(self) -> None:
+        # Usage errors follow argparse convention and exit with code 2,
+        # matching the contract documented on ``main``.
         tmpdir = tempfile.mkdtemp()
         try:
             json_path = os.path.join(tmpdir, "coverage.json")
@@ -1141,7 +1143,7 @@ class MainFileThresholdTests(unittest.TestCase):
                 "--threshold", "70",
                 "--file-threshold", "a.py=ninety",
             ])
-            self.assertEqual(result, 1)
+            self.assertEqual(result, 2)
         finally:
             import shutil
             shutil.rmtree(tmpdir)

--- a/tests/test_check_per_file_coverage.py
+++ b/tests/test_check_per_file_coverage.py
@@ -28,6 +28,7 @@ _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 load_threshold = _mod.load_threshold
 check_per_file = _mod.check_per_file
+parse_file_threshold = _mod.parse_file_threshold
 main = _mod.main
 
 
@@ -929,6 +930,190 @@ class MainMalformedCoverageJsonTests(unittest.TestCase):
             result = main([
                 "--coverage-json", json_path,
                 "--threshold", "70",
+            ])
+            self.assertEqual(result, 1)
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir)
+
+
+# ===================================================================
+# parse_file_threshold — argument parsing
+# ===================================================================
+
+
+class ParseFileThresholdTests(unittest.TestCase):
+    """Tests for ``parse_file_threshold`` PATH=PCT parsing per G107."""
+
+    def test_simple_path_and_integer(self) -> None:
+        self.assertEqual(
+            parse_file_threshold("a/b.py=90"),
+            ("a/b.py", 90.0),
+        )
+
+    def test_path_with_equals_sign_uses_last(self) -> None:
+        # Splits on the LAST '='; paths may contain '='.
+        self.assertEqual(
+            parse_file_threshold("weird=name.py=85"),
+            ("weird=name.py", 85.0),
+        )
+
+    def test_zero_and_hundred_boundary(self) -> None:
+        self.assertEqual(parse_file_threshold("a.py=0"), ("a.py", 0.0))
+        self.assertEqual(parse_file_threshold("a.py=100"), ("a.py", 100.0))
+
+    def test_missing_equals_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_file_threshold("no-equals-sign")
+
+    def test_empty_path_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_file_threshold("=90")
+
+    def test_non_integer_pct_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_file_threshold("a.py=ninety")
+
+    def test_decimal_pct_raises(self) -> None:
+        # G107 — must be integer; decimals rejected.
+        with self.assertRaises(ValueError):
+            parse_file_threshold("a.py=90.5")
+
+    def test_negative_pct_raises(self) -> None:
+        # The minus sign also defeats isdigit() — covered, but pin the
+        # shape explicitly so a future refactor can't regress it.
+        with self.assertRaises(ValueError):
+            parse_file_threshold("a.py=-1")
+
+    def test_above_100_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_file_threshold("a.py=101")
+
+
+# ===================================================================
+# check_per_file — per-file overrides
+# ===================================================================
+
+
+class CheckPerFileOverrideTests(unittest.TestCase):
+    """Tests for ``check_per_file`` honoring per-file overrides."""
+
+    def test_override_hit_promotes_threshold(self) -> None:
+        # Global threshold 70; override raises a.py to 95.  a.py at 90%
+        # now fails, b.py at 80% still passes against the global.
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(_coverage_json({"a.py": 90.0, "b.py": 80.0}))
+            path = fh.name
+        try:
+            failures, passes = check_per_file(
+                path, 70.0, {"a.py": 95.0}
+            )
+            self.assertEqual([f[0] for f in failures], ["a.py"])
+            self.assertEqual([p[0] for p in passes], ["b.py"])
+        finally:
+            os.unlink(path)
+
+    def test_override_miss_falls_through_to_global(self) -> None:
+        # Override is on c.py (not present); a.py and b.py use the global.
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(_coverage_json({"a.py": 50.0, "b.py": 80.0}))
+            path = fh.name
+        try:
+            failures, passes = check_per_file(
+                path, 70.0, {"c.py": 99.0}
+            )
+            self.assertEqual([f[0] for f in failures], ["a.py"])
+            self.assertEqual([p[0] for p in passes], ["b.py"])
+        finally:
+            os.unlink(path)
+
+    def test_multiple_overrides_apply_independently(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(
+                _coverage_json({"a.py": 92.0, "b.py": 85.0, "c.py": 75.0})
+            )
+            path = fh.name
+        try:
+            failures, passes = check_per_file(
+                path,
+                70.0,
+                {"a.py": 95.0, "b.py": 80.0},
+            )
+            self.assertEqual([f[0] for f in failures], ["a.py"])
+            self.assertEqual(
+                sorted(p[0] for p in passes),
+                ["b.py", "c.py"],
+            )
+        finally:
+            os.unlink(path)
+
+    def test_override_lower_than_global_lets_low_file_pass(self) -> None:
+        # Per-file override may also relax — a.py at 50% passes when
+        # override drops to 40%, even though the global is 70%.
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write(_coverage_json({"a.py": 50.0}))
+            path = fh.name
+        try:
+            failures, passes = check_per_file(
+                path, 70.0, {"a.py": 40.0}
+            )
+            self.assertEqual(failures, [])
+            self.assertEqual([p[0] for p in passes], ["a.py"])
+        finally:
+            os.unlink(path)
+
+
+class MainFileThresholdTests(unittest.TestCase):
+    """Integration tests for ``--file-threshold`` end-to-end."""
+
+    def test_repeated_overrides_pass(self) -> None:
+        tmpdir = tempfile.mkdtemp()
+        try:
+            json_path = os.path.join(tmpdir, "coverage.json")
+            _write(json_path, _coverage_json({"a.py": 92.0, "b.py": 88.0}))
+            result = main([
+                "--coverage-json", json_path,
+                "--threshold", "70",
+                "--file-threshold", "a.py=90",
+                "--file-threshold", "b.py=80",
+            ])
+            self.assertEqual(result, 0)
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir)
+
+    def test_override_failure_returns_one(self) -> None:
+        tmpdir = tempfile.mkdtemp()
+        try:
+            json_path = os.path.join(tmpdir, "coverage.json")
+            _write(json_path, _coverage_json({"a.py": 80.0}))
+            result = main([
+                "--coverage-json", json_path,
+                "--threshold", "70",
+                "--file-threshold", "a.py=90",
+            ])
+            self.assertEqual(result, 1)
+        finally:
+            import shutil
+            shutil.rmtree(tmpdir)
+
+    def test_malformed_override_returns_one(self) -> None:
+        tmpdir = tempfile.mkdtemp()
+        try:
+            json_path = os.path.join(tmpdir, "coverage.json")
+            _write(json_path, _coverage_json({"a.py": 90.0}))
+            result = main([
+                "--coverage-json", json_path,
+                "--threshold", "70",
+                "--file-threshold", "a.py=ninety",
             ])
             self.assertEqual(result, 1)
         finally:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -75,7 +75,7 @@ class GetConfigFindingsTests(unittest.TestCase):
 
 
 class ProseYamlConfigTests(unittest.TestCase):
-    """``prose_yaml`` keys are exposed by constants per G79/G95."""
+    """``prose_yaml`` keys are exposed by constants."""
 
     def test_opt_out_marker_value(self) -> None:
         self.assertEqual(

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -2,8 +2,8 @@
 
 Covers the lazy divergence re-parse of ``configuration.yaml`` via
 ``get_config_findings``, verifies ``CONFIG_PATH`` is an absolute path
-pointing at the expected file, and pins the new ``prose_yaml`` and
-``prose_yaml`` keys.  Missing-section fail-fast is exercised by
+pointing at the expected file, and pins the ``prose_yaml`` opt-out
+marker and in-scope globs.  Missing-section fail-fast is exercised by
 re-importing ``lib.constants`` against a synthetic config file with
 the section removed.
 """

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,13 +1,18 @@
 """Tests for lib.constants module-load behaviour.
 
 Covers the lazy divergence re-parse of ``configuration.yaml`` via
-``get_config_findings`` and verifies ``CONFIG_PATH`` is an absolute
-path pointing at the expected file.
+``get_config_findings``, verifies ``CONFIG_PATH`` is an absolute path
+pointing at the expected file, and pins the new ``prose_yaml`` and
+``prose_yaml`` keys.  Missing-section fail-fast is exercised by
+re-importing ``lib.constants`` against a synthetic config file with
+the section removed.
 """
 
+import importlib
 import os
 import sys
 import unittest
+import unittest.mock
 
 SCRIPTS_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "skill-system-foundry", "scripts")
@@ -67,6 +72,77 @@ class GetConfigFindingsTests(unittest.TestCase):
         """The shipped ``configuration.yaml`` must round-trip clean."""
         findings = constants.get_config_findings()
         self.assertEqual(findings, [])
+
+
+class ProseYamlConfigTests(unittest.TestCase):
+    """``prose_yaml`` keys are exposed by constants per G79/G95."""
+
+    def test_opt_out_marker_value(self) -> None:
+        self.assertEqual(
+            constants.PROSE_YAML_OPT_OUT_MARKER,
+            "<!-- yaml-ignore -->",
+        )
+
+    def test_in_scope_globs_value(self) -> None:
+        self.assertEqual(
+            constants.PROSE_YAML_IN_SCOPE_GLOBS,
+            ("SKILL.md", "capabilities/**/*.md", "references/**/*.md"),
+        )
+
+
+class MissingSectionFailFastTests(unittest.TestCase):
+    """Re-importing ``lib.constants`` against a config missing a
+    required section raises ``RuntimeError`` at import time."""
+
+    def _full_config_minus(self, section: str) -> str:
+        """Return the real configuration file text with *section* removed."""
+        with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
+            text = fh.read()
+        out_lines: list[str] = []
+        skipping = False
+        for line in text.splitlines(keepends=True):
+            if line.startswith(f"{section}:"):
+                skipping = True
+                continue
+            if skipping:
+                if line.strip() == "" or line.startswith("#"):
+                    continue
+                if not line.startswith((" ", "\t")):
+                    skipping = False
+                else:
+                    continue
+            out_lines.append(line)
+        return "".join(out_lines)
+
+    def _reimport_with_config(self, config_text: str) -> None:
+        """Re-import ``lib.constants`` against a synthetic config text.
+
+        Patches ``builtins.open`` so the module's two reads of
+        ``CONFIG_PATH`` see *config_text* instead of the on-disk file.
+        Reloads the real module afterwards so subsequent tests get the
+        canonical state back.
+        """
+        import builtins
+        import io
+
+        real_open = builtins.open
+        target = constants.CONFIG_PATH
+
+        def fake_open(file, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if file == target:
+                return io.StringIO(config_text)
+            return real_open(file, *args, **kwargs)
+
+        try:
+            with unittest.mock.patch("builtins.open", new=fake_open):
+                importlib.reload(constants)
+        finally:
+            importlib.reload(constants)
+
+    def test_missing_prose_yaml_raises(self) -> None:
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(self._full_config_minus("prose_yaml"))
+        self.assertIn("prose_yaml", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -715,5 +715,81 @@ class BundleJsonTests(unittest.TestCase):
         self.assertIn("unrecognized arguments", data["error"])
 
 
+class YamlConformanceJsonSlotTests(unittest.TestCase):
+    """G25 / G67 / G114 — yaml_conformance slot is always present.
+
+    Both ``corpus`` (zero-sentinel here — populated by the corpus
+    harness which validate_skill / audit_skill_system do not run) and
+    ``doc_snippets`` are present on every JSON invocation.  Numeric
+    fields are integers, not strings.
+    """
+
+    def _make_minimal_skill(self, tmpdir: str) -> str:
+        skill = os.path.join(tmpdir, "demo")
+        os.makedirs(skill)
+        write_skill_md(
+            skill,
+            name="demo",
+            description="Demo skill for json output schema tests.",
+        )
+        return skill
+
+    def test_validate_skill_zero_sentinel_when_flag_off(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill = self._make_minimal_skill(tmpdir)
+            proc = _run(VALIDATE_SCRIPT, [skill, "--json"], cwd=REPO_ROOT)
+            data = _parse_json(proc.stdout)
+        self.assertIn("yaml_conformance", data)
+        slot = data["yaml_conformance"]
+        self.assertEqual(
+            set(slot.keys()), {"corpus", "doc_snippets"}
+        )
+        corpus = slot["corpus"]
+        self.assertEqual(
+            corpus,
+            {"total": 0, "passed": 0, "failed": 0, "failures": []},
+        )
+        for k in ("total", "passed", "failed"):
+            self.assertIsInstance(corpus[k], int)
+        snippets = slot["doc_snippets"]
+        self.assertEqual(snippets, {"checked": 0, "findings": []})
+        self.assertIsInstance(snippets["checked"], int)
+
+    def test_validate_skill_doc_snippets_populated_when_flag_on(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill = self._make_minimal_skill(tmpdir)
+            # Add a body fence with a known divergence.
+            with open(os.path.join(skill, "SKILL.md"), "a", encoding="utf-8") as fh:
+                fh.write("\n```yaml\nbad: *alias\n```\n")
+            proc = _run(
+                VALIDATE_SCRIPT,
+                [skill, "--json", "--check-prose-yaml"],
+                cwd=REPO_ROOT,
+            )
+            data = _parse_json(proc.stdout)
+        snippets = data["yaml_conformance"]["doc_snippets"]
+        self.assertEqual(snippets["checked"], 1)
+        self.assertEqual(len(snippets["findings"]), 1)
+        finding = snippets["findings"][0]
+        self.assertEqual(finding["severity"], "fail")
+        self.assertEqual(finding["block_ordinal"], 1)
+        self.assertIsInstance(finding["block_ordinal"], int)
+        self.assertIn("alias indicator", finding["message"])
+
+    def test_audit_skill_system_zero_sentinel_when_flag_off(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.makedirs(os.path.join(tmpdir, "skills"))
+            proc = _run(AUDIT_SCRIPT, [tmpdir, "--json"], cwd=REPO_ROOT)
+            data = _parse_json(proc.stdout)
+        slot = data["yaml_conformance"]
+        self.assertEqual(
+            slot["corpus"],
+            {"total": 0, "passed": 0, "failed": 0, "failures": []},
+        )
+        self.assertEqual(
+            slot["doc_snippets"], {"checked": 0, "findings": []}
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -716,7 +716,7 @@ class BundleJsonTests(unittest.TestCase):
 
 
 class YamlConformanceJsonSlotTests(unittest.TestCase):
-    """G25 / G67 / G114 — yaml_conformance slot is always present.
+    """The yaml_conformance slot is always present.
 
     Both ``corpus`` (zero-sentinel here — populated by the corpus
     harness which validate_skill / audit_skill_system do not run) and

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -269,5 +269,153 @@ class ReadAndValidateTests(unittest.TestCase):
             prose_yaml.read_and_validate("/nonexistent/file.md")
 
 
+class FindInScopeFilesTests(unittest.TestCase):
+    """``find_in_scope_files`` walks the three configured globs only."""
+
+    def _make_skill_root(self) -> str:
+        root = tempfile.mkdtemp()
+        # In-scope files
+        for rel in (
+            "SKILL.md",
+            "capabilities/foo/capability.md",
+            "capabilities/foo/sub.md",
+            "references/main.md",
+            "references/nested/deep.md",
+        ):
+            path = os.path.join(root, rel)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("# heading\n")
+        # Out-of-scope files
+        for rel in ("README.md", "CHANGELOG.md", "assets/template.md"):
+            path = os.path.join(root, rel)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("# heading\n")
+        return root
+
+    def test_only_in_scope_files_returned(self) -> None:
+        root = self._make_skill_root()
+        try:
+            paths = prose_yaml.find_in_scope_files(root)
+            relatives = sorted(
+                os.path.relpath(p, root).replace(os.sep, "/")
+                for p in paths
+            )
+            self.assertEqual(
+                relatives,
+                [
+                    "SKILL.md",
+                    "capabilities/foo/capability.md",
+                    "capabilities/foo/sub.md",
+                    "references/main.md",
+                    "references/nested/deep.md",
+                ],
+            )
+        finally:
+            import shutil
+            shutil.rmtree(root, ignore_errors=True)
+
+
+class CollectProseFindingsTests(unittest.TestCase):
+    """``collect_prose_findings`` aggregates fences across in-scope files."""
+
+    def _build_skill(self, content_by_rel: dict[str, str]) -> str:
+        root = tempfile.mkdtemp()
+        for rel, text in content_by_rel.items():
+            path = os.path.join(root, rel)
+            os.makedirs(os.path.dirname(path) or root, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(text)
+        return root
+
+    def test_clean_skill_returns_no_findings(self) -> None:
+        root = self._build_skill({
+            "SKILL.md": "intro\n```yaml\nkey: value\n```\n",
+        })
+        try:
+            findings, checked, per_file = prose_yaml.collect_prose_findings(root)
+            self.assertEqual(findings, [])
+            self.assertEqual(checked, 1)
+            self.assertEqual(per_file, [("SKILL.md", 1)])
+        finally:
+            import shutil
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_divergent_skill_aggregates_findings(self) -> None:
+        root = self._build_skill({
+            "SKILL.md": "```yaml\nkey: *alias\n```\n",
+            "references/foo.md": "```yaml\nbad: @reserved\n```\n",
+        })
+        try:
+            findings, checked, _ = prose_yaml.collect_prose_findings(root)
+            self.assertEqual(checked, 2)
+            self.assertEqual(len(findings), 2)
+            self.assertEqual(
+                {f["file"] for f in findings},
+                {"SKILL.md", "references/foo.md"},
+            )
+        finally:
+            import shutil
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_audit_prefix_applied(self) -> None:
+        root = self._build_skill({
+            "SKILL.md": "```yaml\nkey: *alias\n```\n",
+        })
+        try:
+            findings, _, per_file = prose_yaml.collect_prose_findings(
+                root, audit_prefix="skills/demo"
+            )
+            self.assertEqual(findings[0]["file"], "skills/demo/SKILL.md")
+            self.assertEqual(per_file[0][0], "skills/demo/SKILL.md")
+        finally:
+            import shutil
+            shutil.rmtree(root, ignore_errors=True)
+
+
+class FormatFindingAsStringTests(unittest.TestCase):
+    """Round-trip a structured finding back into the parser-string shape."""
+
+    def test_fail_with_spec_tag(self) -> None:
+        finding = {
+            "file": "doc.md",
+            "block_ordinal": 2,
+            "severity": "fail",
+            "tag": "[spec]",
+            "message": "'key': bad value; advice",
+        }
+        self.assertEqual(
+            prose_yaml.format_finding_as_string(finding),
+            "FAIL: [spec] doc.md block 2: 'key': bad value; advice",
+        )
+
+    def test_warn_with_empty_tag_defaults_to_spec(self) -> None:
+        finding = {
+            "file": "x.md",
+            "block_ordinal": 1,
+            "severity": "warn",
+            "tag": "",
+            "message": "structural parse error",
+        }
+        self.assertEqual(
+            prose_yaml.format_finding_as_string(finding),
+            "WARN: [spec] x.md block 1: structural parse error",
+        )
+
+    def test_info_severity(self) -> None:
+        finding = {
+            "file": "x.md",
+            "block_ordinal": 3,
+            "severity": "info",
+            "tag": "[spec]",
+            "message": "something",
+        }
+        self.assertEqual(
+            prose_yaml.format_finding_as_string(finding),
+            "INFO: [spec] x.md block 3: something",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -1,0 +1,265 @@
+"""Tests for ``lib/prose_yaml.py``.
+
+Matrix per IMPL-PLAN §4.7 / §4.2 / §4.3:
+- Known-good fence → no findings.
+- Divergent fence → expected divergence finding surfaces.
+- Strict-adjacency opt-out (both directions).
+- ``yml`` / ``YAML`` / ``Yaml`` → INFO ``"did you mean 'yaml'?"``.
+- Tilde / 4-backtick / indented fences invisible.
+- Unterminated fence → FAIL.
+- Empty fence → ``{}``, ordinal advances.
+- Column-0 ``` `` ` ``` inside block scalar terminates early.
+- Multi-fence ordinals monotonic.
+- CRLF markdown handled identically to LF.
+- Path with Windows-native separator → ``to_posix`` normalizes (G130).
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "skill-system-foundry", "scripts")
+)
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib import prose_yaml  # noqa: E402
+
+
+# ===================================================================
+# extract_yaml_fences — fence shape rules
+# ===================================================================
+
+
+class ExtractYamlFencesShapeTests(unittest.TestCase):
+
+    def test_empty_input_returns_empty(self) -> None:
+        self.assertEqual(prose_yaml.extract_yaml_fences(""), [])
+
+    def test_simple_yaml_fence(self) -> None:
+        text = "intro\n```yaml\nkey: value\n```\noutro\n"
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["state"], "parsed")
+        self.assertEqual(records[0]["text"], "key: value")
+        self.assertEqual(records[0]["ordinal"], 1)
+
+    def test_tilde_fence_is_invisible(self) -> None:
+        text = "intro\n~~~yaml\nkey: value\n~~~\n"
+        self.assertEqual(prose_yaml.extract_yaml_fences(text), [])
+
+    def test_four_backtick_fence_is_invisible(self) -> None:
+        text = "````yaml\nkey: value\n````\n"
+        self.assertEqual(prose_yaml.extract_yaml_fences(text), [])
+
+    def test_indented_fence_is_invisible(self) -> None:
+        text = "  ```yaml\n  key: value\n  ```\n"
+        self.assertEqual(prose_yaml.extract_yaml_fences(text), [])
+
+    def test_whitespace_between_backticks_and_yaml_invisible(self) -> None:
+        text = "``` yaml\nkey: value\n```\n"
+        self.assertEqual(prose_yaml.extract_yaml_fences(text), [])
+
+    def test_wrong_case_yml_recognised(self) -> None:
+        text = "```yml\nkey: value\n```\n"
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["state"], "wrong-case")
+
+    def test_wrong_case_uppercase_recognised(self) -> None:
+        text = "```YAML\nkey: value\n```\n"
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(records[0]["state"], "wrong-case")
+
+    def test_wrong_case_titlecase_recognised(self) -> None:
+        text = "```Yaml\nkey: value\n```\n"
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(records[0]["state"], "wrong-case")
+
+    def test_unterminated_fence(self) -> None:
+        text = "```yaml\nkey: value\nno-close\n"
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(records[0]["state"], "unterminated")
+        # unterminated stops the scan — only one record.
+        self.assertEqual(len(records), 1)
+
+    def test_empty_fence_state_parsed(self) -> None:
+        text = "```yaml\n```\n"
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(records[0]["state"], "parsed")
+        self.assertEqual(records[0]["text"], "")
+
+    def test_multiple_fences_ordinal_monotonic(self) -> None:
+        text = (
+            "```yaml\nk1: v1\n```\n"
+            "between\n"
+            "```yaml\nk2: v2\n```\n"
+            "between\n"
+            "```yaml\nk3: v3\n```\n"
+        )
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual([r["ordinal"] for r in records], [1, 2, 3])
+
+    def test_column_zero_backticks_inside_body_terminate_early(self) -> None:
+        # ```yaml fence opens; the literal column-0 ``` inside the body
+        # terminates the block per CommonMark.  Documented limit (G13).
+        text = "```yaml\nliteral: |\n```\n  more\n```\n"
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(records[0]["state"], "parsed")
+        self.assertEqual(records[0]["text"], "literal: |")
+
+    def test_crlf_markdown_handled_identically(self) -> None:
+        lf = "intro\n```yaml\nkey: value\n```\n"
+        crlf = lf.replace("\n", "\r\n")
+        self.assertEqual(
+            prose_yaml.extract_yaml_fences(lf),
+            prose_yaml.extract_yaml_fences(crlf),
+        )
+
+
+# ===================================================================
+# extract_yaml_fences — opt-out marker (§4.3)
+# ===================================================================
+
+
+class OptOutAdjacencyTests(unittest.TestCase):
+
+    def test_strict_adjacency_marks_ignored(self) -> None:
+        text = "<!-- yaml-ignore -->\n```yaml\nbad: value\n```\n"
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(records[0]["state"], "ignored")
+
+    def test_blank_line_between_marker_and_fence_does_not_ignore(self) -> None:
+        text = (
+            "<!-- yaml-ignore -->\n"
+            "\n"
+            "```yaml\n"
+            "still: validated\n"
+            "```\n"
+        )
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(records[0]["state"], "parsed")
+
+    def test_marker_with_surrounding_whitespace_still_matches(self) -> None:
+        text = "  <!-- yaml-ignore -->  \n```yaml\nbad: value\n```\n"
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(records[0]["state"], "ignored")
+
+    def test_ordinal_advances_for_ignored_block(self) -> None:
+        # An ignored fence still counts toward the ordinal stream so
+        # the prose path's block numbering stays stable.
+        text = (
+            "<!-- yaml-ignore -->\n"
+            "```yaml\nignored: 1\n```\n"
+            "```yaml\nactive: 2\n```\n"
+        )
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual([r["state"] for r in records], ["ignored", "parsed"])
+        self.assertEqual([r["ordinal"] for r in records], [1, 2])
+
+
+# ===================================================================
+# validate_prose_yaml — finding shape and routing
+# ===================================================================
+
+
+class ValidateProseYamlTests(unittest.TestCase):
+
+    def test_known_good_fence_no_findings(self) -> None:
+        text = "```yaml\nkey: value\n```\n"
+        self.assertEqual(prose_yaml.validate_prose_yaml("doc.md", text), [])
+
+    def test_divergent_fence_surfaces_finding(self) -> None:
+        text = "```yaml\nkey: *alias\n```\n"
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual(f["severity"], "fail")
+        self.assertEqual(f["tag"], "[spec]")
+        self.assertEqual(f["block_ordinal"], 1)
+        self.assertEqual(f["file"], "doc.md")
+        self.assertIn("alias indicator", f["message"])
+
+    def test_unterminated_fence_emits_fail(self) -> None:
+        text = "```yaml\nkey: value\n"
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["severity"], "fail")
+        self.assertIn("unterminated", findings[0]["message"])
+
+    def test_wrong_case_emits_info(self) -> None:
+        text = "```YAML\nkey: value\n```\n"
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["severity"], "info")
+        self.assertIn("did you mean 'yaml'", findings[0]["message"])
+
+    def test_structural_value_error_caught_and_emitted(self) -> None:
+        # Indent-indicator block scalar raises in the parser; the prose
+        # path catches and emits a single LEVEL_FAIL finding (§4.1).
+        text = "```yaml\nkey: |2\n  text\n```\n"
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["severity"], "fail")
+        self.assertIn("structural parse error", findings[0]["message"])
+        self.assertIn(
+            "indent-indicator-block-scalar", findings[0]["message"]
+        )
+
+    def test_ignored_fence_produces_no_findings(self) -> None:
+        text = "<!-- yaml-ignore -->\n```yaml\nbad: *alias\n```\n"
+        self.assertEqual(prose_yaml.validate_prose_yaml("doc.md", text), [])
+
+    def test_empty_fence_produces_no_findings(self) -> None:
+        text = "```yaml\n```\n"
+        self.assertEqual(prose_yaml.validate_prose_yaml("doc.md", text), [])
+
+    def test_multi_fence_findings_carry_ordinal(self) -> None:
+        text = (
+            "```yaml\nok: value\n```\n"
+            "between\n"
+            "```yaml\nbad: *alias\n```\n"
+        )
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["block_ordinal"], 2)
+
+    def test_file_path_echoed_verbatim(self) -> None:
+        # G120 — the function does not normalise paths; the caller does.
+        text = "```yaml\nbad: *alias\n```\n"
+        findings = prose_yaml.validate_prose_yaml(
+            "skill\\caps\\thing.md", text
+        )
+        self.assertEqual(findings[0]["file"], "skill\\caps\\thing.md")
+
+
+# ===================================================================
+# read_and_validate — convenience wrapper, to_posix normalization
+# ===================================================================
+
+
+class ReadAndValidateTests(unittest.TestCase):
+
+    def test_round_trip(self) -> None:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8"
+        ) as fh:
+            fh.write("```yaml\nbad: *alias\n```\n")
+            path = fh.name
+        try:
+            findings = prose_yaml.read_and_validate(path)
+            self.assertEqual(len(findings), 1)
+            # G68 — file path is POSIX even when the OS uses backslashes.
+            self.assertNotIn("\\", findings[0]["file"])
+        finally:
+            os.unlink(path)
+
+    def test_missing_file_propagates_error(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            prose_yaml.read_and_validate("/nonexistent/file.md")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -381,6 +381,26 @@ class CollectProseFindingsTests(unittest.TestCase):
             shutil.rmtree(root, ignore_errors=True)
 
 
+    def test_unreadable_file_becomes_structured_fail(self) -> None:
+        # A UTF-8 decode failure must surface as a FAIL finding rather
+        # than a raw exception that tears down the walk.
+        root = tempfile.mkdtemp()
+        try:
+            skill_md = os.path.join(root, "SKILL.md")
+            with open(skill_md, "wb") as fh:
+                fh.write(b"\xff\xfe not utf-8 at all")
+            findings, checked, per_file = prose_yaml.collect_prose_findings(root)
+            self.assertEqual(checked, 0)
+            self.assertEqual(per_file, [("SKILL.md", 0)])
+            self.assertEqual(len(findings), 1)
+            self.assertEqual(findings[0]["severity"], "fail")
+            self.assertEqual(findings[0]["file"], "SKILL.md")
+            self.assertIn("could not read file", findings[0]["message"])
+        finally:
+            import shutil
+            shutil.rmtree(root, ignore_errors=True)
+
+
 class FormatFindingAsStringTests(unittest.TestCase):
     """Round-trip a structured finding back into the parser-string shape."""
 

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -197,15 +197,23 @@ class ValidateProseYamlTests(unittest.TestCase):
         self.assertIn("did you mean 'yaml'", findings[0]["message"])
 
     def test_structural_value_error_caught_and_emitted(self) -> None:
-        # Indent-indicator block scalar raises in the parser; the prose
-        # path catches and emits a single LEVEL_FAIL finding (§4.1).
-        text = "```yaml\nkey: |2\n  text\n```\n"
-        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        # When the underlying parser raises ValueError, the prose path
+        # catches it and emits a single LEVEL_FAIL finding rather than
+        # propagating.  Mock the parser to guarantee the raise path
+        # fires regardless of which constructs the parser rejects today.
+        import unittest.mock
+        with unittest.mock.patch(
+            "lib.prose_yaml.parse_yaml_subset",
+            side_effect=ValueError("synthetic structural failure"),
+        ):
+            findings = prose_yaml.validate_prose_yaml(
+                "doc.md", "```yaml\nkey: value\n```\n"
+            )
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0]["severity"], "fail")
         self.assertIn("structural parse error", findings[0]["message"])
         self.assertIn(
-            "indent-indicator-block-scalar", findings[0]["message"]
+            "synthetic structural failure", findings[0]["message"]
         )
 
     def test_ignored_fence_produces_no_findings(self) -> None:

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -147,6 +147,18 @@ class OptOutAdjacencyTests(unittest.TestCase):
         records = prose_yaml.extract_yaml_fences(text)
         self.assertEqual(records[0]["state"], "ignored")
 
+    def test_wrong_case_covers_arbitrary_variants(self) -> None:
+        # Any case variant of 'yaml' or 'yml' (other than the
+        # canonical lowercase 'yaml') must surface as wrong-case.
+        for token in ("YAML", "Yaml", "yAmL", "YML", "Yml", "yML"):
+            text = f"```{token}\nfoo: bar\n```\n"
+            records = prose_yaml.extract_yaml_fences(text)
+            self.assertEqual(
+                records[0]["state"], "wrong-case",
+                f"{token!r} should be classified wrong-case",
+            )
+            self.assertEqual(records[0]["language"], token)
+
     def test_opt_out_marker_overrides_wrong_case(self) -> None:
         # The opt-out marker must apply regardless of opener classification,
         # so a wrong-case fence can be waived without surfacing an INFO.

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -223,6 +223,26 @@ class ValidateProseYamlTests(unittest.TestCase):
             "synthetic structural failure", findings[0]["message"]
         )
 
+    def test_unterminated_frontmatter_skips_prose_scan(self) -> None:
+        # Malformed frontmatter (no closing ``---``) must not cause
+        # fences inside that block to be validated as body content —
+        # the file's frontmatter parse error is surfaced separately by
+        # the main validator.
+        text = (
+            "---\n"
+            "name: demo\n"
+            "description: |\n"
+            "  ```yaml\n"
+            "  bad: *alias\n"
+            "  ```\n"
+            "# No closing delimiter below this line.\n"
+            "```yaml\n"
+            "also: *alias\n"
+            "```\n"
+        )
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(findings, [])
+
     def test_empty_frontmatter_is_stripped(self) -> None:
         # A ``---\\n---\\n`` block is still frontmatter for scope
         # purposes; fences after it are validated, fences before the

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -223,6 +223,23 @@ class ValidateProseYamlTests(unittest.TestCase):
             "synthetic structural failure", findings[0]["message"]
         )
 
+    def test_frontmatter_yaml_fence_not_scanned(self) -> None:
+        # A ```yaml fence embedded inside a folded description in the
+        # frontmatter must not be validated as body content.
+        text = (
+            "---\n"
+            "name: demo\n"
+            "description: >\n"
+            "  sample: ```yaml\n"
+            "  body here\n"
+            "  ```\n"
+            "---\n"
+            "# Body\n"
+            "```yaml\nok: value\n```\n"
+        )
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(findings, [])
+
     def test_ignored_fence_produces_no_findings(self) -> None:
         text = "<!-- yaml-ignore -->\n```yaml\nbad: *alias\n```\n"
         self.assertEqual(prose_yaml.validate_prose_yaml("doc.md", text), [])
@@ -395,7 +412,12 @@ class CollectProseFindingsTests(unittest.TestCase):
             self.assertEqual(len(findings), 1)
             self.assertEqual(findings[0]["severity"], "fail")
             self.assertEqual(findings[0]["file"], "SKILL.md")
+            self.assertIsNone(findings[0]["block_ordinal"])
             self.assertIn("could not read file", findings[0]["message"])
+            # The human-formatted line omits the "block N" segment.
+            formatted = prose_yaml.format_finding_as_string(findings[0])
+            self.assertNotIn("block 0", formatted)
+            self.assertNotIn("block None", formatted)
         finally:
             import shutil
             shutil.rmtree(root, ignore_errors=True)

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -147,6 +147,13 @@ class OptOutAdjacencyTests(unittest.TestCase):
         records = prose_yaml.extract_yaml_fences(text)
         self.assertEqual(records[0]["state"], "ignored")
 
+    def test_opt_out_marker_overrides_wrong_case(self) -> None:
+        # The opt-out marker must apply regardless of opener classification,
+        # so a wrong-case fence can be waived without surfacing an INFO.
+        text = "<!-- yaml-ignore -->\n```YAML\nbad: value\n```\n"
+        records = prose_yaml.extract_yaml_fences(text)
+        self.assertEqual(records[0]["state"], "ignored")
+
     def test_ordinal_advances_for_ignored_block(self) -> None:
         # An ignored fence still counts toward the ordinal stream so
         # the prose path's block numbering stays stable.

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -223,6 +223,34 @@ class ValidateProseYamlTests(unittest.TestCase):
             "synthetic structural failure", findings[0]["message"]
         )
 
+    def test_empty_frontmatter_is_stripped(self) -> None:
+        # A ``---\\n---\\n`` block is still frontmatter for scope
+        # purposes; fences after it are validated, fences before the
+        # closer must not be.
+        text = (
+            "---\n"
+            "---\n"
+            "```yaml\nbad: *alias\n```\n"
+        )
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(len(findings), 1)
+
+    def test_frontmatter_boundary_is_line_based(self) -> None:
+        # A ``---`` substring inside a YAML block scalar value must
+        # not terminate the frontmatter block early.
+        text = (
+            "---\n"
+            "description: |\n"
+            "  embedded --- dashes are fine\n"
+            "---\n"
+            "```yaml\nbad: *alias\n```\n"
+        )
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        # Body contains one divergent fence; the frontmatter contents
+        # (including the line with ``---``) are not scanned.
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["block_ordinal"], 1)
+
     def test_thematic_break_is_not_stripped_as_frontmatter(self) -> None:
         # A Markdown thematic break (``---`` at column 0) at the top of
         # a file must not be misread as frontmatter — otherwise an

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -231,25 +231,40 @@ class ValidateProseYamlTests(unittest.TestCase):
         findings = prose_yaml.validate_prose_yaml("doc.md", text)
         self.assertEqual(findings, [])
 
-    def test_unterminated_frontmatter_skips_prose_scan(self) -> None:
-        # Malformed frontmatter (no closing ``---``) must not cause
-        # fences inside that block to be validated as body content —
-        # the file's frontmatter parse error is surfaced separately by
-        # the main validator.
+    def test_unterminated_opener_still_scans_body_fences(self) -> None:
+        # A file that opens with ``---`` but has no closing delimiter
+        # is ambiguous — it could be malformed frontmatter, or a
+        # thematic break at line 1.  The prose check stays
+        # conservative and scans the full text so body-level divergent
+        # fences still reach the validator.  ``load_frontmatter``
+        # surfaces the parse error separately when intent was
+        # frontmatter.
         text = (
             "---\n"
-            "name: demo\n"
-            "description: |\n"
-            "  ```yaml\n"
-            "  bad: *alias\n"
-            "  ```\n"
-            "# No closing delimiter below this line.\n"
+            "some prose without a closing delimiter\n"
             "```yaml\n"
-            "also: *alias\n"
+            "bad: *alias\n"
             "```\n"
         )
         findings = prose_yaml.validate_prose_yaml("doc.md", text)
-        self.assertEqual(findings, [])
+        self.assertEqual(len(findings), 1)
+
+    def test_prose_block_between_dashes_not_stripped(self) -> None:
+        # A doc that starts with a thematic break ``---`` followed by
+        # plain prose and another ``---`` must not have that leading
+        # block silently stripped — ``parse_yaml_subset`` returns
+        # ``{}`` for prose, but an empty parsed mapping is not enough
+        # evidence that the block is real frontmatter.
+        text = (
+            "---\n"
+            "Just a paragraph, not YAML.\n"
+            "---\n"
+            "```yaml\n"
+            "bad: *alias\n"
+            "```\n"
+        )
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(len(findings), 1)
 
     def test_empty_frontmatter_is_stripped(self) -> None:
         # A ``---\\n---\\n`` block is still frontmatter for scope

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -1,6 +1,6 @@
 """Tests for ``lib/prose_yaml.py``.
 
-Matrix per IMPL-PLAN §4.7 / §4.2 / §4.3:
+Test matrix:
 - Known-good fence → no findings.
 - Divergent fence → expected divergence finding surfaces.
 - Strict-adjacency opt-out (both directions).
@@ -11,7 +11,7 @@ Matrix per IMPL-PLAN §4.7 / §4.2 / §4.3:
 - Column-0 ``` `` ` ``` inside block scalar terminates early.
 - Multi-fence ordinals monotonic.
 - CRLF markdown handled identically to LF.
-- Path with Windows-native separator → ``to_posix`` normalizes (G130).
+- Path with Windows-native separator → ``to_posix`` normalizes.
 """
 
 import os
@@ -104,7 +104,7 @@ class ExtractYamlFencesShapeTests(unittest.TestCase):
 
     def test_column_zero_backticks_inside_body_terminate_early(self) -> None:
         # ```yaml fence opens; the literal column-0 ``` inside the body
-        # terminates the block per CommonMark.  Documented limit (G13).
+        # terminates the block per CommonMark.  Documented limit.
         text = "```yaml\nliteral: |\n```\n  more\n```\n"
         records = prose_yaml.extract_yaml_fences(text)
         self.assertEqual(records[0]["state"], "parsed")
@@ -120,7 +120,7 @@ class ExtractYamlFencesShapeTests(unittest.TestCase):
 
 
 # ===================================================================
-# extract_yaml_fences — opt-out marker (§4.3)
+# extract_yaml_fences — opt-out marker
 # ===================================================================
 
 
@@ -235,7 +235,7 @@ class ValidateProseYamlTests(unittest.TestCase):
         self.assertEqual(findings[0]["block_ordinal"], 2)
 
     def test_file_path_echoed_verbatim(self) -> None:
-        # G120 — the function does not normalise paths; the caller does.
+        # The function does not normalise paths; the caller does.
         text = "```yaml\nbad: *alias\n```\n"
         findings = prose_yaml.validate_prose_yaml(
             "skill\\caps\\thing.md", text
@@ -259,7 +259,7 @@ class ReadAndValidateTests(unittest.TestCase):
         try:
             findings = prose_yaml.read_and_validate(path)
             self.assertEqual(len(findings), 1)
-            # G68 — file path is POSIX even when the OS uses backslashes.
+            # File path is POSIX even when the OS uses backslashes.
             self.assertNotIn("\\", findings[0]["file"])
         finally:
             os.unlink(path)

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -223,6 +223,21 @@ class ValidateProseYamlTests(unittest.TestCase):
             "synthetic structural failure", findings[0]["message"]
         )
 
+    def test_thematic_break_is_not_stripped_as_frontmatter(self) -> None:
+        # A Markdown thematic break (``---`` at column 0) at the top of
+        # a file must not be misread as frontmatter — otherwise an
+        # arbitrary chunk of the body would silently skip validation.
+        text = (
+            "---\n"
+            "\n"
+            "After the break, a divergent fence:\n"
+            "---\n"
+            "```yaml\nbad: *alias\n```\n"
+        )
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["block_ordinal"], 1)
+
     def test_frontmatter_yaml_fence_not_scanned(self) -> None:
         # A ```yaml fence embedded inside a folded description in the
         # frontmatter must not be validated as body content.

--- a/tests/test_prose_yaml.py
+++ b/tests/test_prose_yaml.py
@@ -223,6 +223,14 @@ class ValidateProseYamlTests(unittest.TestCase):
             "synthetic structural failure", findings[0]["message"]
         )
 
+    def test_frontmatter_with_no_body_is_treated_as_valid(self) -> None:
+        # A file where the closing ``---`` is the final line (no body
+        # content after it) is still a valid frontmatter block; it
+        # must not be mistaken for an unterminated block.
+        text = "---\nname: demo\n---\n"
+        findings = prose_yaml.validate_prose_yaml("doc.md", text)
+        self.assertEqual(findings, [])
+
     def test_unterminated_frontmatter_skips_prose_scan(self) -> None:
         # Malformed frontmatter (no closing ``---``) must not cause
         # fences inside that block to be validated as body content —

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -38,6 +38,12 @@ class ToPosixTests(unittest.TestCase):
     def test_empty_string_returns_empty(self) -> None:
         self.assertEqual(reporting.to_posix(""), "")
 
+    def test_windows_backslash_normalised_on_any_platform(self) -> None:
+        # Callers that cross a Windows/POSIX boundary (e.g. data read
+        # from a Windows-authored tool on a Linux runner) still get
+        # POSIX separators out.
+        self.assertEqual(reporting.to_posix("a\\b\\c"), "a/b/c")
+
 
 class ParseFindingStringTests(unittest.TestCase):
     """``parse_finding_string`` covers spec-tagged, untagged, and bad input."""

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -94,6 +94,12 @@ class ParseFindingStringTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             reporting.parse_finding_string("")
 
+    def test_unterminated_tag_raises(self) -> None:
+        # A body that starts with '[' but has no matching ']' is a
+        # malformed tag — producer bug — not an untagged message.
+        with self.assertRaises(ValueError):
+            reporting.parse_finding_string("FAIL: [spec malformed body")
+
 
 class ParseFindingStringRoundTripTests(unittest.TestCase):
     """Round-trip parser findings through ``parse_finding_string``."""

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -3,9 +3,9 @@
 Covers:
 - ``to_posix`` — separator replacement on POSIX-style and
   Windows-style inputs.
-- ``parse_finding_string`` — parser-finding-string round-trip per G54
-  and malformed-input rejection per G31.  Tag-agnostic handling per G81
-  is exercised with a synthetic unrecognized tag.
+- ``parse_finding_string`` — parser-finding-string round-trip and
+  malformed-input rejection.  Tag-agnostic handling is exercised with
+  a synthetic unrecognized tag.
 """
 
 import os
@@ -69,7 +69,7 @@ class ParseFindingStringTests(unittest.TestCase):
         self.assertEqual(result["message"], "plain message body")
 
     def test_unknown_tag_preserved_verbatim(self) -> None:
-        # G81 — helper is tag-agnostic; any bracketed token survives.
+        # The helper is tag-agnostic; any bracketed token survives.
         result = reporting.parse_finding_string(
             "FAIL: [platform] something happened"
         )
@@ -90,7 +90,7 @@ class ParseFindingStringTests(unittest.TestCase):
 
 
 class ParseFindingStringRoundTripTests(unittest.TestCase):
-    """G54 — round-trip parser findings through ``parse_finding_string``."""
+    """Round-trip parser findings through ``parse_finding_string``."""
 
     def test_known_divergent_input_round_trips(self) -> None:
         # Input crafted to trip multiple plain-scalar branches in

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,113 @@
+"""Tests for lib.reporting helpers.
+
+Covers:
+- ``to_posix`` — separator replacement on POSIX-style and
+  Windows-style inputs.
+- ``parse_finding_string`` — parser-finding-string round-trip per G54
+  and malformed-input rejection per G31.  Tag-agnostic handling per G81
+  is exercised with a synthetic unrecognized tag.
+"""
+
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "skill-system-foundry", "scripts")
+)
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib import reporting  # noqa: E402
+from lib.yaml_parser import parse_yaml_subset  # noqa: E402
+
+
+class ToPosixTests(unittest.TestCase):
+    """``to_posix`` rewrites the platform separator."""
+
+    def test_posix_input_unchanged(self) -> None:
+        self.assertEqual(
+            reporting.to_posix("a/b/c"),
+            "a/b/c",
+        )
+
+    def test_native_separator_replaced(self) -> None:
+        native = "a" + os.sep + "b" + os.sep + "c"
+        self.assertEqual(reporting.to_posix(native), "a/b/c")
+
+    def test_empty_string_returns_empty(self) -> None:
+        self.assertEqual(reporting.to_posix(""), "")
+
+
+class ParseFindingStringTests(unittest.TestCase):
+    """``parse_finding_string`` covers spec-tagged, untagged, and bad input."""
+
+    def test_fail_with_spec_tag(self) -> None:
+        raw = "FAIL: [spec] 'name': bad value; wrap value in single quotes"
+        result = reporting.parse_finding_string(raw)
+        self.assertEqual(result["severity"], "fail")
+        self.assertEqual(result["tag"], "[spec]")
+        self.assertEqual(
+            result["message"],
+            "'name': bad value; wrap value in single quotes",
+        )
+
+    def test_warn_with_spec_tag(self) -> None:
+        result = reporting.parse_finding_string(
+            "WARN: [spec] 'k': value warns"
+        )
+        self.assertEqual(result["severity"], "warn")
+        self.assertEqual(result["tag"], "[spec]")
+
+    def test_info_lowercased(self) -> None:
+        result = reporting.parse_finding_string("INFO: [spec] something")
+        self.assertEqual(result["severity"], "info")
+
+    def test_untagged_body_yields_empty_tag(self) -> None:
+        result = reporting.parse_finding_string("FAIL: plain message body")
+        self.assertEqual(result["tag"], "")
+        self.assertEqual(result["message"], "plain message body")
+
+    def test_unknown_tag_preserved_verbatim(self) -> None:
+        # G81 — helper is tag-agnostic; any bracketed token survives.
+        result = reporting.parse_finding_string(
+            "FAIL: [platform] something happened"
+        )
+        self.assertEqual(result["tag"], "[platform]")
+        self.assertEqual(result["message"], "something happened")
+
+    def test_missing_separator_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            reporting.parse_finding_string("no colon")
+
+    def test_unknown_severity_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            reporting.parse_finding_string("BAD: [spec] body")
+
+    def test_empty_string_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            reporting.parse_finding_string("")
+
+
+class ParseFindingStringRoundTripTests(unittest.TestCase):
+    """G54 — round-trip parser findings through ``parse_finding_string``."""
+
+    def test_known_divergent_input_round_trips(self) -> None:
+        # Input crafted to trip multiple plain-scalar branches in
+        # _check_plain_scalar so the findings list has several
+        # FAIL/WARN entries for the round-trip pass.
+        text = "a: [bad\nb: '\nc: ! tagged\n"
+        findings: list[str] = []
+        parse_yaml_subset(text, findings)
+        self.assertGreater(len(findings), 0)
+        for raw in findings:
+            parsed = reporting.parse_finding_string(raw)
+            # Severity reconstructs to the original token.
+            severity_upper = parsed["severity"].upper()
+            tag_chunk = (parsed["tag"] + " ") if parsed["tag"] else ""
+            reconstructed = f"{severity_upper}: {tag_chunk}{parsed['message']}"
+            self.assertEqual(reconstructed, raw)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2723,8 +2723,8 @@ class CodexFindingsJsonSchemaTests(unittest.TestCase):
         self.assertFalse(data["success"])
         self.assertIn("errors", data)
         # Schema preserved: known top-level keys plus the additive
-        # ``yaml_conformance`` slot from #93 (always present, zero
-        # sentinel when checks did not run).
+        # ``yaml_conformance`` slot (always present, zero sentinel when
+        # checks did not run).
         self.assertEqual(
             set(data.keys()),
             {

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2722,10 +2722,15 @@ class CodexFindingsJsonSchemaTests(unittest.TestCase):
             data = json.loads(proc.stdout)
         self.assertFalse(data["success"])
         self.assertIn("errors", data)
-        # Schema preserved: no new top-level keys introduced.
+        # Schema preserved: known top-level keys plus the additive
+        # ``yaml_conformance`` slot from #93 (always present, zero
+        # sentinel when checks did not run).
         self.assertEqual(
             set(data.keys()),
-            {"tool", "path", "type", "success", "summary", "errors", "version"},
+            {
+                "tool", "path", "type", "success", "summary",
+                "errors", "version", "yaml_conformance",
+            },
         )
         codex_fails = [
             entry for entry in data["errors"].get("failures", [])

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2875,6 +2875,22 @@ class CheckProseYamlIntegrationTests(unittest.TestCase):
         self.assertEqual(slot["checked"], 0)
         self.assertEqual(slot["findings"], [])
 
+    def test_capability_mode_surfaces_noop_info(self) -> None:
+        # --check-prose-yaml under --capability is a no-op by scope,
+        # but the caller must be told instead of silently dropping the
+        # request.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill = self._make_skill(tmpdir)
+            cap_dir = os.path.join(skill, "capabilities", "foo")
+            os.makedirs(cap_dir)
+            with open(os.path.join(cap_dir, "capability.md"), "w", encoding="utf-8") as fh:
+                fh.write("# Foo\n")
+            proc = _run(
+                [cap_dir, "--capability", "--check-prose-yaml"],
+                cwd=REPO_ROOT,
+            )
+        self.assertIn("--check-prose-yaml has no effect", proc.stdout)
+
     def test_scope_includes_capabilities_and_references(self) -> None:
         # The three globs are SKILL.md + capabilities/**/*.md +
         # references/**/*.md.  Plant a fence in each of the latter two.

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2803,5 +2803,104 @@ class CollectFoundryConfigFindingsTests(unittest.TestCase):
         self.assertEqual(findings, [])
 
 
+class CheckProseYamlIntegrationTests(unittest.TestCase):
+    """End-to-end behaviour of ``--check-prose-yaml`` and ``--foundry-self``."""
+
+    def _make_skill(self, tmpdir: str, *, body: str = "") -> str:
+        skill = os.path.join(tmpdir, "demo")
+        os.makedirs(skill)
+        from helpers import write_skill_md
+        write_skill_md(
+            skill,
+            name="demo",
+            description="Demo skill for prose-YAML integration tests.",
+            body=f"# Demo\n{body}",
+        )
+        return skill
+
+    def test_flag_off_ignores_divergent_fence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill = self._make_skill(
+                tmpdir, body="\n```yaml\nbad: *alias\n```\n"
+            )
+            proc = _run([skill], cwd=REPO_ROOT)
+        # With the flag off the divergent fence does not surface.
+        self.assertEqual(proc.returncode, 0)
+        self.assertNotIn("alias indicator", proc.stdout)
+
+    def test_flag_on_surfaces_divergent_fence(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill = self._make_skill(
+                tmpdir, body="\n```yaml\nbad: *alias\n```\n"
+            )
+            proc = _run([skill, "--check-prose-yaml"], cwd=REPO_ROOT)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("alias indicator", proc.stdout)
+        self.assertIn("block 1", proc.stdout)
+
+    def test_foundry_self_implies_prose_check(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill = self._make_skill(
+                tmpdir, body="\n```yaml\nbad: *alias\n```\n"
+            )
+            proc = _run([skill, "--foundry-self"], cwd=REPO_ROOT)
+        self.assertEqual(proc.returncode, 1)
+        self.assertIn("alias indicator", proc.stdout)
+
+    def test_warn_only_fence_is_zero_exit(self) -> None:
+        # Anchor in value position is WARN, not FAIL — exit code stays 0.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill = self._make_skill(
+                tmpdir, body="\n```yaml\nkey: &alias trailing\n```\n"
+            )
+            proc = _run([skill, "--check-prose-yaml"], cwd=REPO_ROOT)
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn("anchor name consumed", proc.stdout)
+
+    def test_scope_excludes_top_level_extras(self) -> None:
+        # CLAUDE.md, CHANGELOG.md, and assets/* are out of scope; a
+        # divergent fence in those files must not surface.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill = self._make_skill(tmpdir, body="\n# clean body\n")
+            for rel in ("CLAUDE.md", "CHANGELOG.md", "assets/note.md"):
+                path = os.path.join(skill, rel)
+                os.makedirs(os.path.dirname(path) or skill, exist_ok=True)
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write("```yaml\nout: *alias\n```\n")
+            proc = _run(
+                [skill, "--check-prose-yaml", "--json"], cwd=REPO_ROOT
+            )
+            data = json.loads(proc.stdout)
+        slot = data["yaml_conformance"]["doc_snippets"]
+        self.assertEqual(slot["checked"], 0)
+        self.assertEqual(slot["findings"], [])
+
+    def test_scope_includes_capabilities_and_references(self) -> None:
+        # The three globs are SKILL.md + capabilities/**/*.md +
+        # references/**/*.md.  Plant a fence in each of the latter two.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill = self._make_skill(tmpdir)
+            for rel in (
+                "capabilities/foo/capability.md",
+                "references/bar.md",
+            ):
+                path = os.path.join(skill, rel)
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write("```yaml\nbad: *alias\n```\n")
+            proc = _run(
+                [skill, "--check-prose-yaml", "--json"], cwd=REPO_ROOT
+            )
+            data = json.loads(proc.stdout)
+        files = {
+            f["file"]
+            for f in data["yaml_conformance"]["doc_snippets"]["findings"]
+        }
+        self.assertEqual(
+            files,
+            {"capabilities/foo/capability.md", "references/bar.md"},
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #92.

## Summary

Adds doc-snippet validation that extracts ` ```yaml ` fenced code blocks from in-scope Markdown and parses each via `parse_yaml_subset`, surfaced through new `--check-prose-yaml` and `--foundry-self` flags on `validate_skill.py` and `audit_skill_system.py`. No silent acceptance: every divergence guidance might teach reaches the user as a structured finding.

## What's new

**Library**
- `lib/prose_yaml.py` — `extract_yaml_fences(text)` → records with `{ordinal, text, state}` (states: `parsed`/`ignored`/`unterminated`/`wrong-case`); `validate_prose_yaml(file_path, text)` → structured findings; `read_and_validate(path)` convenience wrapper that propagates OS / decode errors. LF-normalises text on entry; record `text` is always LF-only.
- `lib/reporting.py` — `to_posix(path)` for platform-independent finding paths; `parse_finding_string(raw)` strict parser of the `"SEVERITY: [tag] body"` contract. Malformed input → `ValueError`.
- `lib/configuration.yaml` + `lib/constants.py` — new `prose_yaml` section (opt-out marker, in-scope globs); fail-fast `RuntimeError` at import if the section is missing.

**Entry points**
- `validate_skill.py --check-prose-yaml` (opt-in) and `--foundry-self` (implies `--check-prose-yaml`). `LEVEL_FAIL` → non-zero exit; `WARN`/`INFO` print only.
- `audit_skill_system.py` — same flags. `--foundry-self` is a mode switch across every scanned skill (not a target filter).
- Verbose: per-file `Checking prose YAML: <file> (<N> fences)` message.
- `--help` text on both entry points points to `references/authoring-principles.md` for the convention.

**JSON output** — new `yaml_conformance` top-level peer of `errors` / `warnings`, both slots always present:

```json
{
  "yaml_conformance": {
    "corpus": {"total": 0, "passed": 0, "failed": 0, "failures": []},
    "doc_snippets": {"checked": <int>, "findings": [...]}
  }
}
```

`corpus` is a zero-sentinel here. Audit mode produces a flat `doc_snippets.findings[]` across skills with `<skill-root>/<relative-path>` prefixes. All paths use POSIX separators on every platform.

**Infrastructure**
- `.github/scripts/check-per-file-coverage.py` extended with repeatable `--file-threshold PATH=PCT` so `prose_yaml.py` is held to a 90% bar while the repo floor stays at 70%.
- `.github/workflows/python-tests.yaml` invokes the override on Ubuntu (Windows coverage stays advisory).

**Documentation**
- `references/authoring-principles.md` — new "Counter-example convention" section (opt-out marker, fence shape rules, column-0 backtick guidance, commented-out fence limit) and a new "Line wrapping" rule (one paragraph = one logical line; defer wrapping to the renderer).
- `capabilities/validation/capability.md` — flag docs and cross-reference to the convention.
- `CLAUDE.md` — flag-behavior table (`--check-prose-yaml`, `--foundry-self`, `--allow-nested-references`, `--verbose`).
- `.github/instructions/markdown.instructions.md` — review guidance for the convention plus the line-wrapping rule.
- `.agents/skills/markdown-docs/SKILL.md` — internal skill picks up the line-wrapping rule.

## Key decisions

- **Strict fence shape**: backticks-only, exactly three, lowercase `yaml`, no whitespace before the language token, opener at byte offset 0. Tilde / 4-backtick / indented fences are invisible. `yml`/`YAML`/`Yaml` surface as `INFO` "did you mean 'yaml'?".
- **Strict-adjacency opt-out**: `<!-- yaml-ignore -->` must be the line immediately above the fence-open line, no blank line between. Ignored fences advance `block_ordinal` but not `checked` so ordinal numbering stays stable across marker edits.
- **`parse_finding_string` is strict, not lenient** — malformed input raises `ValueError`. Round-trip test pins the producer/consumer contract.
- **POSIX paths in finding `file` fields** so JSON output is byte-identical across CI matrix combinations.
- **Coverage thresholds enforced on Ubuntu only**; Windows is advisory.

## Pre-merge gates

- [x] `validate_skill.py . --allow-nested-references --foundry-self` exits 0 (foundry self-validation includes the 4 existing in-scope fences; doubles as the fix-up check).
- [x] `prose_yaml.py` ≥ 90% branch coverage.
- [x] Repo floor ≥ 70% branch coverage.

## Test plan

- [x] Unit: known-good fence → no findings
- [x] Unit: known-divergent fence → finding with correct file + ordinal
- [x] Unit: `<!-- yaml-ignore -->` adjacent → skipped, ordinal stable
- [x] Unit: `<!-- yaml-ignore -->` with blank line → NOT skipped (strict adjacency)
- [x] Unit: `yml`/`YAML`/`Yaml` → `INFO` finding, content not parsed
- [x] Unit: tilde, 4+ backtick, indented fences → invisible
- [x] Unit: unterminated fence → FAIL finding at the right ordinal
- [x] Unit: empty fence → parses to `{}`, counted in `checked` and `block_ordinal`
- [x] Unit: column-0 backtick inside block scalar → terminates early (documented limit)
- [x] Unit: multiple fences per file → ordinals monotonic 1-based
- [x] Unit: CRLF markdown source → handled identically to LF
- [x] Unit: `parse_finding_string` round-trip on real divergent findings + malformed-input `ValueError` paths
- [x] Unit: `to_posix` converts Windows-native separator in findings
- [x] Integration: flag matrix (`--check-prose-yaml` off/on, `--foundry-self` on foundry/non-foundry, FAIL → non-zero exit, WARN-only → zero exit)
- [x] Integration: scope correctness — `CLAUDE.md` / `CHANGELOG.md` / `assets/` NOT scanned; `capabilities/**/*.md` and `references/**/*.md` ARE scanned
- [x] Integration: audit mode aggregates findings with `skills/<name>/` prefix; mode-switch runs across every scanned skill
- [x] JSON: `yaml_conformance` slot shape with zero-sentinel defaults; integer types on numeric fields
- [x] Self-validation: foundry exits clean with `--foundry-self`
- [x] CI matrix passes on both ubuntu-latest and windows-latest with Python 3.12