### PR TITLE
Add end-to-end integration smoke test for authoring and release pipelines

### DIFF
--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -42,10 +42,14 @@ This is the single source of truth for the current version. Git tags mirror it a
 Confirm the release gate is green on `main` for the commit being tagged **before** publishing the release. `release.yml` triggers on `release: published` and does not run tests; `python-tests.yaml` on `main` is the only workflow that gates a release — `shellcheck.yaml` and `codex-code-review.yaml` are advisory and can be red at release time. Check the gate via the GitHub Actions UI or:
 
 ```bash
-gh run list --workflow python-tests.yaml --branch main --limit 1
+# Latest python-tests.yaml run on main — conclusion must be success
+# and headSha must match the commit you are about to tag.
+gh run list --workflow python-tests.yaml --branch main --limit 1 \
+  --json conclusion,headSha,databaseId,displayTitle
+git rev-parse main
 ```
 
-Do not publish a release until the latest `main` run of `python-tests.yaml` is green. This is a procedural gate, not a workflow gate.
+Do not publish a release unless the latest `main` run of `python-tests.yaml` is green **and** its `headSha` equals the commit being tagged. If `main` has advanced past the commit you intend to release, either wait for the run on the newer tip to finish (and retarget the tag to that tip), or re-run the workflow on the exact commit via `gh run rerun <databaseId>`. This is a procedural gate, not a workflow gate.
 
 Then run validation and tests locally to confirm the codebase is clean:
 

--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -39,13 +39,13 @@ This is the single source of truth for the current version. Git tags mirror it a
 
 ### Step 1: Verify Pre-Release State
 
-Confirm CI is green on `main` for the commit being tagged **before** publishing the release. The `release.yml` workflow triggers on `release: published` and does not run tests — `python-tests.yaml` on `main` is the gate. Check it via the GitHub Actions UI or:
+Confirm the release gate is green on `main` for the commit being tagged **before** publishing the release. `release.yml` triggers on `release: published` and does not run tests; `python-tests.yaml` on `main` is the only workflow that gates a release — `shellcheck.yaml` and `codex-code-review.yaml` are advisory and can be red at release time. Check the gate via the GitHub Actions UI or:
 
 ```bash
 gh run list --workflow python-tests.yaml --branch main --limit 1
 ```
 
-Do not publish a release until the latest `main` run is green. This is a procedural gate, not a workflow gate.
+Do not publish a release until the latest `main` run of `python-tests.yaml` is green. This is a procedural gate, not a workflow gate.
 
 Then run validation and tests locally to confirm the codebase is clean:
 

--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -39,7 +39,15 @@ This is the single source of truth for the current version. Git tags mirror it a
 
 ### Step 1: Verify Pre-Release State
 
-Run validation and tests to confirm the codebase is clean:
+Confirm CI is green on `main` for the commit being tagged **before** publishing the release. The `release.yml` workflow triggers on `release: published` and does not run tests — `python-tests.yaml` on `main` is the gate. Check it via the GitHub Actions UI or:
+
+```bash
+gh run list --workflow python-tests.yaml --branch main --limit 1
+```
+
+Do not publish a release until the latest `main` run is green. This is a procedural gate, not a workflow gate.
+
+Then run validation and tests locally to confirm the codebase is clean:
 
 ```bash
 # Self-validate the meta-skill
@@ -56,7 +64,7 @@ python -m coverage run -m unittest discover -s tests -p "test_*.py" -v
 python -m coverage report
 ```
 
-All validation checks must pass (zero failures). Coverage must meet the 70% threshold configured in `.coveragerc`.
+All validation checks must pass (zero failures). Coverage must meet the 70% threshold configured in `.coveragerc`. The suite includes an end-to-end integration smoke test (`tests/test_integration_pipeline.py`) that guards both the `scaffold → validate → bundle → unzip → validate` authoring pipeline and the `zip -r` release artifact shape.
 
 ### Step 2: Bump the Version
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,19 +1,7 @@
 import os
-import subprocess
 
 
 DEFAULT_DESCRIPTION = "Packages a minimal demo skill for bundling smoke tests."
-
-
-def run_script(argv: list[str], *, cwd: str | None = None) -> subprocess.CompletedProcess:
-    """Run *argv* as a subprocess in *cwd* and capture stdout/stderr as text.
-
-    Shared helper for subprocess-style CLI tests so scaffold / bundle /
-    validate invocations don't re-duplicate ``subprocess.run`` boilerplate.
-    Callers are responsible for choosing ``argv[0]`` (typically
-    ``sys.executable`` for the in-repo Python scripts).
-    """
-    return subprocess.run(argv, cwd=cwd, capture_output=True, text=True)
 
 
 def write_text(path: str, content: str) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,10 +6,12 @@ DEFAULT_DESCRIPTION = "Packages a minimal demo skill for bundling smoke tests."
 
 
 def run_script(argv: list[str], *, cwd: str | None = None) -> subprocess.CompletedProcess:
-    """Run *argv* under the current Python interpreter and capture output.
+    """Run *argv* as a subprocess in *cwd* and capture stdout/stderr as text.
 
     Shared helper for subprocess-style CLI tests so scaffold / bundle /
     validate invocations don't re-duplicate ``subprocess.run`` boilerplate.
+    Callers are responsible for choosing ``argv[0]`` (typically
+    ``sys.executable`` for the in-repo Python scripts).
     """
     return subprocess.run(argv, cwd=cwd, capture_output=True, text=True)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,17 @@
 import os
+import subprocess
 
 
 DEFAULT_DESCRIPTION = "Packages a minimal demo skill for bundling smoke tests."
+
+
+def run_script(argv: list[str], *, cwd: str | None = None) -> subprocess.CompletedProcess:
+    """Run *argv* under the current Python interpreter and capture output.
+
+    Shared helper for subprocess-style CLI tests so scaffold / bundle /
+    validate invocations don't re-duplicate ``subprocess.run`` boilerplate.
+    """
+    return subprocess.run(argv, cwd=cwd, capture_output=True, text=True)
 
 
 def write_text(path: str, content: str) -> None:

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -1,17 +1,27 @@
 """End-to-end integration smoke tests for the authoring and release pipelines.
 
-Two cases live here:
+Three cases live here:
 
-- ``ScaffoldBundlePipelineTests`` — scaffold a standalone skill, validate it,
-  patch its frontmatter the way a real author would, bundle it, unzip the
-  bundle into a clean temp dir, and revalidate. Guards the user-facing
-  authoring flow driven by ``scaffold.py`` and ``bundle.py``.
+- ``ScaffoldBundlePipelineTests.test_standalone_skill_round_trip`` —
+  scaffold a standalone skill, validate it, patch its frontmatter the way
+  a real author would, bundle it with the default ``--target claude``,
+  unzip the bundle into a clean temp dir, and revalidate. Guards the
+  user-facing authoring flow driven by ``scaffold.py`` and ``bundle.py``
+  for the platform with the tightest limit.
 
-- ``ReleaseArtifactPipelineTests`` — mirror what ``.github/workflows/release.yml``
-  actually ships (a raw zip of ``skill-system-foundry/``), unzip on a clean
-  path, and validate with the same flags the foundry uses to validate
-  itself. Guards the release artifact, which is produced by ``zip -r`` and
-  is not covered by the ``bundle.py`` path.
+- ``ScaffoldBundlePipelineTests.test_generic_target_accepts_raw_scaffold_output`` —
+  same pipeline without the frontmatter patch, bundled with
+  ``--target generic``. Proves that at least one supported target path
+  works end-to-end on the unmodified scaffold output and keeps the
+  known ``--target claude`` UX gap from hiding a generic-target
+  regression.
+
+- ``ReleaseArtifactPipelineTests`` — mirror what
+  ``.github/workflows/release.yml`` actually ships (a raw zip of
+  ``skill-system-foundry/``), unzip on a clean path, and validate with
+  the same flags the foundry uses to validate itself. Guards the
+  release artifact, which is produced by ``zip -r`` and is not covered
+  by the ``bundle.py`` path.
 
 Subprocess + ``tempfile.TemporaryDirectory`` + stdlib ``zipfile`` —
 matches the conventions in ``test_scaffold_cli.py`` and
@@ -26,6 +36,8 @@ import tempfile
 import unittest
 import zipfile
 
+from helpers import run_script
+
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 SCRIPTS_DIR = os.path.join(REPO_ROOT, "skill-system-foundry", "scripts")
@@ -36,12 +48,7 @@ FOUNDRY_DIR = os.path.join(REPO_ROOT, "skill-system-foundry")
 
 
 def _run(argv: list[str]) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        argv,
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-    )
+    return run_script(argv, cwd=REPO_ROOT)
 
 
 def _assert_ok(test: unittest.TestCase, proc: subprocess.CompletedProcess) -> None:
@@ -52,16 +59,69 @@ def _assert_ok(test: unittest.TestCase, proc: subprocess.CompletedProcess) -> No
     )
 
 
+def _scaffold_standalone(system_root: str, skill_name: str) -> str:
+    """Scaffold a standalone skill into *system_root* and return its directory."""
+    proc = _run([
+        sys.executable, SCAFFOLD_SCRIPT,
+        "skill", skill_name,
+        "--root", system_root,
+        "--update-manifest",
+    ])
+    assert proc.returncode == 0, f"scaffold failed: {proc.stdout}\n{proc.stderr}"
+    return os.path.join(system_root, "skills", skill_name)
+
+
+def _bundle_and_extract(
+    test: unittest.TestCase,
+    skill_dir: str,
+    skill_name: str,
+    system_root: str,
+    target: str,
+) -> None:
+    """Bundle *skill_dir* with *target* and revalidate the extracted copy."""
+    bundle_zip = os.path.join(system_root, f"{skill_name}-{target}.zip")
+    bundle = _run([
+        sys.executable, BUNDLE_SCRIPT, skill_dir,
+        "--output", bundle_zip,
+        "--target", target,
+    ])
+    _assert_ok(test, bundle)
+    test.assertTrue(os.path.isfile(bundle_zip))
+
+    with tempfile.TemporaryDirectory() as extract_root:
+        with zipfile.ZipFile(bundle_zip) as zf:
+            zf.extractall(extract_root)
+
+        entries = os.listdir(extract_root)
+        test.assertIn(
+            skill_name, entries,
+            msg=f"extracted bundle missing top-level {skill_name}/ dir; got {entries}",
+        )
+        extracted_skill = os.path.join(extract_root, skill_name)
+        test.assertTrue(
+            os.path.isfile(os.path.join(extracted_skill, "SKILL.md")),
+            msg=f"extracted bundle missing SKILL.md: {extracted_skill}",
+        )
+
+        validate_extracted = _run([
+            sys.executable, VALIDATE_SCRIPT, extracted_skill,
+        ])
+        _assert_ok(test, validate_extracted)
+
+
 # Short, realistic SKILL.md that a downstream author would produce
 # after editing the scaffold output. Must fit under the Claude bundle
 # description limit (200 chars) so bundle.py --target claude passes.
 #
 # Known UX gap: the raw scaffold template ships a 317-char placeholder
 # description that fails `bundle.py --target claude` out of the box. A
-# first-time user running scaffold -> bundle hits the 200-char failure
-# with no guidance. This test patches around it to exercise the full
-# pipeline; shortening the placeholder in assets/skill-standalone.md
-# is the real fix and belongs in a separate change.
+# first-time user running scaffold -> bundle with the default target
+# hits the 200-char failure with no guidance. This test patches around
+# it to exercise the full default-target pipeline; shortening the
+# placeholder in ``skill-system-foundry/assets/skill-standalone.md``
+# is the real fix and belongs in a separate change. The companion test
+# ``test_generic_target_accepts_raw_scaffold_output`` below proves the
+# non-default target paths do not hit this wall, scoping the gap.
 _PATCHED_SKILL_MD = """---
 name: {name}
 description: >
@@ -86,37 +146,27 @@ Follow the normal skill lifecycle: scaffold, edit, validate, bundle.
 
 
 class ScaffoldBundlePipelineTests(unittest.TestCase):
-    """scaffold -> validate -> (edit frontmatter) -> bundle -> unzip -> validate."""
+    """scaffold -> validate -> bundle -> unzip -> validate, across targets."""
 
     def test_standalone_skill_round_trip(self) -> None:
+        """Default --target claude, with the realistic author-edit step."""
         skill_name = "pipeline-demo"
 
         with tempfile.TemporaryDirectory() as system_root:
-            scaffold = _run([
-                sys.executable, SCAFFOLD_SCRIPT,
-                "skill", skill_name,
-                "--root", system_root,
-                "--update-manifest",
-            ])
-            _assert_ok(self, scaffold)
-
-            skill_dir = os.path.join(system_root, "skills", skill_name)
+            skill_dir = _scaffold_standalone(system_root, skill_name)
             self.assertTrue(os.path.isdir(skill_dir))
             self.assertTrue(
                 os.path.isfile(os.path.join(system_root, "manifest.yaml")),
                 msg="--update-manifest should have produced manifest.yaml",
             )
 
-            validate_scaffolded = _run([
+            _assert_ok(self, _run([
                 sys.executable, VALIDATE_SCRIPT, skill_dir,
-            ])
-            _assert_ok(self, validate_scaffolded)
+            ]))
 
             # Simulate the author filling in the template placeholders
-            # before distribution. The raw scaffold output carries a
-            # 317-char placeholder description that fails bundle.py's
-            # Claude 200-char limit — real users always edit before
-            # bundling, and this is the minimal patch that mirrors that.
+            # before distribution — see _PATCHED_SKILL_MD module-level
+            # comment for the UX-gap context.
             skill_md_path = os.path.join(skill_dir, "SKILL.md")
             with open(skill_md_path, "w", encoding="utf-8") as f:
                 f.write(_PATCHED_SKILL_MD.format(
@@ -124,38 +174,33 @@ class ScaffoldBundlePipelineTests(unittest.TestCase):
                     title=skill_name.replace("-", " ").title(),
                 ))
 
-            validate_edited = _run([
+            _assert_ok(self, _run([
                 sys.executable, VALIDATE_SCRIPT, skill_dir,
-            ])
-            _assert_ok(self, validate_edited)
+            ]))
 
-            bundle_zip = os.path.join(system_root, f"{skill_name}.zip")
-            bundle = _run([
-                sys.executable, BUNDLE_SCRIPT, skill_dir,
-                "--output", bundle_zip,
-            ])
-            _assert_ok(self, bundle)
-            self.assertTrue(os.path.isfile(bundle_zip))
+            _bundle_and_extract(
+                self, skill_dir, skill_name, system_root, target="claude",
+            )
 
-            with tempfile.TemporaryDirectory() as extract_root:
-                with zipfile.ZipFile(bundle_zip) as zf:
-                    zf.extractall(extract_root)
+    def test_generic_target_accepts_raw_scaffold_output(self) -> None:
+        """--target generic must bundle the unmodified scaffold output.
 
-                entries = os.listdir(extract_root)
-                self.assertIn(
-                    skill_name, entries,
-                    msg=f"extracted bundle missing top-level {skill_name}/ dir; got {entries}",
-                )
-                extracted_skill = os.path.join(extract_root, skill_name)
-                self.assertTrue(
-                    os.path.isfile(os.path.join(extracted_skill, "SKILL.md")),
-                    msg=f"extracted bundle missing SKILL.md: {extracted_skill}",
-                )
+        Scopes the default-target UX gap and guards against a regression
+        that would flip the 200-char limit from warning to error on the
+        non-default targets.
+        """
+        skill_name = "pipeline-demo-generic"
 
-                validate_extracted = _run([
-                    sys.executable, VALIDATE_SCRIPT, extracted_skill,
-                ])
-                _assert_ok(self, validate_extracted)
+        with tempfile.TemporaryDirectory() as system_root:
+            skill_dir = _scaffold_standalone(system_root, skill_name)
+
+            _assert_ok(self, _run([
+                sys.executable, VALIDATE_SCRIPT, skill_dir,
+            ]))
+
+            _bundle_and_extract(
+                self, skill_dir, skill_name, system_root, target="generic",
+            )
 
 
 class ReleaseArtifactPipelineTests(unittest.TestCase):

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -87,9 +87,18 @@ def _bundle_and_extract(
 
 
 # The exact folded-scalar description block that ``scaffold.py`` emits
-# into SKILL.md. Kept as a literal so the surgical patch below fails
-# loudly (with "placeholder not found") if the template drifts, rather
-# than silently no-op'ing. See ``skill-system-foundry/assets/skill-standalone.md``.
+# into SKILL.md, copied byte-for-byte from
+# ``skill-system-foundry/assets/skill-standalone.md`` (lines 3-8).
+#
+# Duplication is deliberate: editing the asset template's placeholder
+# description is expected to require a synchronized update here. The
+# trade-off is explicit literal coupling (maintenance cost) in exchange
+# for a loud, self-documenting failure when the template drifts — the
+# surgical patch below raises ``assertIn`` with a pointer to this
+# constant, rather than silently no-op'ing the replacement. A
+# programmatic extraction from the asset file would avoid the
+# duplication but would silently accept any new-shape placeholder,
+# defeating the drift detector.
 _TEMPLATE_DESCRIPTION_BLOCK = (
     "description: >\n"
     "  <Description of what this skill does and when to trigger it.\n"

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -23,7 +23,15 @@ FOUNDRY_DIR = os.path.join(REPO_ROOT, "skill-system-foundry")
 
 
 def _run(argv: list[str]) -> subprocess.CompletedProcess:
-    return subprocess.run(argv, cwd=REPO_ROOT, capture_output=True, text=True)
+    # Enforce UTF-8 in the child so bundle.py's ✓/✗/⚠ and
+    # validate_skill.py's → don't trip UnicodeEncodeError on the
+    # Windows matrix cell's cp1252 default console encoding.
+    env = os.environ.copy()
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    return subprocess.run(
+        argv, cwd=REPO_ROOT, capture_output=True, text=True, env=env,
+    )
 
 
 def _assert_ok(test: unittest.TestCase, proc: subprocess.CompletedProcess) -> None:

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -237,7 +237,11 @@ class ReleaseArtifactPipelineTests(unittest.TestCase):
                         if filename.endswith(".pyc"):
                             continue
                         abs_path = os.path.join(dirpath, filename)
-                        arcname = os.path.relpath(abs_path, REPO_ROOT)
+                        # `zip -r` on the ubuntu release runner writes
+                        # POSIX-separated entry names. Normalizing here
+                        # keeps the Windows matrix cell faithful to the
+                        # real release artifact shape.
+                        arcname = os.path.relpath(abs_path, REPO_ROOT).replace(os.sep, "/")
                         zf.write(abs_path, arcname)
 
             # Mirror release.yml's "Verify bundle excludes yaml-conformance

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -59,7 +59,9 @@ def _assert_ok(test: unittest.TestCase, proc: subprocess.CompletedProcess) -> No
     )
 
 
-def _scaffold_standalone(system_root: str, skill_name: str) -> str:
+def _scaffold_standalone(
+    test: unittest.TestCase, system_root: str, skill_name: str,
+) -> str:
     """Scaffold a standalone skill into *system_root* and return its directory."""
     proc = _run([
         sys.executable, SCAFFOLD_SCRIPT,
@@ -67,7 +69,7 @@ def _scaffold_standalone(system_root: str, skill_name: str) -> str:
         "--root", system_root,
         "--update-manifest",
     ])
-    assert proc.returncode == 0, f"scaffold failed: {proc.stdout}\n{proc.stderr}"
+    _assert_ok(test, proc)
     return os.path.join(system_root, "skills", skill_name)
 
 
@@ -153,7 +155,7 @@ class ScaffoldBundlePipelineTests(unittest.TestCase):
         skill_name = "pipeline-demo"
 
         with tempfile.TemporaryDirectory() as system_root:
-            skill_dir = _scaffold_standalone(system_root, skill_name)
+            skill_dir = _scaffold_standalone(self, system_root, skill_name)
             self.assertTrue(os.path.isdir(skill_dir))
             self.assertTrue(
                 os.path.isfile(os.path.join(system_root, "manifest.yaml")),
@@ -192,7 +194,7 @@ class ScaffoldBundlePipelineTests(unittest.TestCase):
         skill_name = "pipeline-demo-generic"
 
         with tempfile.TemporaryDirectory() as system_root:
-            skill_dir = _scaffold_standalone(system_root, skill_name)
+            skill_dir = _scaffold_standalone(self, system_root, skill_name)
 
             _assert_ok(self, _run([
                 sys.executable, VALIDATE_SCRIPT, skill_dir,
@@ -223,10 +225,13 @@ class ReleaseArtifactPipelineTests(unittest.TestCase):
 
             # Stdlib zipfile mirrors `zip -r` semantics and works on
             # Windows matrix cells where the `zip` CLI is absent.
-            # __pycache__ and .pyc files are pruned so the local run
+            # Bytecode (__pycache__/, *.pyc) is pruned so the local run
             # matches release.yml's fresh-checkout shape; otherwise a
             # developer's stale bytecode would diverge from the real
-            # release artifact and could mask a regression.
+            # release artifact and could mask a regression. IDE / OS
+            # scratch files (.DS_Store, Thumbs.db, .idea/, .vscode/)
+            # are not filtered — release.yml's `zip -r` would include
+            # them too, so the test stays faithful to that behaviour.
             with zipfile.ZipFile(artifact, "w", zipfile.ZIP_DEFLATED) as zf:
                 for dirpath, dirnames, filenames in os.walk(FOUNDRY_DIR):
                     if "__pycache__" in dirnames:

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -1,0 +1,201 @@
+"""End-to-end integration smoke tests for the authoring and release pipelines.
+
+Two cases live here:
+
+- ``ScaffoldBundlePipelineTests`` — scaffold a standalone skill, validate it,
+  patch its frontmatter the way a real author would, bundle it, unzip the
+  bundle into a clean temp dir, and revalidate. Guards the user-facing
+  authoring flow driven by ``scaffold.py`` and ``bundle.py``.
+
+- ``ReleaseArtifactPipelineTests`` — mirror what ``.github/workflows/release.yml``
+  actually ships (a raw zip of ``skill-system-foundry/``), unzip on a clean
+  path, and validate with the same flags the foundry uses to validate
+  itself. Guards the release artifact, which is produced by ``zip -r`` and
+  is not covered by the ``bundle.py`` path.
+
+Subprocess + ``tempfile.TemporaryDirectory`` + stdlib ``zipfile`` —
+matches the conventions in ``test_scaffold_cli.py`` and
+``test_bundle_cli.py``. Runs on the ubuntu + windows matrix in
+``python-tests.yaml`` without any workflow changes.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+import zipfile
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SCRIPTS_DIR = os.path.join(REPO_ROOT, "skill-system-foundry", "scripts")
+SCAFFOLD_SCRIPT = os.path.join(SCRIPTS_DIR, "scaffold.py")
+VALIDATE_SCRIPT = os.path.join(SCRIPTS_DIR, "validate_skill.py")
+BUNDLE_SCRIPT = os.path.join(SCRIPTS_DIR, "bundle.py")
+FOUNDRY_DIR = os.path.join(REPO_ROOT, "skill-system-foundry")
+
+
+def _run(argv: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        argv,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _assert_ok(test: unittest.TestCase, proc: subprocess.CompletedProcess) -> None:
+    test.assertEqual(
+        proc.returncode,
+        0,
+        msg=f"exit={proc.returncode}\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}",
+    )
+
+
+# Short, realistic SKILL.md that a downstream author would produce
+# after editing the scaffold output. Must fit under the Claude bundle
+# description limit (200 chars) so bundle.py --target claude passes.
+_PATCHED_SKILL_MD = """---
+name: {name}
+description: >
+  Processes integration smoke test inputs. Triggers when verifying the
+  scaffold to bundle pipeline end to end.
+license: MIT
+metadata:
+  author: Integration Test
+  version: 1.0.0
+---
+
+# {title}
+
+## Purpose
+
+Minimal standalone skill used by the integration pipeline smoke test.
+
+## Instructions
+
+Follow the normal skill lifecycle: scaffold, edit, validate, bundle.
+"""
+
+
+class ScaffoldBundlePipelineTests(unittest.TestCase):
+    """scaffold -> validate -> (edit frontmatter) -> bundle -> unzip -> validate."""
+
+    def test_standalone_skill_round_trip(self) -> None:
+        skill_name = "pipeline-demo"
+
+        with tempfile.TemporaryDirectory() as system_root:
+            scaffold = _run([
+                sys.executable, SCAFFOLD_SCRIPT,
+                "skill", skill_name,
+                "--root", system_root,
+                "--update-manifest",
+            ])
+            _assert_ok(self, scaffold)
+
+            skill_dir = os.path.join(system_root, "skills", skill_name)
+            self.assertTrue(os.path.isdir(skill_dir))
+            self.assertTrue(
+                os.path.isfile(os.path.join(system_root, "manifest.yaml")),
+                msg="--update-manifest should have produced manifest.yaml",
+            )
+
+            validate_scaffolded = _run([
+                sys.executable, VALIDATE_SCRIPT, skill_dir,
+            ])
+            _assert_ok(self, validate_scaffolded)
+
+            # Simulate the author filling in the template placeholders
+            # before distribution. The raw scaffold output carries a
+            # 317-char placeholder description that fails bundle.py's
+            # Claude 200-char limit — real users always edit before
+            # bundling, and this is the minimal patch that mirrors that.
+            skill_md_path = os.path.join(skill_dir, "SKILL.md")
+            with open(skill_md_path, "w", encoding="utf-8") as f:
+                f.write(_PATCHED_SKILL_MD.format(
+                    name=skill_name,
+                    title=skill_name.replace("-", " ").title(),
+                ))
+
+            validate_edited = _run([
+                sys.executable, VALIDATE_SCRIPT, skill_dir,
+            ])
+            _assert_ok(self, validate_edited)
+
+            bundle_zip = os.path.join(system_root, f"{skill_name}.zip")
+            bundle = _run([
+                sys.executable, BUNDLE_SCRIPT, skill_dir,
+                "--output", bundle_zip,
+            ])
+            _assert_ok(self, bundle)
+            self.assertTrue(os.path.isfile(bundle_zip))
+
+            with tempfile.TemporaryDirectory() as extract_root:
+                with zipfile.ZipFile(bundle_zip) as zf:
+                    zf.extractall(extract_root)
+
+                entries = os.listdir(extract_root)
+                self.assertEqual(
+                    len(entries), 1,
+                    msg=f"expected single top-level entry, got {entries}",
+                )
+                extracted_skill = os.path.join(extract_root, entries[0])
+                self.assertTrue(
+                    os.path.isfile(os.path.join(extracted_skill, "SKILL.md")),
+                    msg=f"extracted bundle missing SKILL.md: {extracted_skill}",
+                )
+
+                validate_extracted = _run([
+                    sys.executable, VALIDATE_SCRIPT, extracted_skill,
+                ])
+                _assert_ok(self, validate_extracted)
+
+
+class ReleaseArtifactPipelineTests(unittest.TestCase):
+    """Mirror release.yml's `zip -r skill-system-foundry/` artifact.
+
+    release.yml does not run bundle.py — it ships a raw zip of the
+    skill directory. This test guards that specific artifact shape
+    against the same "unzip and validate on a clean machine" regression
+    the bundle pipeline case guards for user skills.
+    """
+
+    def test_released_artifact_unzips_and_validates(self) -> None:
+        self.assertTrue(
+            os.path.isdir(FOUNDRY_DIR),
+            msg=f"expected foundry dir at {FOUNDRY_DIR}",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact = os.path.join(tmpdir, "skill-system-foundry.zip")
+
+            # Stdlib zipfile mirrors `zip -r` semantics and works on
+            # Windows matrix cells where the `zip` CLI is absent.
+            with zipfile.ZipFile(artifact, "w", zipfile.ZIP_DEFLATED) as zf:
+                for dirpath, _dirnames, filenames in os.walk(FOUNDRY_DIR):
+                    for filename in filenames:
+                        abs_path = os.path.join(dirpath, filename)
+                        arcname = os.path.relpath(abs_path, REPO_ROOT)
+                        zf.write(abs_path, arcname)
+
+            extract_root = os.path.join(tmpdir, "extracted")
+            os.makedirs(extract_root)
+            with zipfile.ZipFile(artifact) as zf:
+                zf.extractall(extract_root)
+
+            extracted_skill = os.path.join(extract_root, "skill-system-foundry")
+            self.assertTrue(
+                os.path.isfile(os.path.join(extracted_skill, "SKILL.md")),
+                msg=f"extracted release artifact missing SKILL.md at {extracted_skill}",
+            )
+
+            validate = _run([
+                sys.executable, VALIDATE_SCRIPT, extracted_skill,
+                "--allow-nested-references",
+                "--foundry-self",
+            ])
+            _assert_ok(self, validate)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -55,6 +55,13 @@ def _assert_ok(test: unittest.TestCase, proc: subprocess.CompletedProcess) -> No
 # Short, realistic SKILL.md that a downstream author would produce
 # after editing the scaffold output. Must fit under the Claude bundle
 # description limit (200 chars) so bundle.py --target claude passes.
+#
+# Known UX gap: the raw scaffold template ships a 317-char placeholder
+# description that fails `bundle.py --target claude` out of the box. A
+# first-time user running scaffold -> bundle hits the 200-char failure
+# with no guidance. This test patches around it to exercise the full
+# pipeline; shortening the placeholder in assets/skill-standalone.md
+# is the real fix and belongs in a separate change.
 _PATCHED_SKILL_MD = """---
 name: {name}
 description: >
@@ -135,11 +142,11 @@ class ScaffoldBundlePipelineTests(unittest.TestCase):
                     zf.extractall(extract_root)
 
                 entries = os.listdir(extract_root)
-                self.assertEqual(
-                    len(entries), 1,
-                    msg=f"expected single top-level entry, got {entries}",
+                self.assertIn(
+                    skill_name, entries,
+                    msg=f"extracted bundle missing top-level {skill_name}/ dir; got {entries}",
                 )
-                extracted_skill = os.path.join(extract_root, entries[0])
+                extracted_skill = os.path.join(extract_root, skill_name)
                 self.assertTrue(
                     os.path.isfile(os.path.join(extracted_skill, "SKILL.md")),
                     msg=f"extracted bundle missing SKILL.md: {extracted_skill}",
@@ -171,9 +178,17 @@ class ReleaseArtifactPipelineTests(unittest.TestCase):
 
             # Stdlib zipfile mirrors `zip -r` semantics and works on
             # Windows matrix cells where the `zip` CLI is absent.
+            # __pycache__ and .pyc files are pruned so the local run
+            # matches release.yml's fresh-checkout shape; otherwise a
+            # developer's stale bytecode would diverge from the real
+            # release artifact and could mask a regression.
             with zipfile.ZipFile(artifact, "w", zipfile.ZIP_DEFLATED) as zf:
-                for dirpath, _dirnames, filenames in os.walk(FOUNDRY_DIR):
+                for dirpath, dirnames, filenames in os.walk(FOUNDRY_DIR):
+                    if "__pycache__" in dirnames:
+                        dirnames.remove("__pycache__")
                     for filename in filenames:
+                        if filename.endswith(".pyc"):
+                            continue
                         abs_path = os.path.join(dirpath, filename)
                         arcname = os.path.relpath(abs_path, REPO_ROOT)
                         zf.write(abs_path, arcname)

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -1,31 +1,8 @@
 """End-to-end integration smoke tests for the authoring and release pipelines.
 
-Three cases live here:
-
-- ``ScaffoldBundlePipelineTests.test_standalone_skill_round_trip`` —
-  scaffold a standalone skill, validate it, patch its frontmatter the way
-  a real author would, bundle it with the default ``--target claude``,
-  unzip the bundle into a clean temp dir, and revalidate. Guards the
-  user-facing authoring flow driven by ``scaffold.py`` and ``bundle.py``
-  for the platform with the tightest limit.
-
-- ``ScaffoldBundlePipelineTests.test_generic_target_accepts_raw_scaffold_output`` —
-  same pipeline without the frontmatter patch, bundled with
-  ``--target generic``. Proves that at least one supported target path
-  works end-to-end on the unmodified scaffold output and keeps the
-  known ``--target claude`` UX gap from hiding a generic-target
-  regression.
-
-- ``ReleaseArtifactPipelineTests`` — mirror what
-  ``.github/workflows/release.yml`` actually ships (a raw zip of
-  ``skill-system-foundry/``), unzip on a clean path, and validate with
-  the same flags the foundry uses to validate itself. Guards the
-  release artifact, which is produced by ``zip -r`` and is not covered
-  by the ``bundle.py`` path.
-
-Subprocess + ``tempfile.TemporaryDirectory`` + stdlib ``zipfile`` —
-matches the conventions in ``test_scaffold_cli.py`` and
-``test_bundle_cli.py``. Runs on the ubuntu + windows matrix in
+Covers the scaffold -> validate -> bundle -> unzip -> validate flow across
+bundle targets, and the `zip -r` release-artifact shape produced by
+``.github/workflows/release.yml``. Runs on the ubuntu + windows matrix in
 ``python-tests.yaml`` without any workflow changes.
 """
 
@@ -35,8 +12,6 @@ import sys
 import tempfile
 import unittest
 import zipfile
-
-from helpers import run_script
 
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -48,7 +23,7 @@ FOUNDRY_DIR = os.path.join(REPO_ROOT, "skill-system-foundry")
 
 
 def _run(argv: list[str]) -> subprocess.CompletedProcess:
-    return run_script(argv, cwd=REPO_ROOT)
+    return subprocess.run(argv, cwd=REPO_ROOT, capture_output=True, text=True)
 
 
 def _assert_ok(test: unittest.TestCase, proc: subprocess.CompletedProcess) -> None:
@@ -111,40 +86,57 @@ def _bundle_and_extract(
         _assert_ok(test, validate_extracted)
 
 
-# Short, realistic SKILL.md that a downstream author would produce
-# after editing the scaffold output. Must fit under the Claude bundle
-# description limit (200 chars) so bundle.py --target claude passes.
-#
-# Known UX gap: the raw scaffold template ships a 317-char placeholder
-# description that fails `bundle.py --target claude` out of the box. A
-# first-time user running scaffold -> bundle with the default target
-# hits the 200-char failure with no guidance. This test patches around
-# it to exercise the full default-target pipeline; shortening the
-# placeholder in ``skill-system-foundry/assets/skill-standalone.md``
-# is the real fix and belongs in a separate change. The companion test
-# ``test_generic_target_accepts_raw_scaffold_output`` below proves the
-# non-default target paths do not hit this wall, scoping the gap.
-_PATCHED_SKILL_MD = """---
-name: {name}
-description: >
-  Processes integration smoke test inputs. Triggers when verifying the
-  scaffold to bundle pipeline end to end.
-license: MIT
-metadata:
-  author: Integration Test
-  version: 1.0.0
----
+# The exact folded-scalar description block that ``scaffold.py`` emits
+# into SKILL.md. Kept as a literal so the surgical patch below fails
+# loudly (with "placeholder not found") if the template drifts, rather
+# than silently no-op'ing. See ``skill-system-foundry/assets/skill-standalone.md``.
+_TEMPLATE_DESCRIPTION_BLOCK = (
+    "description: >\n"
+    "  <Description of what this skill does and when to trigger it.\n"
+    "  Max 1024 characters. Be specific about contexts, keywords, and use cases.\n"
+    "  Include trigger phrases. Be slightly pushy to avoid under-triggering.\n"
+    "  Third-person voice recommended (foundry convention).\n"
+    "  Optionally include \"Don't use when...\" for disambiguation.>\n"
+)
 
-# {title}
+# Short replacement description that fits under every bundle target's
+# limit (Claude's 200-char cap is the tightest). Known UX gap: the raw
+# scaffold template ships a 317-char placeholder description that fails
+# ``bundle.py --target claude`` out of the box — shortening the
+# placeholder in ``skill-system-foundry/assets/skill-standalone.md`` is
+# the real fix and belongs in a separate change. The companion test
+# ``test_generic_target_accepts_raw_scaffold_output`` keeps the gap
+# from hiding a regression on non-default targets.
+_AUTHORED_DESCRIPTION_BLOCK = (
+    "description: >\n"
+    "  Processes integration smoke test inputs. Triggers when verifying the\n"
+    "  scaffold to bundle pipeline end to end.\n"
+)
 
-## Purpose
 
-Minimal standalone skill used by the integration pipeline smoke test.
+def _patch_description(test: unittest.TestCase, skill_md_path: str) -> None:
+    """Replace only the scaffolded description block, preserving everything else.
 
-## Instructions
-
-Follow the normal skill lifecycle: scaffold, edit, validate, bundle.
-"""
+    Mirrors what a real author does — edit the description, leave the
+    rest of the template untouched. Reading-and-patching (rather than
+    overwriting the whole file) keeps this test honest: if
+    ``scaffold.py`` starts emitting a new frontmatter field or body
+    section, the test continues to exercise it.
+    """
+    with open(skill_md_path, "r", encoding="utf-8") as f:
+        original = f.read()
+    test.assertIn(
+        _TEMPLATE_DESCRIPTION_BLOCK, original,
+        msg=(
+            "scaffold template's description block changed — update "
+            "_TEMPLATE_DESCRIPTION_BLOCK to match the new emitted shape"
+        ),
+    )
+    patched = original.replace(
+        _TEMPLATE_DESCRIPTION_BLOCK, _AUTHORED_DESCRIPTION_BLOCK, 1,
+    )
+    with open(skill_md_path, "w", encoding="utf-8") as f:
+        f.write(patched)
 
 
 class ScaffoldBundlePipelineTests(unittest.TestCase):
@@ -166,15 +158,10 @@ class ScaffoldBundlePipelineTests(unittest.TestCase):
                 sys.executable, VALIDATE_SCRIPT, skill_dir,
             ]))
 
-            # Simulate the author filling in the template placeholders
-            # before distribution — see _PATCHED_SKILL_MD module-level
-            # comment for the UX-gap context.
-            skill_md_path = os.path.join(skill_dir, "SKILL.md")
-            with open(skill_md_path, "w", encoding="utf-8") as f:
-                f.write(_PATCHED_SKILL_MD.format(
-                    name=skill_name,
-                    title=skill_name.replace("-", " ").title(),
-                ))
+            # Simulate the author filling in the description placeholder
+            # before distribution — see _AUTHORED_DESCRIPTION_BLOCK for
+            # the UX-gap context.
+            _patch_description(self, os.path.join(skill_dir, "SKILL.md"))
 
             _assert_ok(self, _run([
                 sys.executable, VALIDATE_SCRIPT, skill_dir,
@@ -211,7 +198,8 @@ class ReleaseArtifactPipelineTests(unittest.TestCase):
     release.yml does not run bundle.py — it ships a raw zip of the
     skill directory. This test guards that specific artifact shape
     against the same "unzip and validate on a clean machine" regression
-    the bundle pipeline case guards for user skills.
+    the bundle pipeline case guards for user skills, plus the
+    yaml-conformance exclusion that release.yml asserts inline.
     """
 
     def test_released_artifact_unzips_and_validates(self) -> None:
@@ -242,6 +230,18 @@ class ReleaseArtifactPipelineTests(unittest.TestCase):
                         abs_path = os.path.join(dirpath, filename)
                         arcname = os.path.relpath(abs_path, REPO_ROOT)
                         zf.write(abs_path, arcname)
+
+            # Mirror release.yml's "Verify bundle excludes yaml-conformance
+            # corpus" step. The corpus currently lives outside the bundled
+            # path, so this is a passive invariant — pin it here so a
+            # future restructure that pulls the corpus into the bundle
+            # fails the test before it ships.
+            with zipfile.ZipFile(artifact) as zf:
+                hits = [n for n in zf.namelist() if "yaml-conformance" in n]
+            self.assertEqual(
+                hits, [],
+                msg=f"release bundle must not contain yaml-conformance entries: {hits}",
+            )
 
             extract_root = os.path.join(tmpdir, "extracted")
             os.makedirs(extract_root)


### PR DESCRIPTION
## Summary

Adds `tests/test_integration_pipeline.py` covering the full authoring pipeline (`scaffold → validate → bundle → unzip → validate`) and the `release.yml` artifact shape (`zip -r` + yaml-conformance exclusion + unzip and validate with `--foundry-self`). Runs on the existing ubuntu + windows matrix in `python-tests.yaml` without workflow changes. Updates `.agents/skills/git-release/SKILL.md` to make the "verify CI green on main before publishing" preflight explicit.

No production code changed. No new workflow, no new blocking gate — the release-gating model stays where issue #103 left it: a human checks `python-tests.yaml` on `main` before publishing.

## What's new

**Tests**

- `tests/test_integration_pipeline.py`
  - `ScaffoldBundlePipelineTests.test_standalone_skill_round_trip` — default `--target claude`, with a surgical description patch simulating the author edit step (see "Scaffold UX gap" below)
  - `ScaffoldBundlePipelineTests.test_generic_target_accepts_raw_scaffold_output` — `--target generic` on the unmodified scaffold output; scopes the claude-target UX gap so it cannot hide a generic-target regression
  - `ReleaseArtifactPipelineTests.test_released_artifact_unzips_and_validates` — rebuilds the `release.yml` `zip -r skill-system-foundry/` artifact with stdlib `zipfile` (works on Windows matrix cells where the `zip` CLI is absent), asserts the bundle excludes `yaml-conformance` entries (mirroring `release.yml`'s inline verification step), then extracts and revalidates with `--allow-nested-references --foundry-self`

**Skill prose**

- `.agents/skills/git-release/SKILL.md` Step 1 — adds the `gh run list --workflow python-tests.yaml --branch main --limit 1` preflight check with an explicit scope note: `python-tests.yaml` is the only gating workflow; `shellcheck.yaml` and `codex-code-review.yaml` are advisory. Release-checklist prose references the new integration test.

## Key decisions

- **Stdlib `zipfile`, not the `zip` CLI.** Windows matrix cells don't ship `zip`. The test prunes `__pycache__/` and `*.pyc` during archive to match `release.yml`'s fresh-checkout shape; IDE/OS scratch files (`.DS_Store`, `.idea/`) are not filtered because `release.yml`'s `zip -r` wouldn't filter them either.

- **Surgical description-only patch in the authoring test.** Reading the scaffolded `SKILL.md` and replacing only the folded-scalar description block (rather than overwriting the whole file) keeps the test honest — if `scaffold.py` starts emitting a new frontmatter field or body section, the test continues to exercise it.

- **Template-drift detector via literal duplication.** `_TEMPLATE_DESCRIPTION_BLOCK` in the test is byte-identical to the folded-scalar description block in `skill-system-foundry/assets/skill-standalone.md`. The duplication is deliberate: the surgical-patch `assertIn` fails loudly with "placeholder not found" when the template drifts. A programmatic extraction from the asset file would avoid duplication but silently accept any new-shape placeholder, defeating the drift detector. Contract is documented in the constant's comment.

- **Scaffold UX gap scoped but not fixed.** The raw scaffold template ships a 317-char placeholder description that fails `bundle.py --target claude` (200-char cap). The round-trip test patches around this; the companion generic-target test proves the non-default target paths don't hit the wall. Shortening the placeholder in `assets/skill-standalone.md` is the real fix and belongs in a separate change — flagged explicitly in the `_AUTHORED_DESCRIPTION_BLOCK` comment.

- **Release-artifact test mirrors all three `release.yml` steps.** Build (`zip -r` equivalent), verify (yaml-conformance exclusion assertion), extract-and-validate. The yaml-conformance invariant is passive today (the corpus lives under `tests/fixtures/`, outside the bundled path) but pinning it here makes a future restructure that pulls the corpus into the bundle fail locally before it ships.

- **No `tests/helpers.py` addition.** An initial iteration added a `run_script` subprocess helper, then removed it on review — the test module uses its own local `_run` wrapper, consistent with the pattern in `test_scaffold_cli.py` and `test_bundle_cli.py`.

## Acceptance criteria (issue #103)

- [x] New test exists under `tests/` and runs under `coverage run`
- [x] Test fails if any of the five pipeline steps regress (each step wrapped in `_assert_ok`)
- [x] Test uses `tempfile.TemporaryDirectory` for cleanup
- [x] Test runs on ubuntu and windows matrix cells (stdlib-only, `os.path` throughout)
- [x] `git-release` skill updated with the "verify CI green on main before publishing" gate

## Test plan

All checks executed locally; results inline.

- [x] `python -m coverage run -m unittest discover -s tests -p "test_*.py"` — **1473 tests pass** (12.2s), new file contributes 3 tests.
- [x] `python -m coverage report` — **TOTAL 96%** branch coverage (≥ 70% floor).
- [x] `python skill-system-foundry/scripts/validate_skill.py skill-system-foundry --allow-nested-references` — **exit 0**, all checks passed (17 passes, 0 failures).
- [x] `python skill-system-foundry/scripts/audit_skill_system.py skill-system-foundry` — **exit 0**, only the expected distribution-repo WARN.
- [x] `python -m unittest discover -s tests -p "test_integration_pipeline.py" -v` — 3/3 tests pass (0.7s on macOS; timing on Windows matrix cells will be higher due to subprocess overhead but still well under the suite's existing bounds).
- [x] Manual verification of the template-drift detector: renaming `_TEMPLATE_DESCRIPTION_BLOCK` produces `AssertionError: scaffold template's description block changed — update _TEMPLATE_DESCRIPTION_BLOCK to match the new emitted shape` (not silently no-oping the patch).

Closes #103.