### PR TITLE
Suggest close matches on unknown frontmatter keys

### DIFF
--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -42,6 +42,15 @@ skill:
     - license
     - metadata
 
+  # "Did you mean?" suggestions for unrecognized frontmatter keys.
+  # Parameters are passed to ``difflib.get_close_matches`` in
+  # ``validate_known_keys``.  Calibrated against the known-key set above:
+  # cutoff=0.5 pulls in false positives (meta → name at 0.5); cutoff=0.7
+  # silently drops real typos (meta → metadata at 0.67).
+  frontmatter_suggestions:
+    max_matches: 3
+    cutoff: 0.6
+
   # allowed-tools validation (space-delimited tool names in frontmatter)
   allowed_tools:
     known_tools:

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -174,6 +174,11 @@ MAX_COMPATIBILITY_CHARS = int(_skill["compatibility"]["max_length"])
 # Known frontmatter keys (for unrecognized-key detection)
 KNOWN_FRONTMATTER_KEYS = frozenset(_skill["known_frontmatter_keys"])
 
+# "Did you mean?" suggestion parameters (difflib.get_close_matches)
+_fm_suggest = _skill["frontmatter_suggestions"]
+FRONTMATTER_SUGGEST_MAX_MATCHES = int(_fm_suggest["max_matches"])
+FRONTMATTER_SUGGEST_CUTOFF = float(_fm_suggest["cutoff"])
+
 # Allowed-tools validation
 _allowed_tools = _skill["allowed_tools"]
 KNOWN_TOOLS = frozenset(_allowed_tools["known_tools"])
@@ -269,7 +274,7 @@ CODEX_KNOWN_TOOL_KEYS = frozenset(_codex["known_tool_keys"])
 # Clean up private names
 del _f, _config
 del _skill, _skill_name, _skill_desc, _voice, _skill_body, _body_refs
-del _allowed_tools, _metadata, _plain_scalar, _WS_DECODE
+del _allowed_tools, _metadata, _plain_scalar, _WS_DECODE, _fm_suggest
 del _dep, _role, _bundle
 del _codex, _codex_iface, _codex_deps
 del _prose, _yaml_conf

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -185,7 +185,19 @@ if "frontmatter_suggestions" not in _skill:
     )
 _fm_suggest = _skill["frontmatter_suggestions"]
 FRONTMATTER_SUGGEST_MAX_MATCHES = int(_fm_suggest["max_matches"])
+if FRONTMATTER_SUGGEST_MAX_MATCHES <= 0:
+    raise RuntimeError(
+        "configuration.yaml has invalid value for "
+        "'skill.frontmatter_suggestions.max_matches': "
+        f"{FRONTMATTER_SUGGEST_MAX_MATCHES!r}. Expected a positive integer."
+    )
 FRONTMATTER_SUGGEST_CUTOFF = float(_fm_suggest["cutoff"])
+if not 0.0 <= FRONTMATTER_SUGGEST_CUTOFF <= 1.0:
+    raise RuntimeError(
+        "configuration.yaml has invalid value for "
+        "'skill.frontmatter_suggestions.cutoff': "
+        f"{FRONTMATTER_SUGGEST_CUTOFF!r}. Expected a number in [0.0, 1.0]."
+    )
 
 # Allowed-tools validation
 _allowed_tools = _skill["allowed_tools"]

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -174,7 +174,15 @@ MAX_COMPATIBILITY_CHARS = int(_skill["compatibility"]["max_length"])
 # Known frontmatter keys (for unrecognized-key detection)
 KNOWN_FRONTMATTER_KEYS = frozenset(_skill["known_frontmatter_keys"])
 
-# "Did you mean?" suggestion parameters (difflib.get_close_matches)
+# "Did you mean?" suggestion parameters (difflib.get_close_matches).
+# Fail-fast so a stale checkout missing this section produces a clear
+# error at import rather than a later bare KeyError.
+if "frontmatter_suggestions" not in _skill:
+    raise RuntimeError(
+        "configuration.yaml is missing required section "
+        "'skill.frontmatter_suggestions'; update your checkout or "
+        "restore the full configuration file."
+    )
 _fm_suggest = _skill["frontmatter_suggestions"]
 FRONTMATTER_SUGGEST_MAX_MATCHES = int(_fm_suggest["max_matches"])
 FRONTMATTER_SUGGEST_CUTOFF = float(_fm_suggest["cutoff"])

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -223,10 +223,10 @@ def validate_known_keys(frontmatter: object) -> tuple[list[str], list[str]]:
 
     Unrecognized keys produce INFO-level warnings to help catch
     misspellings (e.g. 'compatability' instead of 'compatibility').
-    For each unknown key, ``difflib.get_close_matches`` (with stdlib
-    defaults, ``n=3``/``cutoff=0.6``) is consulted and any hits are
-    appended in the form ``key (did you mean: a, b, c?)``. Keys with
-    no close match are emitted unchanged.
+    For each unknown key, ``difflib.get_close_matches`` is consulted
+    (``n=3``, ``cutoff=0.6``) and any hits are appended in the form
+    ``key (did you mean: a, b, c?)``. Keys with no close match are
+    emitted unchanged.
 
     Returns (errors, passes) tuple.
     """
@@ -243,7 +243,7 @@ def validate_known_keys(frontmatter: object) -> tuple[list[str], list[str]]:
         known_sorted = sorted(KNOWN_FRONTMATTER_KEYS)
         rendered: list[str] = []
         for key in unknown_keys:
-            matches = difflib.get_close_matches(key, known_sorted)
+            matches = difflib.get_close_matches(key, known_sorted, n=3, cutoff=0.6)
             if matches:
                 rendered.append(f"{key} (did you mean: {', '.join(matches)}?)")
             else:

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -1,5 +1,7 @@
 """Shared validation functions for skill-system-foundry scripts."""
 
+import difflib
+
 from .constants import (
     MAX_NAME_CHARS, MIN_NAME_CHARS,
     RE_NAME_FORMAT, RESERVED_NAMES,
@@ -221,6 +223,10 @@ def validate_known_keys(frontmatter: object) -> tuple[list[str], list[str]]:
 
     Unrecognized keys produce INFO-level warnings to help catch
     misspellings (e.g. 'compatability' instead of 'compatibility').
+    For each unknown key, ``difflib.get_close_matches`` (with stdlib
+    defaults, ``n=3``/``cutoff=0.6``) is consulted and any hits are
+    appended in the form ``key (did you mean: a, b, c?)``. Keys with
+    no close match are emitted unchanged.
 
     Returns (errors, passes) tuple.
     """
@@ -234,10 +240,18 @@ def validate_known_keys(frontmatter: object) -> tuple[list[str], list[str]]:
         k for k in frontmatter if k not in KNOWN_FRONTMATTER_KEYS
     )
     if unknown_keys:
+        known_sorted = sorted(KNOWN_FRONTMATTER_KEYS)
+        rendered: list[str] = []
+        for key in unknown_keys:
+            matches = difflib.get_close_matches(key, known_sorted)
+            if matches:
+                rendered.append(f"{key} (did you mean: {', '.join(matches)}?)")
+            else:
+                rendered.append(key)
         errors.append(
             f"{LEVEL_INFO}: [foundry] unrecognized frontmatter keys: "
-            f"{', '.join(unknown_keys)} — check for typos. "
-            f"Known keys: {', '.join(sorted(KNOWN_FRONTMATTER_KEYS))}"
+            f"{', '.join(rendered)} — check for typos. "
+            f"Known keys: {', '.join(known_sorted)}"
         )
     else:
         passes.append("frontmatter: all keys recognized")

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -8,6 +8,7 @@ from .constants import (
     KNOWN_FRONTMATTER_KEYS, KNOWN_TOOLS, MAX_ALLOWED_TOOLS,
     RE_METADATA_VERSION,
     MAX_AUTHOR_LENGTH, KNOWN_SPDX_LICENSES,
+    FRONTMATTER_SUGGEST_MAX_MATCHES, FRONTMATTER_SUGGEST_CUTOFF,
     LEVEL_FAIL, LEVEL_WARN, LEVEL_INFO,
 )
 
@@ -224,9 +225,10 @@ def validate_known_keys(frontmatter: object) -> tuple[list[str], list[str]]:
     Unrecognized keys produce INFO-level warnings to help catch
     misspellings (e.g. 'compatability' instead of 'compatibility').
     For each unknown key, ``difflib.get_close_matches`` is consulted
-    (``n=3``, ``cutoff=0.6``) and any hits are appended in the form
-    ``key (did you mean: a, b, c?)``. Keys with no close match are
-    emitted unchanged.
+    (``n`` and ``cutoff`` sourced from ``configuration.yaml`` →
+    ``FRONTMATTER_SUGGEST_MAX_MATCHES`` / ``FRONTMATTER_SUGGEST_CUTOFF``)
+    and any hits are appended in the form ``key (did you mean: a, b, c?)``.
+    Keys with no close match are emitted unchanged.
 
     Returns (errors, passes) tuple.
     """
@@ -243,7 +245,12 @@ def validate_known_keys(frontmatter: object) -> tuple[list[str], list[str]]:
         known_sorted = sorted(KNOWN_FRONTMATTER_KEYS)
         rendered: list[str] = []
         for key in unknown_keys:
-            matches = difflib.get_close_matches(key, known_sorted, n=3, cutoff=0.6)
+            matches = difflib.get_close_matches(
+                key,
+                known_sorted,
+                n=FRONTMATTER_SUGGEST_MAX_MATCHES,
+                cutoff=FRONTMATTER_SUGGEST_CUTOFF,
+            )
             if matches:
                 rendered.append(f"{key} (did you mean: {', '.join(matches)}?)")
             else:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -208,6 +208,34 @@ class MissingSectionFailFastTests(unittest.TestCase):
             )
         self.assertIn("frontmatter_suggestions", str(ctx.exception))
 
+    def _full_config_with_substitution(self, old: str, new: str) -> str:
+        """Return configuration text with *old* replaced by *new* exactly once."""
+        with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
+            text = fh.read()
+        if text.count(old) != 1:
+            self.fail(
+                f"Expected exactly one occurrence of {old!r} in configuration.yaml"
+            )
+        return text.replace(old, new, 1)
+
+    def test_invalid_frontmatter_suggest_max_matches_raises(self) -> None:
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_with_substitution(
+                    "max_matches: 3", "max_matches: 0"
+                )
+            )
+        self.assertIn("max_matches", str(ctx.exception))
+
+    def test_invalid_frontmatter_suggest_cutoff_raises(self) -> None:
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_with_substitution(
+                    "cutoff: 0.6", "cutoff: 1.5"
+                )
+            )
+        self.assertIn("cutoff", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -166,6 +166,48 @@ class MissingSectionFailFastTests(unittest.TestCase):
             )
         self.assertIn("yaml_conformance", str(ctx.exception))
 
+    def _full_config_minus_nested(self, parent: str, child: str) -> str:
+        """Return configuration text with *parent.child* stripped out.
+
+        Walks the YAML line-by-line: the ``child:`` line under
+        ``parent:`` and all lines at deeper indentation are dropped.
+        """
+        with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
+            text = fh.read()
+        out_lines: list[str] = []
+        in_parent = False
+        parent_indent = 0
+        skipping = False
+        skip_indent = 0
+        for line in text.splitlines(keepends=True):
+            stripped = line.lstrip(" ")
+            indent = len(line) - len(stripped)
+            bare = line.strip()
+            if not in_parent and bare == f"{parent}:":
+                in_parent = True
+                parent_indent = indent
+                out_lines.append(line)
+                continue
+            if in_parent and indent <= parent_indent and bare and not bare.startswith("#"):
+                in_parent = False
+            if in_parent and bare == f"{child}:":
+                skipping = True
+                skip_indent = indent
+                continue
+            if skipping:
+                if bare == "" or bare.startswith("#") or indent > skip_indent:
+                    continue
+                skipping = False
+            out_lines.append(line)
+        return "".join(out_lines)
+
+    def test_missing_frontmatter_suggestions_raises(self) -> None:
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_minus_nested("skill", "frontmatter_suggestions")
+            )
+        self.assertIn("frontmatter_suggestions", str(ctx.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -180,7 +180,7 @@ class MissingSectionFailFastTests(unittest.TestCase):
         skipping = False
         skip_indent = 0
         for line in text.splitlines(keepends=True):
-            stripped = line.lstrip(" ")
+            stripped = line.lstrip(" \t")
             indent = len(line) - len(stripped)
             bare = line.strip()
             if not in_parent and bare == f"{parent}:":

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2525,13 +2525,18 @@ class ValidateKnownKeysTests(unittest.TestCase):
         fm = {"xyz": "value"}
         # Guard against future known-key additions turning 'xyz' into a
         # hit: recompute via the same pinned parameters as the impl and
-        # bail the premise if the fixture stops being a "no match" case.
-        self.assertEqual(
-            difflib.get_close_matches(
-                "xyz", sorted(KNOWN_FRONTMATTER_KEYS), n=3, cutoff=0.6
-            ),
-            [],
-        )
+        # skip if the fixture stops being a "no match" case, so fixture
+        # drift surfaces as a skip rather than a spurious failure.
+        if difflib.get_close_matches(
+            "xyz",
+            sorted(KNOWN_FRONTMATTER_KEYS),
+            n=FRONTMATTER_SUGGEST_MAX_MATCHES,
+            cutoff=FRONTMATTER_SUGGEST_CUTOFF,
+        ):
+            self.skipTest(
+                "'xyz' now has close matches in KNOWN_FRONTMATTER_KEYS; "
+                "update this fixture to use a key with no suggestions."
+            )
         errors, passes = validate_known_keys(fm)
         info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
         self.assertEqual(len(info_errors), 1)
@@ -2563,14 +2568,18 @@ class ValidateKnownKeysTests(unittest.TestCase):
     def test_mixed_hit_and_miss_keys(self) -> None:
         """Unknown keys render with suggestions only where matches exist."""
         fm = {"descripton": "oops", "xyz": "value"}
-        # Same defensive guard as the no-match test — pin 'xyz' as the
-        # no-match half of this fixture against future key additions.
-        self.assertEqual(
-            difflib.get_close_matches(
-                "xyz", sorted(KNOWN_FRONTMATTER_KEYS), n=3, cutoff=0.6
-            ),
-            [],
-        )
+        # Same defensive guard as the no-match test — skip rather than
+        # fail if 'xyz' acquires a close match under a future key set.
+        if difflib.get_close_matches(
+            "xyz",
+            sorted(KNOWN_FRONTMATTER_KEYS),
+            n=FRONTMATTER_SUGGEST_MAX_MATCHES,
+            cutoff=FRONTMATTER_SUGGEST_CUTOFF,
+        ):
+            self.skipTest(
+                "'xyz' now has close matches in KNOWN_FRONTMATTER_KEYS; "
+                "update this fixture to use a key with no suggestions."
+            )
         errors, passes = validate_known_keys(fm)
         info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
         self.assertEqual(len(info_errors), 1)

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2464,6 +2464,31 @@ class ValidateLicenseTests(unittest.TestCase):
 class ValidateKnownKeysTests(unittest.TestCase):
     """Tests for the validate_known_keys function."""
 
+    def _build_no_close_match_key(self) -> str:
+        """Return a deterministic key that yields no close matches.
+
+        Starts from a long sentinel (whose Levenshtein ratio against any
+        short known key is well below ``cutoff``) and extends it if a
+        future ``KNOWN_FRONTMATTER_KEYS`` expansion ever causes a hit,
+        so the no-match test paths always execute instead of being
+        silently skipped when the fixture drifts.
+        """
+        candidate = "frontmatter-no-close-match-sentinel"
+        known_keys = sorted(KNOWN_FRONTMATTER_KEYS)
+        for attempt in range(128):
+            if not difflib.get_close_matches(
+                candidate,
+                known_keys,
+                n=FRONTMATTER_SUGGEST_MAX_MATCHES,
+                cutoff=FRONTMATTER_SUGGEST_CUTOFF,
+            ):
+                return candidate
+            candidate = f"{candidate}-{attempt}"
+        self.fail(
+            "Could not derive a frontmatter key with no close matches; "
+            "adjust the sentinel used by _build_no_close_match_key()."
+        )
+
     def test_all_known_keys_pass(self) -> None:
         """A frontmatter with only known keys produces a pass."""
         fm = {k: "value" for k in KNOWN_FRONTMATTER_KEYS}
@@ -2522,21 +2547,8 @@ class ValidateKnownKeysTests(unittest.TestCase):
 
     def test_no_close_match_omits_suggestion(self) -> None:
         """An unrecognized key with no close match has no suggestion text."""
-        fm = {"xyz": "value"}
-        # Guard against future known-key additions turning 'xyz' into a
-        # hit: recompute via the same pinned parameters as the impl and
-        # skip if the fixture stops being a "no match" case, so fixture
-        # drift surfaces as a skip rather than a spurious failure.
-        if difflib.get_close_matches(
-            "xyz",
-            sorted(KNOWN_FRONTMATTER_KEYS),
-            n=FRONTMATTER_SUGGEST_MAX_MATCHES,
-            cutoff=FRONTMATTER_SUGGEST_CUTOFF,
-        ):
-            self.skipTest(
-                "'xyz' now has close matches in KNOWN_FRONTMATTER_KEYS; "
-                "update this fixture to use a key with no suggestions."
-            )
+        no_match_key = self._build_no_close_match_key()
+        fm = {no_match_key: "value"}
         errors, passes = validate_known_keys(fm)
         info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
         self.assertEqual(len(info_errors), 1)
@@ -2567,28 +2579,17 @@ class ValidateKnownKeysTests(unittest.TestCase):
 
     def test_mixed_hit_and_miss_keys(self) -> None:
         """Unknown keys render with suggestions only where matches exist."""
-        fm = {"descripton": "oops", "xyz": "value"}
-        # Same defensive guard as the no-match test — skip rather than
-        # fail if 'xyz' acquires a close match under a future key set.
-        if difflib.get_close_matches(
-            "xyz",
-            sorted(KNOWN_FRONTMATTER_KEYS),
-            n=FRONTMATTER_SUGGEST_MAX_MATCHES,
-            cutoff=FRONTMATTER_SUGGEST_CUTOFF,
-        ):
-            self.skipTest(
-                "'xyz' now has close matches in KNOWN_FRONTMATTER_KEYS; "
-                "update this fixture to use a key with no suggestions."
-            )
+        no_match_key = self._build_no_close_match_key()
+        fm = {"descripton": "oops", no_match_key: "value"}
         errors, passes = validate_known_keys(fm)
         info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
         self.assertEqual(len(info_errors), 1)
         self.assertIn("descripton (did you mean: description?)", info_errors[0])
-        # Intent: 'xyz' has no close match, so it must not carry a
-        # "(did you mean" parenthetical — assert on that intent directly
-        # rather than on positional context within the sorted list.
-        self.assertNotIn("xyz (did you mean", info_errors[0])
-        self.assertIn("xyz", info_errors[0])
+        # Intent: the no-match key must not carry a "(did you mean"
+        # parenthetical — assert on that intent directly rather than
+        # on positional context within the sorted list.
+        self.assertNotIn(f"{no_match_key} (did you mean", info_errors[0])
+        self.assertIn(no_match_key, info_errors[0])
 
 
 # ===================================================================

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2509,6 +2509,50 @@ class ValidateKnownKeysTests(unittest.TestCase):
         for key in ("name", "description", "compatibility"):
             self.assertIn(key, info_errors[0])
 
+    def test_close_match_suggests_known_key(self) -> None:
+        """A near-miss like 'descripton' suggests 'description'."""
+        fm = {"descripton": "oops"}
+        errors, passes = validate_known_keys(fm)
+        info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
+        self.assertEqual(len(info_errors), 1)
+        self.assertIn("descripton (did you mean: description?)", info_errors[0])
+
+    def test_no_close_match_omits_suggestion(self) -> None:
+        """An unrecognized key with no close match has no suggestion text."""
+        fm = {"xyz": "value"}
+        errors, passes = validate_known_keys(fm)
+        info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
+        self.assertEqual(len(info_errors), 1)
+        self.assertNotIn("did you mean", info_errors[0])
+
+    def test_multiple_close_matches_listed(self) -> None:
+        """Up to three close matches appear in the suggestion."""
+        # 'licensse' is close to 'license'; synthesize a frontmatter where
+        # the key is close to multiple known keys via a short ambiguous stem.
+        fm = {"nam": "value"}
+        errors, passes = validate_known_keys(fm)
+        info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
+        self.assertEqual(len(info_errors), 1)
+        import difflib
+        expected = difflib.get_close_matches(
+            "nam", sorted(KNOWN_FRONTMATTER_KEYS)
+        )
+        # Guard the test's premise: the stdlib default must return >= 1.
+        self.assertGreaterEqual(len(expected), 1)
+        self.assertIn(
+            f"nam (did you mean: {', '.join(expected)}?)", info_errors[0]
+        )
+
+    def test_mixed_hit_and_miss_keys(self) -> None:
+        """Unknown keys render with suggestions only where matches exist."""
+        fm = {"descripton": "oops", "xyz": "value"}
+        errors, passes = validate_known_keys(fm)
+        info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
+        self.assertEqual(len(info_errors), 1)
+        self.assertIn("descripton (did you mean: description?)", info_errors[0])
+        # 'xyz' has no close match — it appears bare, not followed by '('.
+        self.assertIn("xyz — check for typos", info_errors[0])
+
 
 # ===================================================================
 # validate_skill — optional frontmatter integration

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -44,6 +44,8 @@ from lib.validation import (
     validate_known_keys,
 )
 from lib.constants import (
+    FRONTMATTER_SUGGEST_CUTOFF,
+    FRONTMATTER_SUGGEST_MAX_MATCHES,
     KNOWN_FRONTMATTER_KEYS,
     KNOWN_SPDX_LICENSES,
     KNOWN_TOOLS,
@@ -2550,8 +2552,8 @@ class ValidateKnownKeysTests(unittest.TestCase):
         expected = difflib.get_close_matches(
             "nam",
             sorted(KNOWN_FRONTMATTER_KEYS),
-            n=3,  # Matches validate_known_keys(): suggest at most three keys.
-            cutoff=0.6,  # Matches validate_known_keys(): exclude weak matches.
+            n=FRONTMATTER_SUGGEST_MAX_MATCHES,
+            cutoff=FRONTMATTER_SUGGEST_CUTOFF,
         )
         self.assertGreaterEqual(len(expected), 1)
         self.assertIn(

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2527,9 +2527,13 @@ class ValidateKnownKeysTests(unittest.TestCase):
         self.assertNotIn("did you mean", info_errors[0])
 
     def test_multiple_close_matches_listed(self) -> None:
-        """Up to three close matches appear in the suggestion."""
-        # 'licensse' is close to 'license'; synthesize a frontmatter where
-        # the key is close to multiple known keys via a short ambiguous stem.
+        """Up to three close matches appear in the suggestion.
+
+        The expected list is re-computed via the live ``difflib`` so the
+        test pins "implementation uses stdlib defaults" rather than
+        hardcoding any particular score — if a future Python tweaks the
+        ratio math, the test still checks the same contract.
+        """
         fm = {"nam": "value"}
         errors, passes = validate_known_keys(fm)
         info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
@@ -2537,7 +2541,6 @@ class ValidateKnownKeysTests(unittest.TestCase):
         expected = difflib.get_close_matches(
             "nam", sorted(KNOWN_FRONTMATTER_KEYS)
         )
-        # Guard the test's premise: the stdlib default must return >= 1.
         self.assertGreaterEqual(len(expected), 1)
         self.assertIn(
             f"nam (did you mean: {', '.join(expected)}?)", info_errors[0]
@@ -2550,8 +2553,11 @@ class ValidateKnownKeysTests(unittest.TestCase):
         info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
         self.assertEqual(len(info_errors), 1)
         self.assertIn("descripton (did you mean: description?)", info_errors[0])
-        # 'xyz' has no close match — it appears bare, not followed by '('.
-        self.assertIn("xyz — check for typos", info_errors[0])
+        # Intent: 'xyz' has no close match, so it must not carry a
+        # "(did you mean" parenthetical — assert on that intent directly
+        # rather than on positional context within the sorted list.
+        self.assertNotIn("xyz (did you mean", info_errors[0])
+        self.assertIn("xyz", info_errors[0])
 
 
 # ===================================================================

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2467,11 +2467,12 @@ class ValidateKnownKeysTests(unittest.TestCase):
     def _build_no_close_match_key(self) -> str:
         """Return a deterministic key that yields no close matches.
 
-        Starts from a long sentinel (whose Levenshtein ratio against any
-        short known key is well below ``cutoff``) and extends it if a
-        future ``KNOWN_FRONTMATTER_KEYS`` expansion ever causes a hit,
-        so the no-match test paths always execute instead of being
-        silently skipped when the fixture drifts.
+        Starts from a long sentinel (whose ``difflib.SequenceMatcher``
+        similarity ratio against any short known key is well below
+        ``cutoff``) and extends it if a future ``KNOWN_FRONTMATTER_KEYS``
+        expansion ever causes a hit, so the no-match test paths always
+        execute instead of being silently skipped when the fixture
+        drifts.
         """
         candidate = "frontmatter-no-close-match-sentinel"
         known_keys = sorted(KNOWN_FRONTMATTER_KEYS)

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -6,6 +6,7 @@ main() CLI entry point.
 """
 
 import contextlib
+import difflib
 import io
 import json
 import os
@@ -2533,7 +2534,6 @@ class ValidateKnownKeysTests(unittest.TestCase):
         errors, passes = validate_known_keys(fm)
         info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
         self.assertEqual(len(info_errors), 1)
-        import difflib
         expected = difflib.get_close_matches(
             "nam", sorted(KNOWN_FRONTMATTER_KEYS)
         )

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -2521,6 +2521,15 @@ class ValidateKnownKeysTests(unittest.TestCase):
     def test_no_close_match_omits_suggestion(self) -> None:
         """An unrecognized key with no close match has no suggestion text."""
         fm = {"xyz": "value"}
+        # Guard against future known-key additions turning 'xyz' into a
+        # hit: recompute via the same pinned parameters as the impl and
+        # bail the premise if the fixture stops being a "no match" case.
+        self.assertEqual(
+            difflib.get_close_matches(
+                "xyz", sorted(KNOWN_FRONTMATTER_KEYS), n=3, cutoff=0.6
+            ),
+            [],
+        )
         errors, passes = validate_known_keys(fm)
         info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
         self.assertEqual(len(info_errors), 1)
@@ -2529,17 +2538,20 @@ class ValidateKnownKeysTests(unittest.TestCase):
     def test_multiple_close_matches_listed(self) -> None:
         """Up to three close matches appear in the suggestion.
 
-        The expected list is re-computed via the live ``difflib`` so the
-        test pins "implementation uses stdlib defaults" rather than
-        hardcoding any particular score — if a future Python tweaks the
-        ratio math, the test still checks the same contract.
+        The expected list is re-computed via the live ``difflib`` using
+        the same pinned parameters as ``validate_known_keys()`` rather
+        than hardcoding any particular score — if a future Python tweaks
+        the ratio math, the test still checks the same contract.
         """
         fm = {"nam": "value"}
         errors, passes = validate_known_keys(fm)
         info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
         self.assertEqual(len(info_errors), 1)
         expected = difflib.get_close_matches(
-            "nam", sorted(KNOWN_FRONTMATTER_KEYS)
+            "nam",
+            sorted(KNOWN_FRONTMATTER_KEYS),
+            n=3,  # Matches validate_known_keys(): suggest at most three keys.
+            cutoff=0.6,  # Matches validate_known_keys(): exclude weak matches.
         )
         self.assertGreaterEqual(len(expected), 1)
         self.assertIn(
@@ -2549,6 +2561,14 @@ class ValidateKnownKeysTests(unittest.TestCase):
     def test_mixed_hit_and_miss_keys(self) -> None:
         """Unknown keys render with suggestions only where matches exist."""
         fm = {"descripton": "oops", "xyz": "value"}
+        # Same defensive guard as the no-match test — pin 'xyz' as the
+        # no-match half of this fixture against future key additions.
+        self.assertEqual(
+            difflib.get_close_matches(
+                "xyz", sorted(KNOWN_FRONTMATTER_KEYS), n=3, cutoff=0.6
+            ),
+            [],
+        )
         errors, passes = validate_known_keys(fm)
         info_errors = [e for e in errors if e.startswith(LEVEL_INFO)]
         self.assertEqual(len(info_errors), 1)


### PR DESCRIPTION
## Summary

Extends the existing INFO-level warning for unrecognized frontmatter keys with a per-key "did you mean …?" hint, backed by the stdlib `difflib.get_close_matches`. Typos like `descripton` now render as `descripton (did you mean: description?)` instead of being buried in a flat list alongside the full known-key roster. Keys with no close match keep their previous bare rendering.

Scope is deliberately narrow: one function (`validate_known_keys`) plus its library dependencies and test module. No new runtime dependency — `difflib` is stdlib, so the meta-skill stays installable-free. **Frontmatter schema is unchanged** (no new/renamed/removed frontmatter fields). The internal `configuration.yaml` schema *does* grow a required `skill.frontmatter_suggestions` block (`max_matches`, `cutoff`) that parameterizes the new lookup, with import-time fail-fast guards in `constants.py` for missing section, non-positive `max_matches`, and out-of-range `cutoff`.

## Why

The existing message already listed every known key after the unrecognized ones, on the theory that a reader could spot their typo by eye. For short keys (`nam`, `licens`, `meta`) that works fine; for longer near-misses (`descripton`, `compatability`, `alloed-tools`) the noise drowns the signal. A targeted hint cuts the cognitive step the reader has to do.

## What's new

**Library** (`skill-system-foundry/scripts/lib/validation.py`, `constants.py`, `configuration.yaml`)

- Module-level `import difflib` in `validation.py`.
- Per-key `difflib.get_close_matches(key, known_sorted, n=FRONTMATTER_SUGGEST_MAX_MATCHES, cutoff=FRONTMATTER_SUGGEST_CUTOFF)` lookup inside `validate_known_keys`.
- Unknown keys render as `key (did you mean: a, b, c?)` when matches exist, unchanged otherwise. The trailing `Known keys: …` list is preserved so readers still see the full vocabulary.
- New `skill.frontmatter_suggestions` YAML block (`max_matches: 3`, `cutoff: 0.6`) — single source of truth, exposed via `FRONTMATTER_SUGGEST_MAX_MATCHES` / `FRONTMATTER_SUGGEST_CUTOFF` in `constants.py`.
- Import-time fail-fast guards: missing section → `RuntimeError`, `max_matches <= 0` → `RuntimeError`, `cutoff` outside `[0.0, 1.0]` → `RuntimeError`. Matches the existing `prose_yaml` / `yaml_conformance` pattern.

**Tests** (`tests/test_validate_skill.py`, `tests/test_constants.py`)

- `test_close_match_suggests_known_key` — the common typo case (`descripton` → `description`).
- `test_no_close_match_omits_suggestion` / `test_mixed_hit_and_miss_keys` — use a runtime-derived `_build_no_close_match_key()` helper so the no-match path always executes even if `KNOWN_FRONTMATTER_KEYS` expands.
- `test_multiple_close_matches_listed` — mirrors the implementation via live `difflib` with the same pinned constants, so test and impl cannot drift.
- `test_missing_frontmatter_suggestions_raises`, `test_invalid_frontmatter_suggest_max_matches_raises`, `test_invalid_frontmatter_suggest_cutoff_raises` — cover each fail-fast guard.
- `import difflib` hoisted to module top alongside the other stdlib imports.

## Configuration rationale

- `cutoff=0.6` — empirically calibrated against the current known-key set. Real typos score 0.63–0.96 on the correct key, wrong runners-up sit at 0.20–0.50. Dropping to 0.5 pulls in `meta → name` (0.5) as a false positive; raising to 0.7 silently loses `meta → metadata` (0.67) and `compat → compatibility` (0.63).
- `n=3` — kept as future-proofing. With today's six-key vocabulary every query that clears the cutoff returns exactly one match, so `n=3` has no visible effect now. If a future key addition creates genuine collisions, the rendering already handles multiple suggestions without code change.

## What's unchanged

- Severity: still `LEVEL_INFO` — this is a helper, not a gate.
- `(errors, passes)` return contract.
- Known-key path: "all keys recognized" pass unchanged.
- `KNOWN_FRONTMATTER_KEYS` source of truth still `configuration.yaml` → `constants.py`.
- **Frontmatter schema** — same six keys, same semantics, no rename/add/remove.

## Test plan

- [x] `python -m coverage run -m unittest discover -s tests -p "test_*.py"` — 1565 tests pass.
- [x] `python -m coverage report` — 97% branch coverage (threshold 70%).
- [x] `python scripts/validate_skill.py . --allow-nested-references --json` — 17 passes, 0 failures, 0 warnings.
- [x] `python scripts/audit_skill_system.py . --json` — 0 failures (1 expected warning for missing `skills/` directory in distribution repo).
