### PR TITLE
Fail CI when workflow uses: lines are not pinned to a commit SHA

### DIFF
--- a/.agents/skills/github-actions/SKILL.md
+++ b/.agents/skills/github-actions/SKILL.md
@@ -15,7 +15,7 @@ description: >
 
 # GitHub Actions Skill
 
-Guides the creation, modification, and review of GitHub Actions workflows in the Skill System Foundry repository. Codifies the conventions established across the four existing workflows.
+Guides the creation, modification, and review of GitHub Actions workflows in the Skill System Foundry repository. Codifies the conventions established across the repository's existing workflows.
 
 ## Repository Workflows
 

--- a/.agents/skills/github-actions/SKILL.md
+++ b/.agents/skills/github-actions/SKILL.md
@@ -23,6 +23,7 @@ Guides the creation, modification, and review of GitHub Actions workflows in the
 |---|---|---|---|
 | Tests + coverage | `python-tests.yaml` | Push to `main`, PRs | `test` (matrix), `update-badge` |
 | Shell lint | `shellcheck.yaml` | Push/PR (path-filtered to `.sh`) | `shellcheck` |
+| Action-pin verify | `verify-action-pins.yaml` | Push to `main`, PRs | `verify` |
 | Codex code review | `codex-code-review.yaml` | PR events (non-draft) | `review` (read-only), `publish` (write) |
 | Release bundle | `release.yml` | Release published | `bundle` |
 
@@ -44,6 +45,8 @@ When updating an action version:
 1. Find the new tag's commit SHA on the action's repository releases page
 2. Replace the SHA in the workflow
 3. Update the comment to reflect the new tag and version
+
+This rule is enforced by `.github/scripts/verify-action-pins.py`, which the `verify-action-pins.yaml` workflow runs on every PR and push to `main`. Any `uses:` line that is not a 40-character lowercase commit SHA (or `./local-path` / `docker://...`) fails CI. Run the script locally with `python .github/scripts/verify-action-pins.py` to check before pushing.
 
 ### Least-Privilege Permissions
 
@@ -154,7 +157,7 @@ Jobs that only run shell commands or Python scripts can rely on the GitHub defau
 
 Check these in order:
 
-1. **Are all actions SHA-pinned?** Look for any `uses:` line without a 40-character SHA
+1. **Are all actions SHA-pinned?** Enforced automatically by `verify-action-pins.yaml`; rely on the gate instead of reviewing this by eye.
 2. **Are permissions minimal?** Does the workflow request more access than it needs? Does a write permission belong at job level instead of workflow level?
 3. **Is the permission boundary maintained?** Read-only analysis and write-capable publishing should be in separate jobs
 4. **Are new environment variables validated?** Scripts called by the workflow should check `${VAR:?}` at the top

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -62,6 +62,12 @@ def _strip_inline(raw: str) -> str:
     value = raw.strip()
     if not value:
         return value
+    # An unquoted leading ``#`` makes the entire right-hand side a YAML
+    # comment (the value is empty). Return empty so classify reports the
+    # real issue — empty uses value — instead of a misleading
+    # "missing '@<commit-sha>' pin" against the comment text.
+    if value[0] == "#":
+        return ""
     if value[0] in ("'", '"'):
         quote = value[0]
         end = value.find(quote, 1)
@@ -177,9 +183,14 @@ def collect_violations(workflows_dir: str) -> list[dict]:
                 "uses": value,
                 "reason": reason,
             })
-    # Insertion order already matches (file, line): list_workflow_files
-    # returns basenames sorted lexically, scan_workflow yields ascending
-    # line numbers, and all entries for one file flush before the next.
+    # Sort defensively on (file, line) even though insertion order
+    # already matches today (list_workflow_files returns basenames
+    # sorted lexically, scan_workflow yields ascending line numbers,
+    # all entries for one file flush before the next). The docstring
+    # advertises sorted output, so a future refactor that recurses into
+    # subdirectories or parallelises reads must not quietly break the
+    # contract.
+    results.sort(key=lambda v: (v["file"], v["line"]))
     return results
 
 

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -60,11 +60,17 @@ _USES_RE = re.compile(
 _FLOW_USES_RE = re.compile(
     r"""[{,]\s*['"]?uses['"]?\s*:\s*([^,}\n]*?)\s*(?=[,}])"""
 )
-# Matches a line whose step body starts with ``{`` — optionally after
-# a list marker. Only those lines are scanned with the flow regex; a
-# shell command containing literal ``{ uses: ... }`` in its middle is
-# not a flow-mapping step and must be ignored.
-_FLOW_STEP_RE = re.compile(r"^\s*(?:-\s*)?\{")
+# Matches a line whose logical value is a flow mapping — either a
+# bare list item (``- { ... }``), a bare flow map (``{ ... }``), or a
+# keyed mapping value (``call: { ... }`` / ``- name: { ... }``). Only
+# those lines are scanned with the flow regex; a shell command
+# containing literal ``{ uses: ... }`` embedded in scalar text
+# produces no leading ``key:`` ending in ``{`` so it is ignored. The
+# keyed form is required to catch reusable-workflow jobs written as
+# ``job-id: { uses: org/repo/.github/workflows/x.yml@ref }``.
+_FLOW_STEP_RE = re.compile(
+    r"^\s*(?:-\s*)?(?:[\w.-]+\s*:\s*)?\{"
+)
 
 
 def _strip_inline(raw: str) -> str:
@@ -181,15 +187,21 @@ def scan_workflow(text: str) -> list[tuple[int, str, str]]:
 
 
 def list_workflow_files(workflows_dir: str) -> list[str]:
-    """Return sorted absolute paths of every workflow YAML in *dir*."""
-    if not os.path.isdir(workflows_dir):
+    """Return sorted absolute paths of every workflow YAML in *dir*.
+
+    *workflows_dir* may be relative; it is normalised to an absolute
+    path internally so the returned list matches the documented
+    contract regardless of what the caller passed.
+    """
+    absolute_dir = os.path.abspath(workflows_dir)
+    if not os.path.isdir(absolute_dir):
         return []
     names = [
-        n for n in os.listdir(workflows_dir)
+        n for n in os.listdir(absolute_dir)
         if n.endswith(".yml") or n.endswith(".yaml")
     ]
     names.sort()
-    return [os.path.join(workflows_dir, n) for n in names]
+    return [os.path.join(absolute_dir, n) for n in names]
 
 
 def collect_violations(workflows_dir: str) -> list[dict]:

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -31,6 +31,7 @@ import argparse
 import json
 import os
 import re
+import sys
 
 _REPO_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..")
@@ -47,6 +48,15 @@ _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 # comments before classification.
 _USES_RE = re.compile(
     r"""^\s*(?:-\s+)?['"]?uses['"]?\s*:\s*(\S.*?|)\s*$"""
+)
+# Flow-style YAML mappings (``- { uses: ref }`` / ``{ name: x, uses: ref
+# }``) are also valid GitHub Actions step syntax, so the scanner must
+# find ``uses`` keys inside ``{}`` as well. The lookbehind is ``{`` or
+# ``,`` to allow both leading and subsequent positions; the value is
+# captured lazily up to the next ``,`` or ``}`` that would terminate
+# it in the flow map.
+_FLOW_USES_RE = re.compile(
+    r"""[{,]\s*['"]?uses['"]?\s*:\s*([^,}\n]*?)\s*(?=[,}])"""
 )
 
 
@@ -137,20 +147,27 @@ def scan_workflow(text: str) -> list[tuple[int, str, str]]:
 
     *text* is the full content of a workflow file. Lines whose first
     non-whitespace character is ``#`` are skipped so commented-out
-    examples do not register. Line numbers are 1-indexed.
+    examples do not register. Both block-style (``uses: ref``) and
+    flow-style (``{ uses: ref }``) mapping forms are scanned. Line
+    numbers are 1-indexed.
     """
     violations: list[tuple[int, str, str]] = []
     for lineno, line in enumerate(text.splitlines(), start=1):
         stripped = line.lstrip()
         if stripped.startswith("#"):
             continue
-        match = _USES_RE.match(line)
-        if not match:
+        block = _USES_RE.match(line)
+        if block is not None:
+            value = _strip_inline(block.group(1))
+            reason = classify(value)
+            if reason is not None:
+                violations.append((lineno, value, reason))
             continue
-        value = _strip_inline(match.group(1))
-        reason = classify(value)
-        if reason is not None:
-            violations.append((lineno, value, reason))
+        for flow in _FLOW_USES_RE.finditer(line):
+            value = _strip_inline(flow.group(1))
+            reason = classify(value)
+            if reason is not None:
+                violations.append((lineno, value, reason))
     return violations
 
 
@@ -230,6 +247,18 @@ def main(argv: list[str] | None = None) -> int:
         workflows_dir = os.path.abspath(args.workflows_dir)
     else:
         workflows_dir = os.path.join(_REPO_ROOT, ".github", "workflows")
+
+    # Fail closed when the workflows directory is missing. Returning 0
+    # against ``list_workflow_files -> []`` would otherwise produce a
+    # misleading "All workflow `uses:` references are SHA-pinned."
+    # result that hides a setup error (wrong ``--workflows-dir``, a
+    # repo without workflows, or a CI checkout that lost the tree).
+    if not os.path.isdir(workflows_dir):
+        print(
+            f"ERROR: workflows directory not found: {workflows_dir}",
+            file=sys.stderr,
+        )
+        return 1
 
     violations = collect_violations(workflows_dir)
 

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -38,10 +38,16 @@ _REPO_ROOT = os.path.abspath(
 
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 # Matches a YAML-key ``uses:`` at the start of a line, optionally
-# preceded by a list marker ("- "). Captures the raw right-hand side
-# (value plus any trailing comment); the caller strips quotes and
-# trailing comments before classification.
-_USES_RE = re.compile(r"^\s*(?:-\s+)?uses:\s*(\S.*?)\s*$")
+# preceded by a list marker ("- "). The ``uses`` token may itself be
+# quoted (``'uses':`` / ``"uses":``) — GitHub Actions still treats those
+# as the same key, so the gate must not miss them. Captures the raw
+# right-hand side (value plus any trailing comment); may be empty so an
+# intentionally blank ``uses:`` reaches ``classify`` and is reported
+# rather than silently ignored. The caller strips quotes and trailing
+# comments before classification.
+_USES_RE = re.compile(
+    r"""^\s*(?:-\s+)?['"]?uses['"]?\s*:\s*(\S.*?|)\s*$"""
+)
 
 
 def _strip_inline(raw: str) -> str:
@@ -81,10 +87,19 @@ def classify(value: str) -> str | None:
     """
     if not value:
         return "empty uses value"
+    # Reject any parent-traversal form *before* the ``./`` accept
+    # branch, otherwise ``./../foo`` would slip through because it
+    # starts with ``./``. Catch the bare, leading, embedded, and
+    # trailing forms.
+    if (
+        value == ".."
+        or value.startswith("../")
+        or "/../" in value
+        or value.endswith("/..")
+    ):
+        return "local action path must not contain parent traversal"
     if value.startswith("./"):
         return None
-    if value.startswith("../"):
-        return "local action path must start with './' (no parent traversal)"
     if value.startswith("docker://"):
         return None
     if "@" not in value:

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -72,6 +72,13 @@ _FLOW_USES_RE = re.compile(
 _FLOW_STEP_RE = re.compile(
     r"""^\s*(?:-\s*)?(?:['"]?[\w.-]+['"]?\s*:\s*)?\{"""
 )
+# Matches a block-scalar opener: ``key: |`` / ``key: >`` with any
+# chomping (+/-) and explicit indent indicators, plus an optional
+# trailing comment. Lines after the opener whose indent is strictly
+# greater than the opener's are part of the scalar body and must not
+# be scanned — shell content like ``key: { uses: foo }`` inside a
+# ``run: |`` block is text, not YAML structure.
+_BLOCK_SCALAR_RE = re.compile(r":\s*[|>][+\-\d]*\s*(?:#.*)?$")
 
 
 def _strip_inline(raw: str) -> str:
@@ -162,13 +169,31 @@ def scan_workflow(text: str) -> list[tuple[int, str, str]]:
     *text* is the full content of a workflow file. Lines whose first
     non-whitespace character is ``#`` are skipped so commented-out
     examples do not register. Both block-style (``uses: ref``) and
-    flow-style (``{ uses: ref }``) mapping forms are scanned. Line
+    flow-style (``{ uses: ref }``) mapping forms are scanned.
+
+    Block-scalar bodies (``run: |`` / ``run: >``) are tracked by
+    indent: a line is considered inside the scalar when its indent is
+    strictly greater than the opener's, and scanning resumes once a
+    non-empty line dedents back to the opener's indent (or less).
+    Lines inside a scalar are skipped so shell content that looks like
+    YAML structure does not false-positive the flow scanner. Line
     numbers are 1-indexed.
     """
     violations: list[tuple[int, str, str]] = []
+    block_scalar_indent: int | None = None
     for lineno, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip())
+        if block_scalar_indent is not None:
+            if indent > block_scalar_indent:
+                continue
+            block_scalar_indent = None
         stripped = line.lstrip()
         if stripped.startswith("#"):
+            continue
+        if _BLOCK_SCALAR_RE.search(line):
+            block_scalar_indent = indent
             continue
         block = _USES_RE.match(line)
         if block is not None:

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -1,11 +1,14 @@
 """Enforce SHA-pinned ``uses:`` references in every workflow file.
 
 Walks ``.github/workflows/*.yml`` and ``.github/workflows/*.yaml`` line by
-line (no YAML parsing — the issue spec deliberately prefers a simple
-scan over a full parse, at the cost of a theoretical false-positive
-when a multi-line ``run: |`` block has a line whose first non-whitespace
-text is literally ``uses:``; no current workflow trips this) and applies
-these rules to every ``uses:`` key it finds:
+line. No YAML parsing — the issue spec deliberately prefers a simple
+scan over a full parse. Recognised block-scalar bodies (``run: |`` /
+``run: >`` with any chomping or indent indicator) are tracked by
+indent and skipped, so a shell line that happens to look like
+``key: { uses: ... }`` does not false-positive. The only remaining
+theoretical miss is a multi-line YAML construct the lightweight scan
+does not recognise as a block scalar — no current workflow trips it.
+The rules applied to every ``uses:`` key found:
 
 ===========================================  =========
 Reference form                               Treatment

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -54,10 +54,17 @@ _USES_RE = re.compile(
 # find ``uses`` keys inside ``{}`` as well. The lookbehind is ``{`` or
 # ``,`` to allow both leading and subsequent positions; the value is
 # captured lazily up to the next ``,`` or ``}`` that would terminate
-# it in the flow map.
+# it in the flow map. The caller restricts where this regex runs so
+# literal ``{ uses: ... }`` inside scalar text (e.g. a ``run:`` script
+# body) does not false-positive.
 _FLOW_USES_RE = re.compile(
     r"""[{,]\s*['"]?uses['"]?\s*:\s*([^,}\n]*?)\s*(?=[,}])"""
 )
+# Matches a line whose step body starts with ``{`` — optionally after
+# a list marker. Only those lines are scanned with the flow regex; a
+# shell command containing literal ``{ uses: ... }`` in its middle is
+# not a flow-mapping step and must be ignored.
+_FLOW_STEP_RE = re.compile(r"^\s*(?:-\s*)?\{")
 
 
 def _strip_inline(raw: str) -> str:
@@ -163,6 +170,8 @@ def scan_workflow(text: str) -> list[tuple[int, str, str]]:
             if reason is not None:
                 violations.append((lineno, value, reason))
             continue
+        if _FLOW_STEP_RE.match(line) is None:
+            continue
         for flow in _FLOW_USES_RE.finditer(line):
             value = _strip_inline(flow.group(1))
             reason = classify(value)
@@ -199,7 +208,7 @@ def collect_violations(workflows_dir: str) -> list[dict]:
         try:
             with open(absolute, encoding="utf-8") as fh:
                 text = fh.read()
-        except OSError as exc:
+        except (OSError, UnicodeError) as exc:
             results.append({
                 "file": label,
                 "line": 0,

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -1,8 +1,11 @@
 """Enforce SHA-pinned ``uses:`` references in every workflow file.
 
 Walks ``.github/workflows/*.yml`` and ``.github/workflows/*.yaml`` line by
-line (no YAML parsing needed) and applies these rules to every ``uses:``
-key it finds:
+line (no YAML parsing — the issue spec deliberately prefers a simple
+scan over a full parse, at the cost of a theoretical false-positive
+when a multi-line ``run: |`` block has a line whose first non-whitespace
+text is literally ``uses:``; no current workflow trips this) and applies
+these rules to every ``uses:`` key it finds:
 
 ===========================================  =========
 Reference form                               Treatment
@@ -127,25 +130,25 @@ def list_workflow_files(workflows_dir: str) -> list[str]:
     return [os.path.join(workflows_dir, n) for n in names]
 
 
-def collect_violations(
-    workflows_dir: str,
-    rel_base: str,
-) -> list[dict]:
+def collect_violations(workflows_dir: str) -> list[dict]:
     """Walk *workflows_dir* and return a sorted list of violation dicts.
 
-    *rel_base* is the directory that violation ``file`` fields are made
-    relative to. Paths are always emitted with forward slashes so
-    output is stable across platforms.
+    Violation ``file`` fields are always labelled
+    ``.github/workflows/<basename>`` regardless of where the scanned
+    directory actually lives on disk. That matches production output
+    exactly, so a contributor who runs the script with
+    ``--workflows-dir`` locally sees the same paths CI would print.
+    Forward slashes make the label stable across platforms.
     """
     results: list[dict] = []
     for absolute in list_workflow_files(workflows_dir):
-        rel = os.path.relpath(absolute, rel_base).replace(os.sep, "/")
+        label = ".github/workflows/" + os.path.basename(absolute)
         try:
             with open(absolute, encoding="utf-8") as fh:
                 text = fh.read()
         except OSError as exc:
             results.append({
-                "file": rel,
+                "file": label,
                 "line": 0,
                 "uses": "",
                 "reason": f"read-error: {type(exc).__name__}: {exc}",
@@ -153,7 +156,7 @@ def collect_violations(
             continue
         for lineno, value, reason in scan_workflow(text):
             results.append({
-                "file": rel,
+                "file": label,
                 "line": lineno,
                 "uses": value,
                 "reason": reason,
@@ -182,12 +185,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.workflows_dir is not None:
         workflows_dir = os.path.abspath(args.workflows_dir)
-        rel_base = os.path.dirname(workflows_dir)
     else:
         workflows_dir = os.path.join(_REPO_ROOT, ".github", "workflows")
-        rel_base = _REPO_ROOT
 
-    violations = collect_violations(workflows_dir, rel_base)
+    violations = collect_violations(workflows_dir)
 
     if args.json:
         print(json.dumps(violations, indent=2, sort_keys=True))

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -111,7 +111,13 @@ def classify(value: str) -> str | None:
     if "@" not in value:
         return "missing '@<commit-sha>' pin"
     prefix, _, ref = value.rpartition("@")
-    if "/" not in prefix or not ref:
+    # The prefix must be ``owner/repo`` or ``owner/repo/subpath`` with
+    # every segment non-empty. Splitting on ``/`` and checking segment
+    # count + emptiness catches bypasses like ``org/@<sha>``,
+    # ``/repo@<sha>``, or ``org//@<sha>`` that a naive ``"/" in prefix``
+    # test would wave through.
+    parts = prefix.split("/")
+    if len(parts) < 2 or any(not part for part in parts) or not ref:
         return "not a recognised action reference form"
     if not _SHA_RE.match(ref):
         return f"ref '{ref}' is not a 40-character lowercase commit SHA"

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -62,14 +62,15 @@ _FLOW_USES_RE = re.compile(
 )
 # Matches a line whose logical value is a flow mapping — either a
 # bare list item (``- { ... }``), a bare flow map (``{ ... }``), or a
-# keyed mapping value (``call: { ... }`` / ``- name: { ... }``). Only
-# those lines are scanned with the flow regex; a shell command
-# containing literal ``{ uses: ... }`` embedded in scalar text
-# produces no leading ``key:`` ending in ``{`` so it is ignored. The
-# keyed form is required to catch reusable-workflow jobs written as
-# ``job-id: { uses: org/repo/.github/workflows/x.yml@ref }``.
+# keyed mapping value (``call: { ... }`` / ``- name: { ... }``). The
+# key may itself be single- or double-quoted (``'call': { ... }``) —
+# YAML treats those as the same mapping key, so the gate must not
+# miss quoted-key flow maps. Lines whose step body does not begin
+# with ``{`` (after any optional key/list prefix) fall through to no
+# flow scanning, so scalar text containing literal ``{ uses: ... }``
+# does not false-positive.
 _FLOW_STEP_RE = re.compile(
-    r"^\s*(?:-\s*)?(?:[\w.-]+\s*:\s*)?\{"
+    r"""^\s*(?:-\s*)?(?:['"]?[\w.-]+['"]?\s*:\s*)?\{"""
 )
 
 
@@ -196,9 +197,16 @@ def list_workflow_files(workflows_dir: str) -> list[str]:
     absolute_dir = os.path.abspath(workflows_dir)
     if not os.path.isdir(absolute_dir):
         return []
+    # Filter to regular files so an entry like ``bogus.yaml/``
+    # (a directory whose name happens to end with the YAML suffix)
+    # does not pass to ``open()`` and surface as a spurious
+    # ``read-error: IsADirectoryError`` violation that would false-fail
+    # CI. Symlinks to files are accepted via ``os.path.isfile``'s
+    # default follow-link behaviour.
     names = [
         n for n in os.listdir(absolute_dir)
-        if n.endswith(".yml") or n.endswith(".yaml")
+        if (n.endswith(".yml") or n.endswith(".yaml"))
+        and os.path.isfile(os.path.join(absolute_dir, n))
     ]
     names.sort()
     return [os.path.join(absolute_dir, n) for n in names]

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -220,10 +220,23 @@ def collect_violations(workflows_dir: str) -> list[dict]:
     directory actually lives on disk. That matches production output
     exactly, so a contributor who runs the script with
     ``--workflows-dir`` locally sees the same paths CI would print.
-    Forward slashes make the label stable across platforms.
+    Forward slashes make the label stable across platforms. An
+    ``OSError`` from the directory listing itself (e.g. a permission
+    issue) surfaces as a single ``list-error`` violation at
+    ``.github/workflows/`` so CI fails closed with an actionable
+    message rather than crashing with an uncaught traceback.
     """
     results: list[dict] = []
-    for absolute in list_workflow_files(workflows_dir):
+    try:
+        workflow_paths = list_workflow_files(workflows_dir)
+    except OSError as exc:
+        return [{
+            "file": ".github/workflows/",
+            "line": 0,
+            "uses": "",
+            "reason": f"list-error: {type(exc).__name__}: {exc}",
+        }]
+    for absolute in workflow_paths:
         label = ".github/workflows/" + os.path.basename(absolute)
         try:
             with open(absolute, encoding="utf-8") as fh:

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -31,7 +31,6 @@ import argparse
 import json
 import os
 import re
-import sys
 
 _REPO_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..")
@@ -61,8 +60,10 @@ def _strip_inline(raw: str) -> str:
         quote = value[0]
         end = value.find(quote, 1)
         if end == -1:
-            # Unterminated quote — fall through to raw stripping so the
-            # classifier still surfaces a useful failure reason.
+            # Unterminated quote would already be rejected by any YAML
+            # parser — GitHub Actions will not accept the file — so the
+            # scanner just returns the raw string and lets the classifier
+            # decide. No correctness risk either way.
             return value
         return value[1:end]
     for sep in (" #", "\t#"):
@@ -89,7 +90,7 @@ def classify(value: str) -> str | None:
     if "@" not in value:
         return "missing '@<commit-sha>' pin"
     prefix, _, ref = value.rpartition("@")
-    if "/" not in prefix or not prefix or not ref:
+    if "/" not in prefix or not ref:
         return "not a recognised action reference form"
     if not _SHA_RE.match(ref):
         return f"ref '{ref}' is not a 40-character lowercase commit SHA"
@@ -161,7 +162,9 @@ def collect_violations(workflows_dir: str) -> list[dict]:
                 "uses": value,
                 "reason": reason,
             })
-    results.sort(key=lambda v: (v["file"], v["line"]))
+    # Insertion order already matches (file, line): list_workflow_files
+    # returns basenames sorted lexically, scan_workflow yields ascending
+    # line numbers, and all entries for one file flush before the next.
     return results
 
 

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -1,0 +1,225 @@
+"""Enforce SHA-pinned ``uses:`` references in every workflow file.
+
+Walks ``.github/workflows/*.yml`` and ``.github/workflows/*.yaml`` line by
+line (no YAML parsing needed) and applies these rules to every ``uses:``
+key it finds:
+
+===========================================  =========
+Reference form                               Treatment
+===========================================  =========
+``org/repo@<40-char-lowercase-hex>``         allowed
+``org/repo/subpath@<40-char-lowercase-hex>`` allowed
+``./path``                                   allowed
+``docker://image...``                        allowed
+anything else                                rejected
+===========================================  =========
+
+Output:
+  * Default human mode: one ``FAIL: <file>:<line>: <uses> -- <reason>``
+    line per violation.
+  * ``--json`` mode: a JSON list of ``{"file", "line", "uses",
+    "reason"}`` dicts, sorted by ``(file, line)``.
+
+Exit code: 0 when every ``uses:`` is pinned, 1 on any violation, 2 on
+argparse/usage errors.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+# Matches a YAML-key ``uses:`` at the start of a line, optionally
+# preceded by a list marker ("- "). Captures the raw right-hand side
+# (value plus any trailing comment); the caller strips quotes and
+# trailing comments before classification.
+_USES_RE = re.compile(r"^\s*(?:-\s+)?uses:\s*(\S.*?)\s*$")
+
+
+def _strip_inline(raw: str) -> str:
+    """Return the bare ``uses:`` value with quotes and comment stripped.
+
+    GitHub action references never contain ``#``, so a ``#`` that
+    appears after whitespace on an unquoted value is always an inline
+    YAML comment and is removed. For quoted values (single or double
+    quote pairs) the inside of the quotes is returned verbatim and
+    anything after the closing quote is discarded.
+    """
+    value = raw.strip()
+    if not value:
+        return value
+    if value[0] in ("'", '"'):
+        quote = value[0]
+        end = value.find(quote, 1)
+        if end == -1:
+            # Unterminated quote — fall through to raw stripping so the
+            # classifier still surfaces a useful failure reason.
+            return value
+        return value[1:end]
+    for sep in (" #", "\t#"):
+        idx = value.find(sep)
+        if idx != -1:
+            value = value[:idx]
+            break
+    return value.strip()
+
+
+def classify(value: str) -> str | None:
+    """Return ``None`` when *value* is an allowed reference form.
+
+    Otherwise return a short human-readable reason string.
+    """
+    if not value:
+        return "empty uses value"
+    if value.startswith("./"):
+        return None
+    if value.startswith("../"):
+        return "local action path must start with './' (no parent traversal)"
+    if value.startswith("docker://"):
+        return None
+    if "@" not in value:
+        return "missing '@<commit-sha>' pin"
+    prefix, _, ref = value.rpartition("@")
+    if "/" not in prefix or not prefix or not ref:
+        return "not a recognised action reference form"
+    if not _SHA_RE.match(ref):
+        return f"ref '{ref}' is not a 40-character lowercase commit SHA"
+    return None
+
+
+def scan_workflow(text: str) -> list[tuple[int, str, str]]:
+    """Return ``(line_number, value, reason)`` tuples for every violation.
+
+    *text* is the full content of a workflow file. Lines whose first
+    non-whitespace character is ``#`` are skipped so commented-out
+    examples do not register. Line numbers are 1-indexed.
+    """
+    violations: list[tuple[int, str, str]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        match = _USES_RE.match(line)
+        if not match:
+            continue
+        value = _strip_inline(match.group(1))
+        reason = classify(value)
+        if reason is not None:
+            violations.append((lineno, value, reason))
+    return violations
+
+
+def list_workflow_files(workflows_dir: str) -> list[str]:
+    """Return sorted absolute paths of every workflow YAML in *dir*."""
+    if not os.path.isdir(workflows_dir):
+        return []
+    names = [
+        n for n in os.listdir(workflows_dir)
+        if n.endswith(".yml") or n.endswith(".yaml")
+    ]
+    names.sort()
+    return [os.path.join(workflows_dir, n) for n in names]
+
+
+def collect_violations(
+    workflows_dir: str,
+    rel_base: str,
+) -> list[dict]:
+    """Walk *workflows_dir* and return a sorted list of violation dicts.
+
+    *rel_base* is the directory that violation ``file`` fields are made
+    relative to. Paths are always emitted with forward slashes so
+    output is stable across platforms.
+    """
+    results: list[dict] = []
+    for absolute in list_workflow_files(workflows_dir):
+        rel = os.path.relpath(absolute, rel_base).replace(os.sep, "/")
+        try:
+            with open(absolute, encoding="utf-8") as fh:
+                text = fh.read()
+        except OSError as exc:
+            results.append({
+                "file": rel,
+                "line": 0,
+                "uses": "",
+                "reason": f"read-error: {type(exc).__name__}: {exc}",
+            })
+            continue
+        for lineno, value, reason in scan_workflow(text):
+            results.append({
+                "file": rel,
+                "line": lineno,
+                "uses": value,
+                "reason": reason,
+            })
+    results.sort(key=lambda v: (v["file"], v["line"]))
+    return results
+
+
+def format_human(violations: list[dict]) -> str:
+    """Format *violations* as one ``FAIL`` line per entry."""
+    if not violations:
+        return "All workflow `uses:` references are SHA-pinned."
+    lines = [
+        f"FAIL: {v['file']}:{v['line']}: {v['uses']} -- {v['reason']}"
+        for v in violations
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Returns 0 clean, 1 on violations, 2 on usage errors."""
+    try:
+        args = _parse_args(argv)
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 2
+
+    if args.workflows_dir is not None:
+        workflows_dir = os.path.abspath(args.workflows_dir)
+        rel_base = os.path.dirname(workflows_dir)
+    else:
+        workflows_dir = os.path.join(_REPO_ROOT, ".github", "workflows")
+        rel_base = _REPO_ROOT
+
+    violations = collect_violations(workflows_dir, rel_base)
+
+    if args.json:
+        print(json.dumps(violations, indent=2, sort_keys=True))
+    else:
+        print(format_human(violations))
+
+    return 1 if violations else 0
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse command-line arguments. Raises ``SystemExit`` on errors."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail when any 'uses:' line in .github/workflows/ is not "
+            "pinned to a 40-character commit SHA."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON list of {file, line, uses, reason} dicts.",
+    )
+    parser.add_argument(
+        "--workflows-dir",
+        default=None,
+        help=(
+            "Override the workflows directory to scan (primarily for "
+            "tests). Defaults to <repo>/.github/workflows."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/verify-action-pins.py
+++ b/.github/scripts/verify-action-pins.py
@@ -89,8 +89,12 @@ def _strip_inline(raw: str) -> str:
 def classify(value: str) -> str | None:
     """Return ``None`` when *value* is an allowed reference form.
 
-    Otherwise return a short human-readable reason string.
+    Otherwise return a short human-readable reason string. Leading and
+    trailing whitespace is stripped so standalone callers see the same
+    decision the scan path does (``scan_workflow`` already normalises
+    via ``_strip_inline`` before calling in).
     """
+    value = value.strip()
     if not value:
         return "empty uses value"
     # Reject any parent-traversal form *before* the ``./`` accept
@@ -105,8 +109,12 @@ def classify(value: str) -> str | None:
     ):
         return "local action path must not contain parent traversal"
     if value.startswith("./"):
+        if value == "./":
+            return "local action path must not be empty"
         return None
     if value.startswith("docker://"):
+        if value == "docker://":
+            return "docker action reference must not be empty"
         return None
     if "@" not in value:
         return "missing '@<commit-sha>' pin"

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -50,7 +50,8 @@ jobs:
             --file-threshold skill-system-foundry/scripts/yaml_conformance_report.py=90 \
             --file-threshold skill-system-foundry/scripts/lib/yaml_conformance_runner.py=90 \
             --file-threshold .github/scripts/preflight-yaml-upgrade.py=90 \
-            --file-threshold .github/scripts/refresh-yaml-corpus-digests.py=90
+            --file-threshold .github/scripts/refresh-yaml-corpus-digests.py=90 \
+            --file-threshold .github/scripts/verify-action-pins.py=90
 
       - name: Generate coverage HTML report
         if: always() && steps.run-tests.outcome != 'skipped'

--- a/.github/workflows/verify-action-pins.yaml
+++ b/.github/workflows/verify-action-pins.yaml
@@ -15,5 +15,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
 
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v5 as 5.6.0
+        with:
+          python-version: "3.12"
+
       - name: Verify action pins
         run: python .github/scripts/verify-action-pins.py

--- a/.github/workflows/verify-action-pins.yaml
+++ b/.github/workflows/verify-action-pins.yaml
@@ -1,0 +1,19 @@
+name: Verify action pins
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+
+      - name: Verify action pins
+        run: python .github/scripts/verify-action-pins.py

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -442,6 +442,33 @@ class ScanWorkflowTests(unittest.TestCase):
         text = "    - name: note { uses: actions/checkout@v4 }\n"
         self.assertEqual(scan_workflow(text), [])
 
+    def test_keyed_flow_mapping_unpinned_is_flagged(self) -> None:
+        # Codex-flagged bypass: reusable-workflow jobs can be written
+        # as ``job-id: { uses: ... }``. The flow matcher must run on
+        # those lines too, not just bare-step or list-item forms.
+        text = (
+            "jobs:\n"
+            "  call: { uses: org/repo/.github/workflows/x.yml@main }\n"
+        )
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(
+            violations[0][1],
+            "org/repo/.github/workflows/x.yml@main",
+        )
+
+    def test_keyed_flow_mapping_pinned_is_allowed(self) -> None:
+        text = f"  call: {{ uses: org/repo@{_SHA} }}\n"
+        self.assertEqual(scan_workflow(text), [])
+
+    def test_hyphenated_job_id_keyed_flow_is_flagged(self) -> None:
+        # Job IDs can contain hyphens and dots — the key regex must
+        # accept them.
+        text = "  call-reusable.v2: { uses: org/repo@v4 }\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "org/repo@v4")
+
 
 # ===================================================================
 # collect_violations / list_workflow_files
@@ -504,6 +531,23 @@ class CollectViolationsTests(unittest.TestCase):
                 list_workflow_files(os.path.join(root, "does-not-exist")),
                 [],
             )
+
+    def test_list_workflow_files_returns_absolute_paths(self) -> None:
+        # Copilot-flagged contract gap: the docstring promised absolute
+        # paths but the function previously echoed whatever the caller
+        # passed. Feeding a relative path must now come back absolute.
+        cwd = os.getcwd()
+        try:
+            with tempfile.TemporaryDirectory() as root:
+                os.chdir(root)
+                rel = "workflows"
+                _write(os.path.join(rel, "a.yaml"), "")
+                paths = list_workflow_files(rel)
+                self.assertEqual(len(paths), 1)
+                self.assertTrue(os.path.isabs(paths[0]))
+                self.assertTrue(paths[0].endswith("a.yaml"))
+        finally:
+            os.chdir(cwd)
 
     def test_non_yaml_file_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as wf:

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -221,6 +221,13 @@ class StripInlineTests(unittest.TestCase):
     def test_empty_input(self) -> None:
         self.assertEqual(_strip_inline(""), "")
 
+    def test_leading_hash_treated_as_empty(self) -> None:
+        # A YAML value that is a bare comment ("uses: # trailing") has
+        # no real right-hand side — return empty so classify reports
+        # "empty uses value" rather than a misleading pin reason.
+        self.assertEqual(_strip_inline("# comment"), "")
+        self.assertEqual(_strip_inline("#"), "")
+
 
 # ===================================================================
 # scan_workflow — line-level behaviour
@@ -345,6 +352,16 @@ class ScanWorkflowTests(unittest.TestCase):
         violations = scan_workflow(text)
         self.assertEqual(len(violations), 1)
         self.assertIn("parent traversal", violations[0][2])
+
+    def test_inline_comment_after_empty_uses_is_flagged_as_empty(self) -> None:
+        # Copilot-flagged misleading output: ``uses: # comment`` must
+        # report an empty value rather than treating the comment as the
+        # literal reference.
+        text = "      - uses: # just a note\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "")
+        self.assertIn("empty", violations[0][2])
 
 
 # ===================================================================

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -20,7 +20,6 @@ Covers:
 import io
 import json
 import os
-import sys
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -483,6 +483,51 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertEqual(len(violations), 1)
         self.assertEqual(violations[0][1], "org/repo@main")
 
+    def test_flow_pattern_inside_literal_block_scalar_not_flagged(self) -> None:
+        # Codex-flagged false-positive: ``key: { uses: ... }`` inside
+        # a ``run: |`` block body is shell content, not YAML structure.
+        # The scanner tracks block-scalar indent and skips the body.
+        text = (
+            "    - name: demo\n"
+            "      run: |\n"
+            "        echo hi\n"
+            "        key: { uses: foo@v1 }\n"
+        )
+        self.assertEqual(scan_workflow(text), [])
+
+    def test_flow_pattern_inside_folded_block_scalar_not_flagged(self) -> None:
+        # ``run: >`` (folded block scalar) has the same semantics.
+        text = (
+            "    - name: demo\n"
+            "      run: >\n"
+            "        key: { uses: foo@v1 }\n"
+        )
+        self.assertEqual(scan_workflow(text), [])
+
+    def test_block_scalar_with_chomping_indicator_is_recognised(self) -> None:
+        # Chomping indicators (|-, >-, |+, >+) and explicit indent
+        # (``|2``) also open block scalars. The opener regex must
+        # accept them or a malformed-looking run body would leak.
+        text = (
+            "    run: |-\n"
+            "      key: { uses: foo@v1 }\n"
+        )
+        self.assertEqual(scan_workflow(text), [])
+
+    def test_block_scalar_ends_when_line_dedents(self) -> None:
+        # After the scalar closes, subsequent ``uses:`` lines must be
+        # scanned normally.
+        text = (
+            "    - name: demo\n"
+            "      run: |\n"
+            "        echo hi\n"
+            "    - uses: actions/checkout@v4\n"
+        )
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][0], 4)
+        self.assertEqual(violations[0][1], "actions/checkout@v4")
+
 
 # ===================================================================
 # collect_violations / list_workflow_files

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -536,18 +536,23 @@ class CollectViolationsTests(unittest.TestCase):
         # Copilot-flagged contract gap: the docstring promised absolute
         # paths but the function previously echoed whatever the caller
         # passed. Feeding a relative path must now come back absolute.
-        cwd = os.getcwd()
-        try:
-            with tempfile.TemporaryDirectory() as root:
-                os.chdir(root)
+        #
+        # chdir back to the original cwd *inside* the TemporaryDirectory
+        # context so the cleanup in ``__exit__`` does not try to remove
+        # the current working directory (which fails with WinError 32
+        # on Windows matrix cells).
+        with tempfile.TemporaryDirectory() as root:
+            cwd = os.getcwd()
+            os.chdir(root)
+            try:
                 rel = "workflows"
                 _write(os.path.join(rel, "a.yaml"), "")
                 paths = list_workflow_files(rel)
                 self.assertEqual(len(paths), 1)
                 self.assertTrue(os.path.isabs(paths[0]))
                 self.assertTrue(paths[0].endswith("a.yaml"))
-        finally:
-            os.chdir(cwd)
+            finally:
+                os.chdir(cwd)
 
     def test_non_yaml_file_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as wf:

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -289,7 +289,7 @@ class ScanWorkflowTests(unittest.TestCase):
 
 class CollectViolationsTests(unittest.TestCase):
 
-    def test_mixed_directory_reports_relative_paths(self) -> None:
+    def test_mixed_directory_labels_paths_canonically(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             wf = os.path.join(root, ".github", "workflows")
             _write(
@@ -300,9 +300,11 @@ class CollectViolationsTests(unittest.TestCase):
                 os.path.join(wf, "bad.yml"),
                 _INVALID_WORKFLOW,
             )
-            violations = collect_violations(wf, root)
+            violations = collect_violations(wf)
             files = {v["file"] for v in violations}
-            # Only bad.yml should contribute.
+            # Only bad.yml should contribute, labelled with the
+            # production .github/workflows/ prefix regardless of where
+            # the temp directory lives on disk.
             self.assertEqual(
                 files,
                 {".github/workflows/bad.yml"},
@@ -312,8 +314,7 @@ class CollectViolationsTests(unittest.TestCase):
                 self.assertNotIn("\\", v["file"])
 
     def test_sorted_by_file_then_line(self) -> None:
-        with tempfile.TemporaryDirectory() as root:
-            wf = os.path.join(root, ".github", "workflows")
+        with tempfile.TemporaryDirectory() as wf:
             _write(
                 os.path.join(wf, "z.yaml"),
                 f"uses: actions/checkout@v4\nuses: actions/checkout@main\n",
@@ -322,7 +323,7 @@ class CollectViolationsTests(unittest.TestCase):
                 os.path.join(wf, "a.yaml"),
                 f"uses: actions/checkout@v4\n",
             )
-            violations = collect_violations(wf, root)
+            violations = collect_violations(wf)
             self.assertEqual(
                 [(v["file"], v["line"]) for v in violations],
                 [
@@ -335,7 +336,7 @@ class CollectViolationsTests(unittest.TestCase):
     def test_missing_directory_returns_empty(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             self.assertEqual(
-                collect_violations(os.path.join(root, "does-not-exist"), root),
+                collect_violations(os.path.join(root, "does-not-exist")),
                 [],
             )
             self.assertEqual(
@@ -344,17 +345,28 @@ class CollectViolationsTests(unittest.TestCase):
             )
 
     def test_non_yaml_file_ignored(self) -> None:
-        with tempfile.TemporaryDirectory() as root:
-            wf = os.path.join(root, ".github", "workflows")
+        with tempfile.TemporaryDirectory() as wf:
             _write(
                 os.path.join(wf, "README.md"),
                 "uses: actions/checkout@v4\n",
             )
-            self.assertEqual(collect_violations(wf, root), [])
+            self.assertEqual(collect_violations(wf), [])
+
+    def test_empty_workflow_file_produces_no_violations(self) -> None:
+        with tempfile.TemporaryDirectory() as wf:
+            _write(os.path.join(wf, "empty.yaml"), "")
+            self.assertEqual(collect_violations(wf), [])
+
+    def test_comments_only_file_produces_no_violations(self) -> None:
+        with tempfile.TemporaryDirectory() as wf:
+            _write(
+                os.path.join(wf, "comments.yaml"),
+                "# uses: actions/checkout@v4\n# another comment\n",
+            )
+            self.assertEqual(collect_violations(wf), [])
 
     def test_unreadable_file_surfaces_as_read_error(self) -> None:
-        with tempfile.TemporaryDirectory() as root:
-            wf = os.path.join(root, ".github", "workflows")
+        with tempfile.TemporaryDirectory() as wf:
             path = os.path.join(wf, "oops.yaml")
             _write(path, "placeholder")
             # Force an OSError from ``open`` without touching the FS.
@@ -366,7 +378,7 @@ class CollectViolationsTests(unittest.TestCase):
                 return real_open(p, *args, **kwargs)
 
             with mock.patch("builtins.open", side_effect=_boom):
-                violations = collect_violations(wf, root)
+                violations = collect_violations(wf)
             self.assertEqual(len(violations), 1)
             self.assertEqual(violations[0]["line"], 0)
             self.assertIn("read-error", violations[0]["reason"])
@@ -446,7 +458,7 @@ class MainTests(unittest.TestCase):
             self.assertEqual(
                 set(entry.keys()), {"file", "line", "uses", "reason"}
             )
-            self.assertEqual(entry["file"], "workflows/bad.yaml")
+            self.assertEqual(entry["file"], ".github/workflows/bad.yaml")
 
     def test_json_empty_output(self) -> None:
         with tempfile.TemporaryDirectory() as root:

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -24,6 +24,7 @@ import os
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
+from typing import cast
 from unittest import mock
 
 # The filename uses hyphens so import the module via importlib.
@@ -101,8 +102,7 @@ class ClassifyRejectedTests(unittest.TestCase):
     def test_tag_ref_rejected(self) -> None:
         reason = classify("actions/checkout@v4")
         self.assertIsNotNone(reason)
-        assert reason is not None
-        self.assertIn("40-character", reason)
+        self.assertIn("40-character", cast(str, reason))
 
     def test_branch_ref_rejected(self) -> None:
         reason = classify("actions/checkout@main")
@@ -124,8 +124,7 @@ class ClassifyRejectedTests(unittest.TestCase):
     def test_missing_at_rejected(self) -> None:
         reason = classify("actions/checkout")
         self.assertIsNotNone(reason)
-        assert reason is not None
-        self.assertIn("pin", reason)
+        self.assertIn("pin", cast(str, reason))
 
     def test_missing_owner_rejected(self) -> None:
         reason = classify(f"checkout@{_SHA}")
@@ -134,22 +133,19 @@ class ClassifyRejectedTests(unittest.TestCase):
     def test_parent_traversal_local_path_rejected(self) -> None:
         reason = classify("../foo")
         self.assertIsNotNone(reason)
-        assert reason is not None
-        self.assertIn("parent traversal", reason)
+        self.assertIn("parent traversal", cast(str, reason))
 
     def test_dot_slash_parent_traversal_rejected(self) -> None:
         # The accept-./ branch must not short-circuit when the path
         # immediately escapes via ../ — this was a Codex-flagged bypass.
         reason = classify("./../foo")
         self.assertIsNotNone(reason)
-        assert reason is not None
-        self.assertIn("parent traversal", reason)
+        self.assertIn("parent traversal", cast(str, reason))
 
     def test_embedded_parent_traversal_rejected(self) -> None:
         reason = classify("./foo/../bar")
         self.assertIsNotNone(reason)
-        assert reason is not None
-        self.assertIn("parent traversal", reason)
+        self.assertIn("parent traversal", cast(str, reason))
 
     def test_trailing_parent_segment_rejected(self) -> None:
         reason = classify("./foo/..")
@@ -190,16 +186,14 @@ class ClassifyRejectedTests(unittest.TestCase):
         # ``./`` with no suffix is not a real local action path.
         reason = classify("./")
         self.assertIsNotNone(reason)
-        assert reason is not None
-        self.assertIn("empty", reason)
+        self.assertIn("empty", cast(str, reason))
 
     def test_bare_docker_scheme_rejected(self) -> None:
         # ``docker://`` with no image reference is a malformed value
         # that would fail at workflow runtime; the gate rejects it.
         reason = classify("docker://")
         self.assertIsNotNone(reason)
-        assert reason is not None
-        self.assertIn("empty", reason)
+        self.assertIn("empty", cast(str, reason))
 
     def test_whitespace_only_value_is_empty(self) -> None:
         # classify strips its input so a standalone caller passing
@@ -207,8 +201,7 @@ class ClassifyRejectedTests(unittest.TestCase):
         # the scan path produces.
         reason = classify("    ")
         self.assertIsNotNone(reason)
-        assert reason is not None
-        self.assertIn("empty", reason)
+        self.assertIn("empty", cast(str, reason))
 
 
 # ===================================================================

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -1,0 +1,473 @@
+"""Tests for .github/scripts/verify-action-pins.py.
+
+Covers:
+  * ``classify`` — every row of the rules table plus rejected forms
+    (tag, branch name, uppercase hex, short hex, missing '@', missing
+    owner, parent-traversal local path, empty value, bare docker ref).
+  * ``_strip_inline`` — unquoted + trailing YAML comment, single- and
+    double-quoted values with trailing comment, no comment, unterminated
+    quote, tab-separated comment.
+  * ``scan_workflow`` — list-item form (``- uses:``), key form, full-line
+    comment skipping, indented keys, multiple violations, zero
+    violations, line numbering.
+  * ``collect_violations`` — mixed workflow directory with allowed and
+    disallowed forms, relative-path reporting, unreadable-file
+    surfacing, empty directory.
+  * ``main`` — human output, JSON output, usage-error exit code,
+    run against the real repository workflows.
+"""
+
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from unittest import mock
+
+# The filename uses hyphens so import the module via importlib.
+import importlib.util
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..")
+)
+_SCRIPT_PATH = os.path.join(
+    _REPO_ROOT, ".github", "scripts", "verify-action-pins.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "verify_action_pins", _SCRIPT_PATH
+)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"Could not load module from {_SCRIPT_PATH}")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+classify = _mod.classify
+_strip_inline = _mod._strip_inline
+scan_workflow = _mod.scan_workflow
+collect_violations = _mod.collect_violations
+list_workflow_files = _mod.list_workflow_files
+format_human = _mod.format_human
+main = _mod.main
+
+
+# A canonical 40-character lowercase hex SHA for fixtures.
+_SHA = "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+_OTHER_SHA = "a" * 40
+
+
+def _write(path: str, content: str) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+
+# ===================================================================
+# classify — rules table
+# ===================================================================
+
+
+class ClassifyAllowedTests(unittest.TestCase):
+    """Every row of the 'allowed' column must return None."""
+
+    def test_org_repo_sha(self) -> None:
+        self.assertIsNone(classify(f"actions/checkout@{_SHA}"))
+
+    def test_org_repo_subpath_sha(self) -> None:
+        self.assertIsNone(
+            classify(f"milanhorvatovic/codex-ai-code-review-action/prepare@{_SHA}")
+        )
+
+    def test_org_repo_multi_subpath_sha(self) -> None:
+        self.assertIsNone(classify(f"org/repo/a/b/c@{_SHA}"))
+
+    def test_local_action_dot_slash(self) -> None:
+        self.assertIsNone(classify("./.github/actions/foo"))
+
+    def test_docker_tag(self) -> None:
+        self.assertIsNone(classify("docker://alpine:3.19"))
+
+    def test_docker_sha256(self) -> None:
+        self.assertIsNone(
+            classify("docker://alpine@sha256:" + "a" * 64)
+        )
+
+
+class ClassifyRejectedTests(unittest.TestCase):
+    """Every disallowed form must return a non-empty reason string."""
+
+    def test_tag_ref_rejected(self) -> None:
+        reason = classify("actions/checkout@v4")
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertIn("40-character", reason)
+
+    def test_branch_ref_rejected(self) -> None:
+        reason = classify("actions/checkout@main")
+        self.assertIsNotNone(reason)
+
+    def test_short_sha_rejected(self) -> None:
+        reason = classify("actions/checkout@abcdef0")
+        self.assertIsNotNone(reason)
+
+    def test_uppercase_hex_rejected(self) -> None:
+        # Policy is lowercase hex only.
+        reason = classify("actions/checkout@" + _SHA.upper())
+        self.assertIsNotNone(reason)
+
+    def test_forty_char_non_hex_rejected(self) -> None:
+        reason = classify("actions/checkout@" + "g" * 40)
+        self.assertIsNotNone(reason)
+
+    def test_missing_at_rejected(self) -> None:
+        reason = classify("actions/checkout")
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertIn("pin", reason)
+
+    def test_missing_owner_rejected(self) -> None:
+        reason = classify(f"checkout@{_SHA}")
+        self.assertIsNotNone(reason)
+
+    def test_parent_traversal_local_path_rejected(self) -> None:
+        reason = classify("../foo")
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertIn("./", reason)
+
+    def test_empty_value_rejected(self) -> None:
+        reason = classify("")
+        self.assertIsNotNone(reason)
+
+    def test_trailing_at_with_empty_ref_rejected(self) -> None:
+        reason = classify("actions/checkout@")
+        self.assertIsNotNone(reason)
+
+
+# ===================================================================
+# _strip_inline — comment and quote handling
+# ===================================================================
+
+
+class StripInlineTests(unittest.TestCase):
+
+    def test_plain_value(self) -> None:
+        self.assertEqual(
+            _strip_inline(f"actions/checkout@{_SHA}"),
+            f"actions/checkout@{_SHA}",
+        )
+
+    def test_trailing_space_comment_stripped(self) -> None:
+        self.assertEqual(
+            _strip_inline(f"actions/checkout@{_SHA} # @v6 as 6.0.2"),
+            f"actions/checkout@{_SHA}",
+        )
+
+    def test_trailing_tab_comment_stripped(self) -> None:
+        self.assertEqual(
+            _strip_inline(f"actions/checkout@{_SHA}\t# pinned"),
+            f"actions/checkout@{_SHA}",
+        )
+
+    def test_single_quoted_value(self) -> None:
+        self.assertEqual(
+            _strip_inline(f"'actions/checkout@{_SHA}'  # comment"),
+            f"actions/checkout@{_SHA}",
+        )
+
+    def test_double_quoted_value(self) -> None:
+        self.assertEqual(
+            _strip_inline(f'"actions/checkout@{_SHA}"'),
+            f"actions/checkout@{_SHA}",
+        )
+
+    def test_unterminated_quote_falls_through(self) -> None:
+        # Should not crash; returns as-is so classify surfaces a failure.
+        result = _strip_inline(f"'actions/checkout@{_SHA}")
+        self.assertIn(_SHA, result)
+
+    def test_hash_without_leading_space_kept(self) -> None:
+        # '#' not preceded by whitespace is part of the value, not a
+        # comment. Classifier will still reject because the ref is not
+        # a bare 40-hex SHA — but the stripper must not eat it.
+        self.assertEqual(
+            _strip_inline("actions/checkout@abc#frag"),
+            "actions/checkout@abc#frag",
+        )
+
+    def test_empty_input(self) -> None:
+        self.assertEqual(_strip_inline(""), "")
+
+
+# ===================================================================
+# scan_workflow — line-level behaviour
+# ===================================================================
+
+
+_VALID_WORKFLOW = f"""name: ok
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@{_SHA} # @v6 as 6.0.2
+      - uses: org/repo/sub@{_OTHER_SHA}
+      - name: Local
+        uses: ./.github/actions/foo
+      - name: Docker
+        uses: docker://alpine:3.19
+"""
+
+
+_INVALID_WORKFLOW = f"""name: bad
+on: push
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@main
+      - uses: '../escape'
+      # uses: actions/ignored@v1   # full-line comment, must be skipped
+      - uses: "actions/quoted@v2"
+"""
+
+
+class ScanWorkflowTests(unittest.TestCase):
+
+    def test_valid_workflow_has_no_violations(self) -> None:
+        self.assertEqual(scan_workflow(_VALID_WORKFLOW), [])
+
+    def test_invalid_workflow_flags_each_bad_line(self) -> None:
+        violations = scan_workflow(_INVALID_WORKFLOW)
+        # Expect four violations: v4, main, ../escape, quoted@v2.
+        self.assertEqual(len(violations), 4)
+        values = [v[1] for v in violations]
+        self.assertIn("actions/checkout@v4", values)
+        self.assertIn("actions/setup-python@main", values)
+        self.assertIn("../escape", values)
+        self.assertIn("actions/quoted@v2", values)
+
+    def test_full_line_comment_is_skipped(self) -> None:
+        violations = scan_workflow(_INVALID_WORKFLOW)
+        self.assertFalse(
+            any("ignored" in v[1] for v in violations),
+            f"commented-out line was picked up: {violations}",
+        )
+
+    def test_line_numbers_are_one_indexed(self) -> None:
+        text = "steps:\n  - uses: actions/checkout@v4\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][0], 2)
+
+    def test_key_form_without_list_marker(self) -> None:
+        text = f"uses: actions/checkout@v4\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "actions/checkout@v4")
+
+    def test_indented_key_form(self) -> None:
+        text = f"        uses: actions/checkout@{_SHA}\n"
+        self.assertEqual(scan_workflow(text), [])
+
+    def test_uses_inside_run_block_not_flagged_when_commented(self) -> None:
+        # Full-line comment is always safe; the line-based scanner is
+        # not expected to understand multi-line ``run:`` bodies, so this
+        # test only asserts the commented-out form is skipped.
+        text = "      # uses: actions/checkout@v4\n"
+        self.assertEqual(scan_workflow(text), [])
+
+
+# ===================================================================
+# collect_violations / list_workflow_files
+# ===================================================================
+
+
+class CollectViolationsTests(unittest.TestCase):
+
+    def test_mixed_directory_reports_relative_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            wf = os.path.join(root, ".github", "workflows")
+            _write(
+                os.path.join(wf, "good.yaml"),
+                _VALID_WORKFLOW,
+            )
+            _write(
+                os.path.join(wf, "bad.yml"),
+                _INVALID_WORKFLOW,
+            )
+            violations = collect_violations(wf, root)
+            files = {v["file"] for v in violations}
+            # Only bad.yml should contribute.
+            self.assertEqual(
+                files,
+                {".github/workflows/bad.yml"},
+            )
+            # Paths use forward slashes even on Windows.
+            for v in violations:
+                self.assertNotIn("\\", v["file"])
+
+    def test_sorted_by_file_then_line(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            wf = os.path.join(root, ".github", "workflows")
+            _write(
+                os.path.join(wf, "z.yaml"),
+                f"uses: actions/checkout@v4\nuses: actions/checkout@main\n",
+            )
+            _write(
+                os.path.join(wf, "a.yaml"),
+                f"uses: actions/checkout@v4\n",
+            )
+            violations = collect_violations(wf, root)
+            self.assertEqual(
+                [(v["file"], v["line"]) for v in violations],
+                [
+                    (".github/workflows/a.yaml", 1),
+                    (".github/workflows/z.yaml", 1),
+                    (".github/workflows/z.yaml", 2),
+                ],
+            )
+
+    def test_missing_directory_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(
+                collect_violations(os.path.join(root, "does-not-exist"), root),
+                [],
+            )
+            self.assertEqual(
+                list_workflow_files(os.path.join(root, "does-not-exist")),
+                [],
+            )
+
+    def test_non_yaml_file_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            wf = os.path.join(root, ".github", "workflows")
+            _write(
+                os.path.join(wf, "README.md"),
+                "uses: actions/checkout@v4\n",
+            )
+            self.assertEqual(collect_violations(wf, root), [])
+
+    def test_unreadable_file_surfaces_as_read_error(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            wf = os.path.join(root, ".github", "workflows")
+            path = os.path.join(wf, "oops.yaml")
+            _write(path, "placeholder")
+            # Force an OSError from ``open`` without touching the FS.
+            real_open = open
+
+            def _boom(p, *args, **kwargs):  # type: ignore[no-untyped-def]
+                if os.path.abspath(p) == os.path.abspath(path):
+                    raise OSError("simulated unreadable")
+                return real_open(p, *args, **kwargs)
+
+            with mock.patch("builtins.open", side_effect=_boom):
+                violations = collect_violations(wf, root)
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0]["line"], 0)
+            self.assertIn("read-error", violations[0]["reason"])
+
+
+# ===================================================================
+# format_human
+# ===================================================================
+
+
+class FormatHumanTests(unittest.TestCase):
+
+    def test_empty(self) -> None:
+        self.assertEqual(
+            format_human([]),
+            "All workflow `uses:` references are SHA-pinned.",
+        )
+
+    def test_single(self) -> None:
+        line = format_human(
+            [
+                {
+                    "file": ".github/workflows/bad.yaml",
+                    "line": 7,
+                    "uses": "actions/checkout@v4",
+                    "reason": "not pinned",
+                }
+            ]
+        )
+        self.assertEqual(
+            line,
+            "FAIL: .github/workflows/bad.yaml:7: actions/checkout@v4 -- not pinned",
+        )
+
+
+# ===================================================================
+# main — CLI wiring
+# ===================================================================
+
+
+class MainTests(unittest.TestCase):
+
+    def _run(
+        self, argv: list[str]
+    ) -> tuple[int, str, str]:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(argv)
+        return code, out.getvalue(), err.getvalue()
+
+    def test_clean_run_human(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            wf = os.path.join(root, ".github", "workflows")
+            _write(os.path.join(wf, "ok.yaml"), _VALID_WORKFLOW)
+            code, stdout, _ = self._run(["--workflows-dir", wf])
+        self.assertEqual(code, 0)
+        self.assertIn("SHA-pinned", stdout)
+
+    def test_violations_return_one(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            wf = os.path.join(root, ".github", "workflows")
+            _write(os.path.join(wf, "bad.yaml"), _INVALID_WORKFLOW)
+            code, stdout, _ = self._run(["--workflows-dir", wf])
+        self.assertEqual(code, 1)
+        self.assertIn("FAIL:", stdout)
+
+    def test_json_output_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            wf = os.path.join(root, ".github", "workflows")
+            _write(os.path.join(wf, "bad.yaml"), _INVALID_WORKFLOW)
+            code, stdout, _ = self._run(["--workflows-dir", wf, "--json"])
+        self.assertEqual(code, 1)
+        payload = json.loads(stdout)
+        self.assertIsInstance(payload, list)
+        self.assertTrue(payload)
+        for entry in payload:
+            self.assertEqual(
+                set(entry.keys()), {"file", "line", "uses", "reason"}
+            )
+            self.assertEqual(entry["file"], "workflows/bad.yaml")
+
+    def test_json_empty_output(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            wf = os.path.join(root, ".github", "workflows")
+            _write(os.path.join(wf, "ok.yaml"), _VALID_WORKFLOW)
+            code, stdout, _ = self._run(["--workflows-dir", wf, "--json"])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(stdout), [])
+
+    def test_usage_error_returns_two(self) -> None:
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            code = main(["--nope"])
+        self.assertEqual(code, 2)
+
+    def test_real_repository_workflows_pass(self) -> None:
+        # The whole point: the repo's current workflow files are all
+        # SHA-pinned, so the default invocation must succeed.
+        code, _, _ = self._run([])
+        self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -137,7 +137,7 @@ class ClassifyRejectedTests(unittest.TestCase):
 
     def test_dot_slash_parent_traversal_rejected(self) -> None:
         # The accept-./ branch must not short-circuit when the path
-        # immediately escapes via ../ — this was a Codex-flagged bypass.
+        # immediately escapes via ../ — a previously-missed bypass.
         reason = classify("./../foo")
         self.assertIsNotNone(reason)
         self.assertIn("parent traversal", cast(str, reason))
@@ -164,7 +164,7 @@ class ClassifyRejectedTests(unittest.TestCase):
         self.assertIsNotNone(reason)
 
     def test_empty_repo_segment_rejected(self) -> None:
-        # Copilot-flagged bypass: ``org/@<sha>`` previously passed
+        # Regression: ``org/@<sha>`` previously passed
         # because the naive ``"/" in prefix`` check was truthy even
         # though the repo segment is empty.
         reason = classify(f"org/@{_SHA}")
@@ -347,7 +347,7 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertEqual(scan_workflow(text), [])
 
     def test_single_quoted_key_is_flagged(self) -> None:
-        # Codex-flagged bypass: YAML permits quoted mapping keys, and
+        # Regression: YAML permits quoted mapping keys, and
         # GitHub Actions treats them identically. The gate must detect
         # them or an unpinned action can slip past.
         text = "      - 'uses': actions/checkout@v4\n"
@@ -368,7 +368,7 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertEqual(violations[0][1], "actions/checkout@v4")
 
     def test_empty_uses_value_is_flagged(self) -> None:
-        # Copilot-flagged hole: an empty ``uses:`` used to be missed
+        # Regression: an empty ``uses:`` used to be missed
         # because the value regex required at least one non-whitespace
         # character. classify already rejects "" — the scanner must now
         # reach it.
@@ -391,7 +391,7 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertIn("parent traversal", violations[0][2])
 
     def test_inline_comment_after_empty_uses_is_flagged_as_empty(self) -> None:
-        # Copilot-flagged misleading output: ``uses: # comment`` must
+        # Regression: ``uses: # comment`` must
         # report an empty value rather than treating the comment as the
         # literal reference.
         text = "      - uses: # just a note\n"
@@ -401,7 +401,7 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertIn("empty", violations[0][2])
 
     def test_flow_style_tag_is_flagged(self) -> None:
-        # Copilot-flagged flow-style bypass: ``- { uses: ref }`` is
+        # Regression: ``- { uses: ref }`` is
         # valid YAML and valid GHA step syntax; the gate must match it.
         text = "      - { uses: actions/checkout@v4 }\n"
         violations = scan_workflow(text)
@@ -425,7 +425,7 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertEqual(violations[0][1], "actions/checkout@v4")
 
     def test_flow_pattern_inside_run_body_not_flagged(self) -> None:
-        # Codex-flagged false-positive: ``{ uses: ... }`` appearing as
+        # Regression: ``{ uses: ... }`` appearing as
         # literal text inside a ``run:`` script body is scalar content,
         # not a flow-mapping step. The flow regex must not match here
         # or every such run-block would trip CI.
@@ -443,7 +443,7 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertEqual(scan_workflow(text), [])
 
     def test_keyed_flow_mapping_unpinned_is_flagged(self) -> None:
-        # Codex-flagged bypass: reusable-workflow jobs can be written
+        # Regression: reusable-workflow jobs can be written
         # as ``job-id: { uses: ... }``. The flow matcher must run on
         # those lines too, not just bare-step or list-item forms.
         text = (
@@ -470,7 +470,7 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertEqual(violations[0][1], "org/repo@v4")
 
     def test_single_quoted_keyed_flow_is_flagged(self) -> None:
-        # Codex-flagged bypass: quoted YAML mapping keys are valid, so
+        # Regression: quoted YAML mapping keys are valid, so
         # "'call': { uses: ... }" must also run through the flow scan.
         text = "  'call': { uses: org/repo@v4 }\n"
         violations = scan_workflow(text)
@@ -484,7 +484,7 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertEqual(violations[0][1], "org/repo@main")
 
     def test_flow_pattern_inside_literal_block_scalar_not_flagged(self) -> None:
-        # Codex-flagged false-positive: ``key: { uses: ... }`` inside
+        # Regression: ``key: { uses: ... }`` inside
         # a ``run: |`` block body is shell content, not YAML structure.
         # The scanner tracks block-scalar indent and skips the body.
         text = (
@@ -592,7 +592,7 @@ class CollectViolationsTests(unittest.TestCase):
             )
 
     def test_list_workflow_files_returns_absolute_paths(self) -> None:
-        # Copilot-flagged contract gap: the docstring promised absolute
+        # Regression: the docstring promised absolute
         # paths but the function previously echoed whatever the caller
         # passed. Feeding a relative path must now come back absolute.
         #
@@ -622,7 +622,7 @@ class CollectViolationsTests(unittest.TestCase):
             self.assertEqual(collect_violations(wf), [])
 
     def test_directory_with_yaml_suffix_is_not_scanned(self) -> None:
-        # Codex-flagged false-fail: a directory whose name ends in
+        # Regression: a directory whose name ends in
         # .yaml used to be passed to open(), producing a spurious
         # ``read-error: IsADirectoryError`` violation. list_workflow_files
         # now filters to regular files so the directory is ignored.
@@ -632,7 +632,7 @@ class CollectViolationsTests(unittest.TestCase):
             self.assertEqual(list_workflow_files(wf), [])
 
     def test_unreadable_directory_surfaces_as_list_error(self) -> None:
-        # Copilot-flagged crash path: os.listdir raises OSError
+        # Regression: os.listdir raises OSError
         # (e.g. PermissionError) when the directory is unreadable.
         # collect_violations now surfaces that as a structured
         # ``list-error`` violation instead of crashing.
@@ -680,7 +680,7 @@ class CollectViolationsTests(unittest.TestCase):
             self.assertIn("read-error", violations[0]["reason"])
 
     def test_invalid_utf8_file_surfaces_as_read_error(self) -> None:
-        # Copilot-flagged crash path: bytes that are not valid UTF-8
+        # Regression: bytes that are not valid UTF-8
         # raise UnicodeDecodeError during fh.read(). The gate catches
         # UnicodeError alongside OSError so the run produces a
         # structured violation instead of crashing.
@@ -792,7 +792,7 @@ class MainTests(unittest.TestCase):
         self.assertEqual(code, 0)
 
     def test_missing_workflows_dir_fails_closed(self) -> None:
-        # Copilot-flagged false-green: a missing directory used to exit
+        # Regression: a missing directory used to exit
         # 0 with "All workflow `uses:` references are SHA-pinned." The
         # gate now fails closed with a clear error on stderr.
         with tempfile.TemporaryDirectory() as root:

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -166,6 +166,25 @@ class ClassifyRejectedTests(unittest.TestCase):
         reason = classify("actions/checkout@")
         self.assertIsNotNone(reason)
 
+    def test_empty_repo_segment_rejected(self) -> None:
+        # Copilot-flagged bypass: ``org/@<sha>`` previously passed
+        # because the naive ``"/" in prefix`` check was truthy even
+        # though the repo segment is empty.
+        reason = classify(f"org/@{_SHA}")
+        self.assertIsNotNone(reason)
+
+    def test_empty_owner_segment_rejected(self) -> None:
+        reason = classify(f"/repo@{_SHA}")
+        self.assertIsNotNone(reason)
+
+    def test_double_slash_in_prefix_rejected(self) -> None:
+        reason = classify(f"org//sub@{_SHA}")
+        self.assertIsNotNone(reason)
+
+    def test_bare_slash_prefix_rejected(self) -> None:
+        reason = classify(f"/@{_SHA}")
+        self.assertIsNotNone(reason)
+
 
 # ===================================================================
 # _strip_inline — comment and quote handling

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -586,6 +586,23 @@ class CollectViolationsTests(unittest.TestCase):
             self.assertEqual(collect_violations(wf), [])
             self.assertEqual(list_workflow_files(wf), [])
 
+    def test_unreadable_directory_surfaces_as_list_error(self) -> None:
+        # Copilot-flagged crash path: os.listdir raises OSError
+        # (e.g. PermissionError) when the directory is unreadable.
+        # collect_violations now surfaces that as a structured
+        # ``list-error`` violation instead of crashing.
+        with tempfile.TemporaryDirectory() as wf:
+            with mock.patch(
+                "os.listdir",
+                side_effect=PermissionError("simulated denial"),
+            ):
+                violations = collect_violations(wf)
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0]["file"], ".github/workflows/")
+            self.assertEqual(violations[0]["line"], 0)
+            self.assertIn("list-error", violations[0]["reason"])
+            self.assertIn("PermissionError", violations[0]["reason"])
+
     def test_empty_workflow_file_produces_no_violations(self) -> None:
         with tempfile.TemporaryDirectory() as wf:
             _write(os.path.join(wf, "empty.yaml"), "")

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -3,7 +3,8 @@
 Covers:
   * ``classify`` — every row of the rules table plus rejected forms
     (tag, branch name, uppercase hex, short hex, missing '@', missing
-    owner, parent-traversal local path, empty value, bare docker ref).
+    owner or repo segment, parent-traversal local path, empty value,
+    whitespace-only value, bare ``./``, bare ``docker://``).
   * ``_strip_inline`` — unquoted + trailing YAML comment, single- and
     double-quoted values with trailing comment, no comment, unterminated
     quote, tab-separated comment.
@@ -184,6 +185,30 @@ class ClassifyRejectedTests(unittest.TestCase):
     def test_bare_slash_prefix_rejected(self) -> None:
         reason = classify(f"/@{_SHA}")
         self.assertIsNotNone(reason)
+
+    def test_bare_dot_slash_rejected(self) -> None:
+        # ``./`` with no suffix is not a real local action path.
+        reason = classify("./")
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertIn("empty", reason)
+
+    def test_bare_docker_scheme_rejected(self) -> None:
+        # ``docker://`` with no image reference is a malformed value
+        # that would fail at workflow runtime; the gate rejects it.
+        reason = classify("docker://")
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertIn("empty", reason)
+
+    def test_whitespace_only_value_is_empty(self) -> None:
+        # classify strips its input so a standalone caller passing
+        # whitespace-only text gets the same "empty uses value" reason
+        # the scan path produces.
+        reason = classify("    ")
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertIn("empty", reason)
 
 
 # ===================================================================

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -431,6 +431,24 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertEqual(len(violations), 1)
         self.assertEqual(violations[0][1], "actions/checkout@v4")
 
+    def test_flow_pattern_inside_run_body_not_flagged(self) -> None:
+        # Codex-flagged false-positive: ``{ uses: ... }`` appearing as
+        # literal text inside a ``run:`` script body is scalar content,
+        # not a flow-mapping step. The flow regex must not match here
+        # or every such run-block would trip CI.
+        text = (
+            "    - name: demo\n"
+            "      run: echo '{ uses: actions/checkout@v4 }'\n"
+        )
+        self.assertEqual(scan_workflow(text), [])
+
+    def test_flow_pattern_in_other_scalar_not_flagged(self) -> None:
+        # Any line whose step body does not begin with '{' is ignored
+        # by the flow matcher. A value that happens to look like a
+        # flow fragment inside a string must not register.
+        text = "    - name: note { uses: actions/checkout@v4 }\n"
+        self.assertEqual(scan_workflow(text), [])
+
 
 # ===================================================================
 # collect_violations / list_workflow_files
@@ -532,6 +550,21 @@ class CollectViolationsTests(unittest.TestCase):
             self.assertEqual(len(violations), 1)
             self.assertEqual(violations[0]["line"], 0)
             self.assertIn("read-error", violations[0]["reason"])
+
+    def test_invalid_utf8_file_surfaces_as_read_error(self) -> None:
+        # Copilot-flagged crash path: bytes that are not valid UTF-8
+        # raise UnicodeDecodeError during fh.read(). The gate catches
+        # UnicodeError alongside OSError so the run produces a
+        # structured violation instead of crashing.
+        with tempfile.TemporaryDirectory() as wf:
+            path = os.path.join(wf, "bad-bytes.yaml")
+            with open(path, "wb") as fh:
+                fh.write(b"name: \xff\xfe not utf-8\n")
+            violations = collect_violations(wf)
+            self.assertEqual(len(violations), 1)
+            self.assertEqual(violations[0]["line"], 0)
+            self.assertIn("read-error", violations[0]["reason"])
+            self.assertIn("UnicodeDecodeError", violations[0]["reason"])
 
 
 # ===================================================================

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -134,7 +134,29 @@ class ClassifyRejectedTests(unittest.TestCase):
         reason = classify("../foo")
         self.assertIsNotNone(reason)
         assert reason is not None
-        self.assertIn("./", reason)
+        self.assertIn("parent traversal", reason)
+
+    def test_dot_slash_parent_traversal_rejected(self) -> None:
+        # The accept-./ branch must not short-circuit when the path
+        # immediately escapes via ../ — this was a Codex-flagged bypass.
+        reason = classify("./../foo")
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertIn("parent traversal", reason)
+
+    def test_embedded_parent_traversal_rejected(self) -> None:
+        reason = classify("./foo/../bar")
+        self.assertIsNotNone(reason)
+        assert reason is not None
+        self.assertIn("parent traversal", reason)
+
+    def test_trailing_parent_segment_rejected(self) -> None:
+        reason = classify("./foo/..")
+        self.assertIsNotNone(reason)
+
+    def test_bare_double_dot_rejected(self) -> None:
+        reason = classify("..")
+        self.assertIsNotNone(reason)
 
     def test_empty_value_rejected(self) -> None:
         reason = classify("")
@@ -279,6 +301,50 @@ class ScanWorkflowTests(unittest.TestCase):
         # test only asserts the commented-out form is skipped.
         text = "      # uses: actions/checkout@v4\n"
         self.assertEqual(scan_workflow(text), [])
+
+    def test_single_quoted_key_is_flagged(self) -> None:
+        # Codex-flagged bypass: YAML permits quoted mapping keys, and
+        # GitHub Actions treats them identically. The gate must detect
+        # them or an unpinned action can slip past.
+        text = "      - 'uses': actions/checkout@v4\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "actions/checkout@v4")
+
+    def test_double_quoted_key_is_flagged(self) -> None:
+        text = '      - "uses": actions/checkout@main\n'
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "actions/checkout@main")
+
+    def test_quoted_key_with_quoted_value_is_flagged(self) -> None:
+        text = "      - 'uses': 'actions/checkout@v4'\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "actions/checkout@v4")
+
+    def test_empty_uses_value_is_flagged(self) -> None:
+        # Copilot-flagged hole: an empty ``uses:`` used to be missed
+        # because the value regex required at least one non-whitespace
+        # character. classify already rejects "" — the scanner must now
+        # reach it.
+        text = "      - uses:\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "")
+        self.assertIn("empty", violations[0][2])
+
+    def test_whitespace_only_uses_value_is_flagged(self) -> None:
+        text = "      - uses:   \n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "")
+
+    def test_dot_slash_parent_traversal_line_is_flagged(self) -> None:
+        text = "      - uses: ./../escape\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("parent traversal", violations[0][2])
 
 
 # ===================================================================

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -469,6 +469,20 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertEqual(len(violations), 1)
         self.assertEqual(violations[0][1], "org/repo@v4")
 
+    def test_single_quoted_keyed_flow_is_flagged(self) -> None:
+        # Codex-flagged bypass: quoted YAML mapping keys are valid, so
+        # "'call': { uses: ... }" must also run through the flow scan.
+        text = "  'call': { uses: org/repo@v4 }\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "org/repo@v4")
+
+    def test_double_quoted_keyed_flow_is_flagged(self) -> None:
+        text = '  "call": { uses: org/repo@main }\n'
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "org/repo@main")
+
 
 # ===================================================================
 # collect_violations / list_workflow_files
@@ -561,6 +575,16 @@ class CollectViolationsTests(unittest.TestCase):
                 "uses: actions/checkout@v4\n",
             )
             self.assertEqual(collect_violations(wf), [])
+
+    def test_directory_with_yaml_suffix_is_not_scanned(self) -> None:
+        # Codex-flagged false-fail: a directory whose name ends in
+        # .yaml used to be passed to open(), producing a spurious
+        # ``read-error: IsADirectoryError`` violation. list_workflow_files
+        # now filters to regular files so the directory is ignored.
+        with tempfile.TemporaryDirectory() as wf:
+            os.makedirs(os.path.join(wf, "bogus.yaml"))
+            self.assertEqual(collect_violations(wf), [])
+            self.assertEqual(list_workflow_files(wf), [])
 
     def test_empty_workflow_file_produces_no_violations(self) -> None:
         with tempfile.TemporaryDirectory() as wf:

--- a/tests/test_verify_action_pins.py
+++ b/tests/test_verify_action_pins.py
@@ -407,6 +407,30 @@ class ScanWorkflowTests(unittest.TestCase):
         self.assertEqual(violations[0][1], "")
         self.assertIn("empty", violations[0][2])
 
+    def test_flow_style_tag_is_flagged(self) -> None:
+        # Copilot-flagged flow-style bypass: ``- { uses: ref }`` is
+        # valid YAML and valid GHA step syntax; the gate must match it.
+        text = "      - { uses: actions/checkout@v4 }\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "actions/checkout@v4")
+
+    def test_flow_style_pinned_is_allowed(self) -> None:
+        text = f"      - {{ uses: actions/checkout@{_SHA} }}\n"
+        self.assertEqual(scan_workflow(text), [])
+
+    def test_flow_style_uses_after_other_keys_is_flagged(self) -> None:
+        text = "      - { name: co, uses: actions/checkout@main }\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "actions/checkout@main")
+
+    def test_flow_style_quoted_key_is_flagged(self) -> None:
+        text = "      - { 'uses': actions/checkout@v4 }\n"
+        violations = scan_workflow(text)
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0][1], "actions/checkout@v4")
+
 
 # ===================================================================
 # collect_violations / list_workflow_files
@@ -605,6 +629,17 @@ class MainTests(unittest.TestCase):
         # SHA-pinned, so the default invocation must succeed.
         code, _, _ = self._run([])
         self.assertEqual(code, 0)
+
+    def test_missing_workflows_dir_fails_closed(self) -> None:
+        # Copilot-flagged false-green: a missing directory used to exit
+        # 0 with "All workflow `uses:` references are SHA-pinned." The
+        # gate now fails closed with a clear error on stderr.
+        with tempfile.TemporaryDirectory() as root:
+            ghost = os.path.join(root, "does-not-exist")
+            code, stdout, stderr = self._run(["--workflows-dir", ghost])
+        self.assertEqual(code, 1)
+        self.assertEqual(stdout, "")
+        self.assertIn("workflows directory not found", stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a CI enforcement gate that fails any PR introducing a `uses:` line in `.github/workflows/*.y{a,}ml` that is not pinned to a 40-character lowercase commit SHA (with `./local-path` and `docker://…` as the documented exceptions). The repo already requires SHA pinning by convention, but nothing enforced it — a tag-pinned line would have slipped through CI unnoticed. A new dedicated workflow at `.github/workflows/verify-action-pins.yaml` runs `.github/scripts/verify-action-pins.py` on every PR and push to `main`, giving an unambiguous status-check signal.

Zero blast radius beyond CI: no production code, validation library, or configuration is touched. All existing workflow files pass the new check unchanged.

## What's new

**Script** (`.github/scripts/verify-action-pins.py`, stdlib only, 229 lines)

- Line-based scanner of workflow YAML — no YAML parse needed for this check, per the issue spec.
- Classifier applies the rules-table decisions per `uses:` value: allowed forms short-circuit, everything else returns a human-readable reason string.
- `--json` emits a sorted list of `{file, line, uses, reason}` dicts (shape matches `.github/scripts/preflight-yaml-upgrade.py`).
- Exit codes: 0 clean, 1 on any violation, 2 on argparse/usage errors.

**Workflow** (`.github/workflows/verify-action-pins.yaml`)

- Triggers on `pull_request` and `push: main`, no path filter — the whole point is an unambiguous status check on every PR.
- `permissions: contents: read`, `actions/checkout` pinned to the SHA already used across the repo.

**Tests** (`tests/test_verify_action_pins.py`, 46 cases)

- Table-driven coverage of every allowed and rejected row from the issue's rules table (tag, branch, short SHA, uppercase hex, non-hex, missing `@`, missing owner, empty ref, `../` traversal).
- `_strip_inline` coverage for unquoted + trailing ` #…`, tab-comment, single- and double-quoted, unterminated quote, `#` without leading whitespace, empty input.
- `scan_workflow` line-level tests for list-item form, key form, indented key, full-line comment skipping, one-indexed line numbers, multiple-violation fixtures.
- `collect_violations` tests for mixed directories, canonical `.github/workflows/<basename>` labelling (production and override both emit the same shape), sort order, missing directory, non-YAML files, empty files, comments-only files, and an `OSError` path that surfaces as a `read-error` violation rather than crashing.
- `main` tests for clean run, violations, `--json` shape and empty payload, argparse usage errors (exit 2), and the repo's real workflows (asserts the gate passes today so the PR itself does not fail it).

**Docs** (`.agents/skills/github-actions/SKILL.md`)

- New table row for `verify-action-pins.yaml`.
- Hard-Requirements narrative tells authors the rule is now enforced automatically and how to run the gate locally.
- Review-checklist item #1 ("Are all actions SHA-pinned?") now points at the automated gate instead of asking reviewers to eyeball `uses:` lines.

**Coverage policy** (`.github/workflows/python-tests.yaml`)

- Adds `.github/scripts/verify-action-pins.py=90` to the per-file override list, matching the other `.github/scripts/*.py` entries. Actual branch coverage on the new module is 100%.

## Key decisions

- **Line-based scan, not YAML parse.** The issue spec deliberately prefers a simple scan. A theoretical false positive exists if a `run: |` multi-line block ever starts a line with literal `uses:`; no current workflow trips this and the script's docstring names the tradeoff so a future maintainer does not "fix" it by pulling in a YAML parser.
- **SHA is `[0-9a-f]{40}` (lowercase only).** Matches every existing pin in the repo and keeps the rule a single concrete regex.
- **Local action paths must start with `./`.** `../` traversals are rejected with a clear reason string — GitHub does not resolve parent paths for `uses:` anyway.
- **Docker references accept any `docker://…`.** The issue explicitly allows tag pinning here; the script does not try to be clever about the suffix.
- **`--workflows-dir` override labels paths canonically.** The script always emits `.github/workflows/<basename>` regardless of where the scanned directory actually lives, so a contributor running the gate locally via `--workflows-dir <tmp>` sees the same paths CI would print.
- **`--json` is included even though the issue does not ask for it.** AGENTS.md makes machine-readable output a repo-wide contract for entry points; skipping it would create drift.
- **One-line addition to the per-file coverage override list.** The repo already keeps `.github/scripts/*.py` at a 90% per-file floor; the new script exceeds that with room to spare.

## Acceptance criteria (issue #107)

- [x] Script exists at `.github/scripts/verify-action-pins.py`, stdlib-only
- [x] Script handles all five reference forms per the rules table
- [x] `.github/workflows/verify-action-pins.yaml` runs the script on pull requests and pushes to `main`
- [x] Fixtures cover allowed and disallowed forms per table
- [x] All existing workflow files pass the check unchanged
- [x] Error output names the workflow file and line for each violation

## Test plan

All checks executed locally; results inline.

- [x] `python -m coverage run -m unittest discover -s tests -p "test_*.py"` — **1519 tests pass** (10.2s).
- [x] `python -m coverage report` — **TOTAL 97%** branch coverage (≥ 70% floor). New script: 100% stmt + branch.
- [x] `python skill-system-foundry/scripts/validate_skill.py skill-system-foundry --allow-nested-references --foundry-self` — **exit 0**, 17/17 checks passed, 21 additional skill-wide refs verified.
- [x] `python skill-system-foundry/scripts/audit_skill_system.py skill-system-foundry` — **exit 0**, only the expected distribution-repo WARN.
- [x] `python .github/scripts/verify-action-pins.py` — **exit 0** against the live repo workflows.
- [x] Hand-crafted fixture containing `actions/checkout@v4`, `org/repo@main`, and `./local/ok` — **exit 1**, correct `FAIL:` lines for the two violations, local path not flagged.
- [x] `python .github/scripts/verify-action-pins.py --json` against the same fixture — valid JSON, sorted by `(file, line)`, every entry has `{file, line, uses, reason}`.
- [x] `python -m unittest discover -s tests -p "test_verify_action_pins.py"` — 46/46 pass (0.013s).
- [x] Validate-skill-spec on the touched dev skill (`.agents/skills/github-actions/`) — 8/8 checks passed, no new file references, SKILL.md at 175/500 lines.

Closes #107.