### PR TITLE
Add version-drift audit and bump_version.py release primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,12 @@ python scripts/audit_skill_system.py .
 
 The `--allow-nested-references` flag is needed because this meta-skill intentionally uses nested references. One warning about a missing `skills/` directory from the audit is expected in this distribution repository.
 
+The version-consistency rule in `audit_skill_system.py` (which compares `SKILL.md`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`) only fires when the audit root contains `.claude-plugin/plugin.json`. The `cd skill-system-foundry` invocation above therefore skips that rule by design — it is a repo-level check, not a skill-level check. To include it, run the audit from the repo root:
+
+```bash
+python skill-system-foundry/scripts/audit_skill_system.py .
+```
+
 #### Flag behavior
 
 | Flag | Effect | When to use |
@@ -216,7 +222,16 @@ Automated validation (`validate_skill.py`, `audit_skill_system.py`) handles many
 
 ## Release Process
 
-Version lives in `skill-system-foundry/SKILL.md` frontmatter (`metadata.version`). Tags mirror as `vX.Y.Z`. The `release.yml` workflow auto-bundles a zip and uploads it as a release asset. Run full validation and tests before tagging.
+Version lives in three files that must agree: `skill-system-foundry/SKILL.md` frontmatter (`metadata.version`, canonical), `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`. The version-consistency rule in `audit_skill_system.py` fails the repo-root audit if they drift. Tags mirror as `vX.Y.Z`. The `release.yml` workflow auto-bundles a zip and uploads it as a release asset. Run full validation and tests before tagging.
+
+Bump all three manifest files in lockstep with `scripts/bump_version.py`:
+
+```sh
+python scripts/bump_version.py NEXT_VERSION --dry-run   # preview the plan and changelog probe
+python scripts/bump_version.py NEXT_VERSION             # write the three files and prepend the changelog
+```
+
+The script rejects invalid semver, equal versions, and downgrades (unless `--allow-downgrade` is passed), refuses to run when the three files already disagree, and probes the changelog generator in `--dry-run` mode before touching disk. The changelog step below is only needed when calling the generator directly (for example, to regenerate a past release).
 
 When publishing the GitHub Release, paste the body from [`.github/RELEASE_NOTES_TEMPLATE.md`](.github/RELEASE_NOTES_TEMPLATE.md) and replace every `{VERSION}` placeholder with the release number. Generate the changelog section using the checklist below.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,7 +150,7 @@ python scripts/audit_skill_system.py .
 
 The `--allow-nested-references` flag is needed because this meta-skill intentionally uses nested references. One warning about a missing `skills/` directory from the audit is expected in this distribution repository.
 
-The version-consistency rule in `audit_skill_system.py` (which compares `SKILL.md`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`) only fires when the audit root contains `.claude-plugin/plugin.json`. The `cd skill-system-foundry` invocation above therefore skips that rule by design — it is a repo-level check, not a skill-level check. To include it, run the audit from the repo root:
+The version-consistency rule in `audit_skill_system.py` (which compares `SKILL.md`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`) only fires when the audit root contains both `.claude-plugin/plugin.json` and `skill-system-foundry/SKILL.md` — the gate keeps the rule scoped to the foundry distribution repository so integrator skill systems that ship their own Claude plugin manifest are unaffected. The `cd skill-system-foundry` invocation above therefore skips that rule by design — it is a repo-level check, not a skill-level check. To include it, run the audit from the repo root:
 
 ```bash
 python skill-system-foundry/scripts/audit_skill_system.py .

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -49,6 +49,7 @@ Exit codes:
 import argparse
 import datetime
 import importlib.util
+import json
 import os
 import subprocess
 import sys
@@ -126,17 +127,52 @@ def head_sha(repo_root: str) -> str | None:
     return sha or None
 
 
+class ManifestReadError(Exception):
+    """A manifest file could not be read or parsed.
+
+    Carries a human-readable per-file message that ``main()`` surfaces
+    under ``EXIT_DRIFT`` so a malformed manifest is treated as a
+    precondition failure rather than an uncaught traceback.
+    """
+
+
+def _safe_read(label: str, fn) -> str | None:
+    """Run *fn* and translate ``OSError``/``json.JSONDecodeError`` to
+    :class:`ManifestReadError` with a *label* prefix.
+    """
+    try:
+        return fn()
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ManifestReadError(f"{label}: {exc}") from exc
+
+
 def read_all_versions(repo_root: str) -> dict[str, str | None]:
-    """Return current version from each of the three manifest files."""
+    """Return current version from each of the three manifest files.
+
+    Raises :class:`ManifestReadError` when any manifest is missing,
+    unreadable, or contains invalid JSON / frontmatter — operator-facing
+    precondition failures that ``main()`` maps to ``EXIT_DRIFT``.
+    """
     skill_path = _version.skill_md_path(repo_root)
     plugin_path = _version.plugin_json_path(repo_root)
     market_path = _version.marketplace_json_path(repo_root)
-    plugin_name = _version.read_plugin_name(plugin_path)
+    plugin_name = _safe_read(
+        "plugin.json", lambda: _version.read_plugin_name(plugin_path)
+    )
     return {
-        "SKILL.md": _version.read_skill_md_version(skill_path),
-        "plugin.json": _version.read_plugin_json_version(plugin_path),
+        "SKILL.md": _safe_read(
+            "SKILL.md", lambda: _version.read_skill_md_version(skill_path)
+        ),
+        "plugin.json": _safe_read(
+            "plugin.json", lambda: _version.read_plugin_json_version(plugin_path)
+        ),
         "marketplace.json": (
-            _version.read_marketplace_json_version(market_path, plugin_name)
+            _safe_read(
+                "marketplace.json",
+                lambda: _version.read_marketplace_json_version(
+                    market_path, plugin_name
+                ),
+            )
             if plugin_name
             else None
         ),
@@ -149,18 +185,25 @@ def plan_writes(
     """Return ``[(path, new_content)]`` for every manifest file.
 
     Raises ``ValueError`` when any anchored regex does not match exactly
-    once — the caller maps that to exit 5.
+    once — the caller maps that to exit 5.  Raises
+    :class:`ManifestReadError` when a manifest cannot be read so the
+    caller can surface that as a precondition failure (``EXIT_DRIFT``)
+    rather than a stack trace.
     """
     skill_path = _version.skill_md_path(repo_root)
     plugin_path = _version.plugin_json_path(repo_root)
     market_path = _version.marketplace_json_path(repo_root)
 
-    with open(skill_path, "r", encoding="utf-8") as fh:
-        skill_content = fh.read()
-    with open(plugin_path, "r", encoding="utf-8") as fh:
-        plugin_content = fh.read()
-    with open(market_path, "r", encoding="utf-8") as fh:
-        market_content = fh.read()
+    def _read(label: str, path: str) -> str:
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                return fh.read()
+        except OSError as exc:
+            raise ManifestReadError(f"{label}: {exc}") from exc
+
+    skill_content = _read("SKILL.md", skill_path)
+    plugin_content = _read("plugin.json", plugin_path)
+    market_content = _read("marketplace.json", market_path)
 
     return [
         (skill_path, _version.plan_skill_md_edit(skill_content, current, new)),
@@ -287,7 +330,19 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
-    args = parser.parse_args(argv)
+    # ``parse_args`` raises ``SystemExit`` on bad input or ``--help``.  The
+    # script's contract is that ``main()`` returns an int, so translate the
+    # exit code: argparse error (2) → ``EXIT_INVALID_INPUT``; ``--help`` /
+    # explicit ``SystemExit(0)`` → ``EXIT_OK``; anything else passes through.
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        code = exc.code
+        if code is None or code == 0:
+            return EXIT_OK
+        if isinstance(code, int) and code == 2:
+            return EXIT_INVALID_INPUT
+        return code if isinstance(code, int) else EXIT_INVALID_INPUT
 
     new_version = args.new_version
     # Reject shapes not covered by SEMVER_RE.
@@ -318,7 +373,15 @@ def main(argv: list[str] | None = None) -> int:
         return EXIT_INVALID_INPUT
 
     # Precondition: all three files already agree.
-    versions = read_all_versions(repo_root)
+    try:
+        versions = read_all_versions(repo_root)
+    except ManifestReadError as exc:
+        print(
+            f"error: cannot read manifest files — {exc}; fix the manifest "
+            "and re-run.",
+            file=sys.stderr,
+        )
+        return EXIT_DRIFT
     missing = [name for name, value in versions.items() if value is None]
     if missing:
         print(
@@ -364,6 +427,13 @@ def main(argv: list[str] | None = None) -> int:
     # Plan the file edits.
     try:
         writes = plan_writes(repo_root, current, new_version)
+    except ManifestReadError as exc:
+        print(
+            f"error: cannot read manifest files — {exc}; fix the manifest "
+            "and re-run.",
+            file=sys.stderr,
+        )
+        return EXIT_DRIFT
     except ValueError as exc:
         print(f"error: plan failed: {exc}", file=sys.stderr)
         return EXIT_PLAN_FAILED

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -79,6 +79,16 @@ EXIT_PARTIAL_WRITE = 6
 GENERATOR_SCRIPT = os.path.join(_SCRIPTS_DIR, "generate_changelog.py")
 
 
+def _display_path(path: str, repo_root: str) -> str:
+    """Return *path* relative to *repo_root* with forward-slash separators.
+
+    Operator-facing output should not depend on the OS the bump ran on —
+    tests assert against the forward-slash form and maintainers copy-paste
+    these paths between Windows and POSIX shells.
+    """
+    return os.path.relpath(path, repo_root).replace(os.sep, "/")
+
+
 def find_repo_root(start: str) -> str | None:
     """Walk upward from *start* until a ``.git`` entry is found.
 
@@ -392,7 +402,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.dry_run:
         print(f"Planned bump: {current} → {new_version}")
         for path, _ in writes:
-            rel = os.path.relpath(path, repo_root)
+            rel = _display_path(path, repo_root)
             print(f"  would update {rel}: {current} → {new_version}")
         if changelog_exists:
             print()
@@ -416,10 +426,10 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         for path in exc.swapped:
-            rel = os.path.relpath(path, repo_root)
+            rel = _display_path(path, repo_root)
             print(f"  swapped to {new_version}: {rel}", file=sys.stderr)
         for path in exc.remaining:
-            rel = os.path.relpath(path, repo_root)
+            rel = _display_path(path, repo_root)
             print(f"  still at  {current}: {rel}", file=sys.stderr)
         return EXIT_PARTIAL_WRITE
     except OSError as exc:
@@ -449,7 +459,7 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"Bumped version: {current} → {new_version}")
     for path, _ in writes:
-        rel = os.path.relpath(path, repo_root)
+        rel = _display_path(path, repo_root)
         print(f"  updated {rel}")
     if changelog_exists:
         print("  updated CHANGELOG.md")

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -59,6 +59,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 from collections.abc import Callable
 
 _SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -153,17 +154,25 @@ def _safe_read(label: str, fn: Callable[[], str | None]) -> str | None:
         raise ManifestReadError(f"{label}: {exc}") from exc
 
 
-def read_all_versions(repo_root: str) -> dict[str, str | None]:
-    """Return current version from each of the three manifest files.
+def read_all_versions(repo_root: str) -> tuple[dict[str, str | None], str]:
+    """Return ``(versions, plugin_name)`` for the three manifest files.
 
-    Raises :class:`ManifestReadError` when any manifest is missing,
-    unreadable, or contains invalid JSON / frontmatter — operator-facing
-    precondition failures that ``main()`` maps to ``EXIT_DRIFT``.  An
-    empty or missing top-level ``"name"`` in ``plugin.json`` is also a
-    precondition failure: without a name the script cannot match the
-    plugin entry inside ``marketplace.json``, and silently skipping that
-    read would surface downstream as a misleading "marketplace.json"
-    error.
+    *versions* maps each manifest filename to its currently declared
+    version, or ``None`` when the version field itself is missing or
+    cannot be parsed (the audit/drift logic in ``main`` treats ``None``
+    as drift).  *plugin_name* is the top-level ``"name"`` from
+    ``plugin.json``; it is needed downstream by :func:`plan_writes` to
+    bind the marketplace edit to the correct plugin entry.
+
+    Raises :class:`ManifestReadError` only on precondition failures
+    that ``main()`` maps to ``EXIT_DRIFT``: an ``OSError`` reading a
+    manifest, a ``json.JSONDecodeError`` parsing a JSON manifest, or a
+    missing/empty top-level ``"name"`` in ``plugin.json`` (without it
+    the script cannot match the marketplace plugin entry, so silently
+    skipping that read would surface as a misleading
+    "marketplace.json" error).  A malformed or missing SKILL.md
+    frontmatter is **not** raised here — the version reader returns
+    ``None`` and the caller treats the absence as drift.
     """
     skill_path = _version.skill_md_path(repo_root)
     plugin_path = _version.plugin_json_path(repo_root)
@@ -176,7 +185,7 @@ def read_all_versions(repo_root: str) -> dict[str, str | None]:
             "plugin.json: missing or empty 'name' — cannot match the "
             "plugin entry in marketplace.json"
         )
-    return {
+    versions: dict[str, str | None] = {
         "SKILL.md": _safe_read(
             "SKILL.md", lambda: _version.read_skill_md_version(skill_path)
         ),
@@ -190,18 +199,21 @@ def read_all_versions(repo_root: str) -> dict[str, str | None]:
             ),
         ),
     }
+    return versions, plugin_name
 
 
 def plan_writes(
-    repo_root: str, current: str, new: str
+    repo_root: str, current: str, new: str, plugin_name: str
 ) -> list[tuple[str, str]]:
     """Return ``[(path, new_content)]`` for every manifest file.
 
     Raises ``ValueError`` when any anchored regex does not match exactly
-    once — the caller maps that to exit 5.  Raises
-    :class:`ManifestReadError` when a manifest cannot be read so the
-    caller can surface that as a precondition failure (``EXIT_DRIFT``)
-    rather than a stack trace.
+    once or when post-substitution structural verification fails — the
+    caller maps that to exit 5.  Raises :class:`ManifestReadError` when
+    a manifest cannot be read so the caller can surface that as a
+    precondition failure (``EXIT_DRIFT``) rather than a stack trace.
+    *plugin_name* is the name read from ``plugin.json`` and is used to
+    bind the marketplace edit to the matching plugin entry.
     """
     skill_path = _version.skill_md_path(repo_root)
     plugin_path = _version.plugin_json_path(repo_root)
@@ -221,7 +233,12 @@ def plan_writes(
     return [
         (skill_path, _version.plan_skill_md_edit(skill_content, current, new)),
         (plugin_path, _version.plan_plugin_json_edit(plugin_content, current, new)),
-        (market_path, _version.plan_marketplace_json_edit(market_content, current, new)),
+        (
+            market_path,
+            _version.plan_marketplace_json_edit(
+                market_content, current, new, plugin_name
+            ),
+        ),
     ]
 
 
@@ -242,29 +259,45 @@ class PartialWriteError(OSError):
 
 
 def commit_writes(writes: list[tuple[str, str]]) -> None:
-    """Replace each target via an adjacent ``.tmp`` using ``os.replace``.
+    """Replace each target via a unique sibling temp file using ``os.replace``.
 
     Each ``os.replace`` is atomic per file, but the set as a whole is
-    not transactional.  Phase 1 stages every ``.tmp`` on disk; phase 2
+    not transactional.  Phase 1 stages every temp file on disk; phase 2
     swaps them into place one at a time.  If phase 1 fails, no target
-    has been touched — the stale ``.tmp`` files are cleaned up.  If
-    phase 2 fails partway through, earlier files already carry the new
+    has been touched — the staged temp files are cleaned up.  If phase
+    2 fails partway through, earlier files already carry the new
     version while later ones still carry the old; that is drift, and
     we raise :class:`PartialWriteError` so the caller can tell the
     operator exactly which files need manual reconciliation.
+
+    Temp files are created with :func:`tempfile.mkstemp` in the same
+    directory as their target so ``os.replace`` is a same-filesystem
+    rename.  Using a unique name (rather than an adjacent
+    deterministic ``.tmp`` suffix) avoids clobbering any pre-existing
+    file at that path — the bump must not collateral-damage stale
+    diagnostic artifacts or unrelated files a maintainer left behind.
     """
     tmp_paths: list[str] = []
     swapped: list[str] = []
     try:
         for path, content in writes:
-            tmp = path + ".tmp"
-            # Default text-mode newline translation is intentional: the
-            # planners produce ``\n`` in memory (because the readers used
-            # default text mode), and we want the writer to translate
-            # back to the platform's native line ending — preserving
-            # CRLF working trees on Windows that get LF in git.  Using
-            # ``newline=""`` here would force LF on Windows and
-            # unintentionally rewrite the manifests.
+            target_dir = os.path.dirname(path) or "."
+            target_base = os.path.basename(path)
+            # mkstemp returns an open fd; close it before reopening in
+            # text mode so the writer applies our encoding/newline
+            # behavior.  Default text-mode newline translation is
+            # intentional: the planners produce ``\n`` in memory
+            # (because the readers used default text mode) and we want
+            # the writer to translate back to the platform's native line
+            # ending — preserving CRLF working trees on Windows that get
+            # LF in git.  Using ``newline=""`` here would force LF on
+            # Windows and unintentionally rewrite the manifests.
+            fd, tmp = tempfile.mkstemp(
+                prefix=target_base + ".",
+                suffix=".tmp",
+                dir=target_dir,
+            )
+            os.close(fd)
             with open(tmp, "w", encoding="utf-8") as fh:
                 fh.write(content)
             tmp_paths.append(tmp)
@@ -395,7 +428,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # Precondition: all three files already agree.
     try:
-        versions = read_all_versions(repo_root)
+        versions, plugin_name = read_all_versions(repo_root)
     except ManifestReadError as exc:
         print(
             f"error: cannot read manifest files — {exc}; fix the manifest "
@@ -447,7 +480,7 @@ def main(argv: list[str] | None = None) -> int:
 
     # Plan the file edits.
     try:
-        writes = plan_writes(repo_root, current, new_version)
+        writes = plan_writes(repo_root, current, new_version, plugin_name)
     except ManifestReadError as exc:
         print(
             f"error: cannot read manifest files — {exc}; fix the manifest "

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -307,15 +307,10 @@ def commit_writes(writes: list[tuple[str, str]]) -> None:
             # Track the temp path immediately so the ``finally`` cleanup
             # can remove it even if the upcoming open/write raises.
             tmp_paths.append(tmp)
-            # Pin LF newlines on disk to match the rest of the foundry
-            # release tooling (``generate_changelog.py`` does the same).
-            # Default text mode would translate ``\n`` → ``os.linesep``
-            # on write, producing CRLF manifests on Windows even for
-            # checkouts where the canonical form is LF, which would
-            # show up as a noisy diff on every cross-platform bump.
-            # Reading the manifests with default text mode already
-            # normalised CRLF/CR → LF in memory, so writing LF here
-            # round-trips cleanly.
+            # Pin LF newlines on disk (``newline="\n"``) to match the
+            # rest of the foundry release tooling — ``generate_changelog.py``
+            # does the same so cross-platform bumps stay deterministic
+            # regardless of the operator's checkout settings.
             with open(tmp, "w", encoding="utf-8", newline="\n") as fh:
                 fh.write(content)
         staged: list[tuple[str, str]] = list(zip([p for p, _ in writes], tmp_paths))

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -181,11 +181,16 @@ def read_all_versions(repo_root: str) -> tuple[dict[str, str | None], str]:
     plugin_name = _safe_read(
         "plugin.json", lambda: _version.read_plugin_name(plugin_path)
     )
-    if not plugin_name:
+    # Strip and re-check so a whitespace-only ``"name": "   "`` (which
+    # would never match a marketplace entry) is rejected at its source
+    # rather than producing a confusing downstream "no matching plugin
+    # entry" failure.  Mirrors ``check_version_consistency`` in the audit.
+    if not plugin_name or not plugin_name.strip():
         raise ManifestReadError(
-            "plugin.json: missing or empty 'name' — cannot match the "
-            "plugin entry in marketplace.json"
+            "plugin.json: missing, empty, or whitespace-only 'name' — "
+            "cannot match the plugin entry in marketplace.json"
         )
+    plugin_name = plugin_name.strip()
     versions: dict[str, str | None] = {
         "SKILL.md": _safe_read(
             "SKILL.md", lambda: _version.read_skill_md_version(skill_path)
@@ -302,7 +307,16 @@ def commit_writes(writes: list[tuple[str, str]]) -> None:
             # Track the temp path immediately so the ``finally`` cleanup
             # can remove it even if the upcoming open/write raises.
             tmp_paths.append(tmp)
-            with open(tmp, "w", encoding="utf-8") as fh:
+            # Pin LF newlines on disk to match the rest of the foundry
+            # release tooling (``generate_changelog.py`` does the same).
+            # Default text mode would translate ``\n`` → ``os.linesep``
+            # on write, producing CRLF manifests on Windows even for
+            # checkouts where the canonical form is LF, which would
+            # show up as a noisy diff on every cross-platform bump.
+            # Reading the manifests with default text mode already
+            # normalised CRLF/CR → LF in memory, so writing LF here
+            # round-trips cleanly.
+            with open(tmp, "w", encoding="utf-8", newline="\n") as fh:
                 fh.write(content)
         staged: list[tuple[str, str]] = list(zip([p for p, _ in writes], tmp_paths))
         for index, (path, tmp) in enumerate(staged):

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -8,8 +8,9 @@ script reports that drift via ``EXIT_PARTIAL_WRITE``.  Treat this as a
 best-effort lockstep bump, not a cross-file atomic transaction.
 
 The three files are the single source of truth for the release version.
-``audit_skill_system.py`` enforces that they agree; this script is the
-primitive for changing all three in lockstep.
+``skill-system-foundry/scripts/audit_skill_system.py`` enforces that
+they agree; this script is the primitive for changing all three in
+lockstep.
 
 Usage::
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Atomically bump the version across SKILL.md, plugin.json, and marketplace.json.
+"""Bump the version across SKILL.md, plugin.json, and marketplace.json in lockstep.
+
+Each file is replaced via ``os.replace`` so the swap is atomic *per file*,
+but the set of three is **not** transactional: a failure between the
+first and last swap leaves the manifests inconsistent on disk and the
+script reports that drift via ``EXIT_PARTIAL_WRITE``.  Treat this as a
+best-effort lockstep bump, not a cross-file atomic transaction.
 
 The three files are the single source of truth for the release version.
 ``audit_skill_system.py`` enforces that they agree; this script is the
@@ -53,6 +59,7 @@ import json
 import os
 import subprocess
 import sys
+from collections.abc import Callable
 
 _SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -136,7 +143,7 @@ class ManifestReadError(Exception):
     """
 
 
-def _safe_read(label: str, fn) -> str | None:
+def _safe_read(label: str, fn: Callable[[], str | None]) -> str | None:
     """Run *fn* and translate ``OSError``/``json.JSONDecodeError`` to
     :class:`ManifestReadError` with a *label* prefix.
     """
@@ -151,7 +158,12 @@ def read_all_versions(repo_root: str) -> dict[str, str | None]:
 
     Raises :class:`ManifestReadError` when any manifest is missing,
     unreadable, or contains invalid JSON / frontmatter — operator-facing
-    precondition failures that ``main()`` maps to ``EXIT_DRIFT``.
+    precondition failures that ``main()`` maps to ``EXIT_DRIFT``.  An
+    empty or missing top-level ``"name"`` in ``plugin.json`` is also a
+    precondition failure: without a name the script cannot match the
+    plugin entry inside ``marketplace.json``, and silently skipping that
+    read would surface downstream as a misleading "marketplace.json"
+    error.
     """
     skill_path = _version.skill_md_path(repo_root)
     plugin_path = _version.plugin_json_path(repo_root)
@@ -159,6 +171,11 @@ def read_all_versions(repo_root: str) -> dict[str, str | None]:
     plugin_name = _safe_read(
         "plugin.json", lambda: _version.read_plugin_name(plugin_path)
     )
+    if not plugin_name:
+        raise ManifestReadError(
+            "plugin.json: missing or empty 'name' — cannot match the "
+            "plugin entry in marketplace.json"
+        )
     return {
         "SKILL.md": _safe_read(
             "SKILL.md", lambda: _version.read_skill_md_version(skill_path)
@@ -166,15 +183,11 @@ def read_all_versions(repo_root: str) -> dict[str, str | None]:
         "plugin.json": _safe_read(
             "plugin.json", lambda: _version.read_plugin_json_version(plugin_path)
         ),
-        "marketplace.json": (
-            _safe_read(
-                "marketplace.json",
-                lambda: _version.read_marketplace_json_version(
-                    market_path, plugin_name
-                ),
-            )
-            if plugin_name
-            else None
+        "marketplace.json": _safe_read(
+            "marketplace.json",
+            lambda: _version.read_marketplace_json_version(
+                market_path, plugin_name
+            ),
         ),
     }
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -7,10 +7,10 @@ first and last swap leaves the manifests inconsistent on disk and the
 script reports that drift via ``EXIT_PARTIAL_WRITE``.  Treat this as a
 best-effort lockstep bump, not a cross-file atomic transaction.
 
-The three files are the single source of truth for the release version.
-``skill-system-foundry/scripts/audit_skill_system.py`` enforces that
-they agree; this script is the primitive for changing all three in
-lockstep.
+``skill-system-foundry/SKILL.md`` is the canonical source for the
+release version.  ``skill-system-foundry/scripts/audit_skill_system.py``
+enforces that ``plugin.json`` and ``marketplace.json`` agree with it;
+this script is the primitive for changing all three files in lockstep.
 
 Usage::
 
@@ -289,15 +289,16 @@ def commit_writes(writes: list[tuple[str, str]]) -> None:
         for path, content in writes:
             target_dir = os.path.dirname(path) or "."
             target_base = os.path.basename(path)
-            # mkstemp returns an open fd; close it before reopening in
-            # text mode so the writer applies our encoding/newline
-            # behavior.  Default text-mode newline translation is
-            # intentional: the planners produce ``\n`` in memory
-            # (because the readers used default text mode) and we want
-            # the writer to translate back to the platform's native line
-            # ending — preserving CRLF working trees on Windows that get
-            # LF in git.  Using ``newline=""`` here would force LF on
-            # Windows and unintentionally rewrite the manifests.
+            # mkstemp creates the file with mode 0600 by default; capture
+            # the target's existing mode so we can restore it on the
+            # staged file before ``os.replace`` installs it.  Without the
+            # chmod step a successful bump would silently downgrade the
+            # manifests to owner-only, surprising for files that ship in
+            # release artifacts and shared worktrees.
+            try:
+                target_mode = os.stat(path).st_mode
+            except OSError:
+                target_mode = None
             fd, tmp = tempfile.mkstemp(
                 prefix=target_base + ".",
                 suffix=".tmp",
@@ -313,6 +314,14 @@ def commit_writes(writes: list[tuple[str, str]]) -> None:
             # regardless of the operator's checkout settings.
             with open(tmp, "w", encoding="utf-8", newline="\n") as fh:
                 fh.write(content)
+            if target_mode is not None:
+                try:
+                    os.chmod(tmp, target_mode)
+                except OSError:
+                    # Best-effort: a chmod failure on the staged file is
+                    # not worth aborting the bump over.  ``os.replace``
+                    # below will still install the new content.
+                    pass
         staged: list[tuple[str, str]] = list(zip([p for p, _ in writes], tmp_paths))
         for index, (path, tmp) in enumerate(staged):
             try:

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -40,7 +40,10 @@ Exit codes:
         not inside a git repository, argparse error)
     3   precondition failed (the three manifest files already disagree)
     4   changelog generator probe or write failed
-    5   plan failed (regex matched zero or multiple times in a file)
+    5   plan failed (regex matched zero or multiple times) OR the first
+        write raised before any file was swapped (no drift introduced)
+    6   partial write — at least one file was swapped before the failure,
+        so version drift is now present on disk and must be reconciled
 """
 
 import argparse
@@ -71,6 +74,7 @@ EXIT_INVALID_INPUT = 2
 EXIT_DRIFT = 3
 EXIT_CHANGELOG_FAILED = 4
 EXIT_PLAN_FAILED = 5
+EXIT_PARTIAL_WRITE = 6
 
 GENERATOR_SCRIPT = os.path.join(_SCRIPTS_DIR, "generate_changelog.py")
 
@@ -402,6 +406,10 @@ def main(argv: list[str] | None = None) -> int:
     try:
         commit_writes(writes)
     except PartialWriteError as exc:
+        if not exc.swapped:
+            # The first write failed before any file was swapped; no drift.
+            print(f"error: write failed: {exc.cause}", file=sys.stderr)
+            return EXIT_PLAN_FAILED
         print(
             f"error: partial write — {exc.cause}.  Version drift is now "
             "present on disk and must be reconciled manually:",
@@ -413,7 +421,7 @@ def main(argv: list[str] | None = None) -> int:
         for path in exc.remaining:
             rel = os.path.relpath(path, repo_root)
             print(f"  still at  {current}: {rel}", file=sys.stderr)
-        return EXIT_PLAN_FAILED
+        return EXIT_PARTIAL_WRITE
     except OSError as exc:
         print(f"error: write failed: {exc}", file=sys.stderr)
         return EXIT_PLAN_FAILED

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -258,7 +258,14 @@ def commit_writes(writes: list[tuple[str, str]]) -> None:
     try:
         for path, content in writes:
             tmp = path + ".tmp"
-            with open(tmp, "w", encoding="utf-8", newline="") as fh:
+            # Default text-mode newline translation is intentional: the
+            # planners produce ``\n`` in memory (because the readers used
+            # default text mode), and we want the writer to translate
+            # back to the platform's native line ending — preserving
+            # CRLF working trees on Windows that get LF in git.  Using
+            # ``newline=""`` here would force LF on Windows and
+            # unintentionally rewrite the manifests.
+            with open(tmp, "w", encoding="utf-8") as fh:
                 fh.write(content)
             tmp_paths.append(tmp)
         staged: list[tuple[str, str]] = list(zip([p for p, _ in writes], tmp_paths))
@@ -318,7 +325,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
             "Bump the version across SKILL.md, plugin.json, and "
-            "marketplace.json atomically."
+            "marketplace.json in lockstep with per-file atomic writes "
+            "(not a cross-file atomic transaction — see EXIT_PARTIAL_WRITE)."
         ),
     )
     parser.add_argument(

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -298,9 +298,11 @@ def commit_writes(writes: list[tuple[str, str]]) -> None:
                 dir=target_dir,
             )
             os.close(fd)
+            # Track the temp path immediately so the ``finally`` cleanup
+            # can remove it even if the upcoming open/write raises.
+            tmp_paths.append(tmp)
             with open(tmp, "w", encoding="utf-8") as fh:
                 fh.write(content)
-            tmp_paths.append(tmp)
         staged: list[tuple[str, str]] = list(zip([p for p, _ in writes], tmp_paths))
         for index, (path, tmp) in enumerate(staged):
             try:
@@ -399,20 +401,23 @@ def main(argv: list[str] | None = None) -> int:
         return code if isinstance(code, int) else EXIT_INVALID_INPUT
 
     new_version = args.new_version
-    # Reject shapes not covered by SEMVER_RE.
-    if not _version.SEMVER_RE.match(new_version):
-        print(
-            f"error: new_version must be X.Y.Z (with optional -prerelease "
-            f"suffix); got {new_version!r}",
-            file=sys.stderr,
-        )
-        return EXIT_INVALID_INPUT
-    # Build metadata is syntactically rejected by SEMVER_RE but be explicit
-    # for operators who might paste a ``1.2.3+build`` string from semver.org.
+    # ``v``-prefixed versions and ``+build`` metadata are also rejected
+    # by ``SEMVER_RE``, but operators frequently paste those forms from
+    # semver.org or git tag listings — emit a targeted message first so
+    # the diagnostic points at the specific mistake instead of the
+    # generic shape error below.
     if "+" in new_version or new_version.startswith("v"):
         print(
             f"error: new_version must not carry a 'v' prefix or '+build' "
             f"metadata; got {new_version!r}",
+            file=sys.stderr,
+        )
+        return EXIT_INVALID_INPUT
+    # Reject any remaining shapes not covered by SEMVER_RE.
+    if not _version.SEMVER_RE.match(new_version):
+        print(
+            f"error: new_version must be X.Y.Z (with optional -prerelease "
+            f"suffix); got {new_version!r}",
             file=sys.stderr,
         )
         return EXIT_INVALID_INPUT

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Atomically bump the version across SKILL.md, plugin.json, and marketplace.json.
+
+The three files are the single source of truth for the release version.
+``audit_skill_system.py`` enforces that they agree; this script is the
+primitive for changing all three in lockstep.
+
+Usage::
+
+    python scripts/bump_version.py 1.2.0
+    python scripts/bump_version.py 1.2.0 --dry-run
+    python scripts/bump_version.py 0.9.0 --allow-downgrade
+
+Behavior:
+
+* Reads the current version from every file and refuses to run if they
+  disagree — version drift must be fixed first (run the audit).
+* Validates the new version against a local semver regex (reject ``v``
+  prefix and ``+build`` metadata).
+* Rejects equal versions unconditionally.  Rejects downgrades unless
+  ``--allow-downgrade`` is passed.
+* Plans the three file edits in memory, probes the changelog generator
+  in ``--dry-run`` mode when ``CHANGELOG.md`` exists, and only then
+  commits the edits via ``os.replace`` (per-file atomicity).  A failing
+  probe aborts before any manifest file is touched.
+* After writing the manifest files, invokes ``scripts/generate_changelog.py``
+  with ``--in-place`` to prepend the new section.  If that step fails the
+  manifest files are already bumped — the script surfaces the failure with
+  a non-zero exit code so the operator can re-run the changelog step.
+
+The script is repo-infrastructure, not part of the meta-skill bundle.
+It is intentionally independent from ``skill-system-foundry/scripts/``;
+logic shared with that tree is duplicated by design (see
+``scripts/lib/version.py``).
+
+Exit codes:
+
+    0   success, or dry-run preview printed
+    2   invalid input (bad semver, equal version, downgrade without flag,
+        not inside a git repository, argparse error)
+    3   precondition failed (the three manifest files already disagree)
+    4   changelog generator probe or write failed
+    5   plan failed (regex matched zero or multiple times in a file)
+"""
+
+import argparse
+import datetime
+import importlib.util
+import os
+import subprocess
+import sys
+
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Load the local ``version`` helper by explicit path so the import does not
+# collide with ``skill-system-foundry/scripts/lib`` when both trees end up
+# on ``sys.path`` (e.g. during test discovery).  The two trees are
+# intentionally independent — duplication over bridging.
+_VERSION_PATH = os.path.join(_SCRIPTS_DIR, "lib", "version.py")
+_spec = importlib.util.spec_from_file_location(
+    "repo_infra_version", _VERSION_PATH
+)
+if _spec is None or _spec.loader is None:  # pragma: no cover - defensive
+    raise RuntimeError(f"cannot load {_VERSION_PATH}")
+_version = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_version)
+
+
+EXIT_OK = 0
+EXIT_INVALID_INPUT = 2
+EXIT_DRIFT = 3
+EXIT_CHANGELOG_FAILED = 4
+EXIT_PLAN_FAILED = 5
+
+GENERATOR_SCRIPT = os.path.join(_SCRIPTS_DIR, "generate_changelog.py")
+
+
+def find_repo_root(start: str) -> str | None:
+    """Walk upward from *start* until a ``.git`` entry is found.
+
+    Returns ``None`` when no ``.git`` entry exists.  Accepts both a
+    ``.git`` directory (ordinary checkout) and a ``.git`` file (git
+    worktrees write a file pointing at the linked repository).
+    """
+    current = os.path.abspath(start)
+    while True:
+        if os.path.exists(os.path.join(current, ".git")):
+            return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None
+        current = parent
+
+
+def head_sha(repo_root: str) -> str | None:
+    """Return ``git rev-parse HEAD`` for *repo_root*, or ``None`` on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    sha = result.stdout.strip()
+    return sha or None
+
+
+def read_all_versions(repo_root: str) -> dict[str, str | None]:
+    """Return current version from each of the three manifest files."""
+    skill_path = _version.skill_md_path(repo_root)
+    plugin_path = _version.plugin_json_path(repo_root)
+    market_path = _version.marketplace_json_path(repo_root)
+    plugin_name = _version.read_plugin_name(plugin_path)
+    return {
+        "SKILL.md": _version.read_skill_md_version(skill_path),
+        "plugin.json": _version.read_plugin_json_version(plugin_path),
+        "marketplace.json": (
+            _version.read_marketplace_json_version(market_path, plugin_name)
+            if plugin_name
+            else None
+        ),
+    }
+
+
+def plan_writes(
+    repo_root: str, current: str, new: str
+) -> list[tuple[str, str]]:
+    """Return ``[(path, new_content)]`` for every manifest file.
+
+    Raises ``ValueError`` when any anchored regex does not match exactly
+    once — the caller maps that to exit 5.
+    """
+    skill_path = _version.skill_md_path(repo_root)
+    plugin_path = _version.plugin_json_path(repo_root)
+    market_path = _version.marketplace_json_path(repo_root)
+
+    with open(skill_path, "r", encoding="utf-8") as fh:
+        skill_content = fh.read()
+    with open(plugin_path, "r", encoding="utf-8") as fh:
+        plugin_content = fh.read()
+    with open(market_path, "r", encoding="utf-8") as fh:
+        market_content = fh.read()
+
+    return [
+        (skill_path, _version.plan_skill_md_edit(skill_content, current, new)),
+        (plugin_path, _version.plan_plugin_json_edit(plugin_content, current, new)),
+        (market_path, _version.plan_marketplace_json_edit(market_content, current, new)),
+    ]
+
+
+def commit_writes(writes: list[tuple[str, str]]) -> None:
+    """Atomically (per-file) replace each target via an adjacent ``.tmp``.
+
+    The write phase is deliberately short: plan is already validated,
+    each ``os.replace`` is atomic on POSIX and Windows.  If a late
+    replace fails, earlier files have already been swapped — the caller
+    surfaces this as a warning; we do not attempt to roll back because
+    the post-write state is still internally consistent (every touched
+    file carries the new version).
+    """
+    tmp_paths: list[str] = []
+    try:
+        for path, content in writes:
+            tmp = path + ".tmp"
+            with open(tmp, "w", encoding="utf-8", newline="") as fh:
+                fh.write(content)
+            tmp_paths.append(tmp)
+        # Phase 2: swap every staged file into place.
+        staged: list[str] = list(tmp_paths)
+        for (path, _), tmp in zip(writes, staged):
+            os.replace(tmp, path)
+            tmp_paths.remove(tmp)
+    finally:
+        # Clean up any tmp files left over after a mid-phase failure.
+        for leftover in tmp_paths:
+            try:
+                os.remove(leftover)
+            except OSError:
+                pass
+
+
+def run_generator(
+    repo_root: str,
+    *,
+    since: str,
+    new_version: str,
+    date: str,
+    until: str,
+    dry_run: bool,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke ``scripts/generate_changelog.py`` with appropriate flags."""
+    argv = [
+        sys.executable,
+        GENERATOR_SCRIPT,
+        "--since",
+        since,
+        "--version",
+        new_version,
+        "--date",
+        date,
+        "--until",
+        until,
+        "--in-place",
+    ]
+    if dry_run:
+        argv.append("--dry-run")
+    return subprocess.run(
+        argv,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Bump the version across SKILL.md, plugin.json, and "
+            "marketplace.json atomically."
+        ),
+    )
+    parser.add_argument(
+        "new_version",
+        help="The new version (X.Y.Z, optional -prerelease suffix).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned edits without writing.",
+    )
+    parser.add_argument(
+        "--allow-downgrade",
+        action="store_true",
+        help=(
+            "Allow setting the new version lower than the current one. "
+            "Equal versions are still rejected."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    new_version = args.new_version
+    # Reject shapes not covered by SEMVER_RE.
+    if not _version.SEMVER_RE.match(new_version):
+        print(
+            f"error: new_version must be X.Y.Z (with optional -prerelease "
+            f"suffix); got {new_version!r}",
+            file=sys.stderr,
+        )
+        return EXIT_INVALID_INPUT
+    # Build metadata is syntactically rejected by SEMVER_RE but be explicit
+    # for operators who might paste a ``1.2.3+build`` string from semver.org.
+    if "+" in new_version or new_version.startswith("v"):
+        print(
+            f"error: new_version must not carry a 'v' prefix or '+build' "
+            f"metadata; got {new_version!r}",
+            file=sys.stderr,
+        )
+        return EXIT_INVALID_INPUT
+
+    repo_root = find_repo_root(os.getcwd())
+    if repo_root is None:
+        print(
+            "error: not inside a git repository; cannot locate the "
+            "manifest files.",
+            file=sys.stderr,
+        )
+        return EXIT_INVALID_INPUT
+
+    # Precondition: all three files already agree.
+    versions = read_all_versions(repo_root)
+    missing = [name for name, value in versions.items() if value is None]
+    if missing:
+        print(
+            f"error: could not read current version from: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+        return EXIT_DRIFT
+    unique_values = set(versions.values())
+    if len(unique_values) != 1:
+        print(
+            "error: version drift detected before bump — "
+            + ", ".join(f"{k}={v}" for k, v in versions.items())
+            + "; run `python skill-system-foundry/scripts/audit_skill_system.py "
+            ". --allow-orchestration` and reconcile before bumping.",
+            file=sys.stderr,
+        )
+        return EXIT_DRIFT
+    current = versions["SKILL.md"]
+    assert current is not None  # Guarded above; aid the type checker.
+
+    # Equal / downgrade guard.
+    try:
+        order = _version.compare(new_version, current)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_INVALID_INPUT
+    if order == 0:
+        print(
+            f"error: new_version {new_version!r} equals the current "
+            f"version; nothing to do.",
+            file=sys.stderr,
+        )
+        return EXIT_INVALID_INPUT
+    if order < 0 and not args.allow_downgrade:
+        print(
+            f"error: new_version {new_version!r} is lower than the current "
+            f"version {current!r}; pass --allow-downgrade to force.",
+            file=sys.stderr,
+        )
+        return EXIT_INVALID_INPUT
+
+    # Plan the file edits.
+    try:
+        writes = plan_writes(repo_root, current, new_version)
+    except ValueError as exc:
+        print(f"error: plan failed: {exc}", file=sys.stderr)
+        return EXIT_PLAN_FAILED
+
+    # Probe the changelog generator when CHANGELOG.md is present.  The
+    # probe runs the generator with --dry-run --in-place so an unmapped
+    # commit or a duplicate section is caught before any file is written.
+    changelog_path = os.path.join(repo_root, "CHANGELOG.md")
+    changelog_exists = os.path.exists(changelog_path)
+    today = datetime.datetime.now(datetime.timezone.utc).date().isoformat()
+    since_tag = f"v{current}"
+    until_ref = head_sha(repo_root) or "HEAD"
+
+    probe_stdout = ""
+    if changelog_exists:
+        probe = run_generator(
+            repo_root,
+            since=since_tag,
+            new_version=new_version,
+            date=today,
+            until=until_ref,
+            dry_run=True,
+        )
+        if probe.returncode != 0:
+            print(
+                f"error: changelog probe failed with exit {probe.returncode}; "
+                "no files were modified.",
+                file=sys.stderr,
+            )
+            if probe.stderr:
+                sys.stderr.write(probe.stderr)
+            return EXIT_CHANGELOG_FAILED
+        probe_stdout = probe.stdout
+
+    # Dry-run: print the plan and exit without touching disk.
+    if args.dry_run:
+        print(f"Planned bump: {current} → {new_version}")
+        for path, _ in writes:
+            rel = os.path.relpath(path, repo_root)
+            print(f"  would update {rel}: {current} → {new_version}")
+        if changelog_exists:
+            print()
+            print("Changelog preview (--dry-run):")
+            print(probe_stdout.rstrip())
+        else:
+            print("(CHANGELOG.md absent — generator step would be skipped.)")
+        return EXIT_OK
+
+    # Execute the staged writes.
+    try:
+        commit_writes(writes)
+    except OSError as exc:
+        print(f"error: write failed: {exc}", file=sys.stderr)
+        return EXIT_PLAN_FAILED
+
+    # Generate the changelog for real.
+    if changelog_exists:
+        result = run_generator(
+            repo_root,
+            since=since_tag,
+            new_version=new_version,
+            date=today,
+            until=until_ref,
+            dry_run=False,
+        )
+        if result.returncode != 0:
+            print(
+                f"error: changelog generator exited {result.returncode} "
+                "after the manifest files were bumped.  The version bump is "
+                "committed to disk; re-run the generator manually to finish.",
+                file=sys.stderr,
+            )
+            if result.stderr:
+                sys.stderr.write(result.stderr)
+            return EXIT_CHANGELOG_FAILED
+
+    print(f"Bumped version: {current} → {new_version}")
+    for path, _ in writes:
+        rel = os.path.relpath(path, repo_root)
+        print(f"  updated {rel}")
+    if changelog_exists:
+        print("  updated CHANGELOG.md")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -155,30 +155,52 @@ def plan_writes(
     ]
 
 
-def commit_writes(writes: list[tuple[str, str]]) -> None:
-    """Atomically (per-file) replace each target via an adjacent ``.tmp``.
+class PartialWriteError(OSError):
+    """Phase 2 of commit_writes failed partway through.
 
-    The write phase is deliberately short: plan is already validated,
-    each ``os.replace`` is atomic on POSIX and Windows.  If a late
-    replace fails, earlier files have already been swapped — the caller
-    surfaces this as a warning; we do not attempt to roll back because
-    the post-write state is still internally consistent (every touched
-    file carries the new version).
+    ``swapped`` lists the paths that were successfully replaced with
+    the new version; those files now disagree with the untouched ones.
+    The caller must surface this drift so the operator can reconcile
+    manually — ``os.replace`` is atomic per file, not across the set.
+    """
+
+    def __init__(self, swapped: list[str], remaining: list[str], cause: OSError) -> None:
+        super().__init__(str(cause))
+        self.swapped = swapped
+        self.remaining = remaining
+        self.cause = cause
+
+
+def commit_writes(writes: list[tuple[str, str]]) -> None:
+    """Replace each target via an adjacent ``.tmp`` using ``os.replace``.
+
+    Each ``os.replace`` is atomic per file, but the set as a whole is
+    not transactional.  Phase 1 stages every ``.tmp`` on disk; phase 2
+    swaps them into place one at a time.  If phase 1 fails, no target
+    has been touched — the stale ``.tmp`` files are cleaned up.  If
+    phase 2 fails partway through, earlier files already carry the new
+    version while later ones still carry the old; that is drift, and
+    we raise :class:`PartialWriteError` so the caller can tell the
+    operator exactly which files need manual reconciliation.
     """
     tmp_paths: list[str] = []
+    swapped: list[str] = []
     try:
         for path, content in writes:
             tmp = path + ".tmp"
             with open(tmp, "w", encoding="utf-8", newline="") as fh:
                 fh.write(content)
             tmp_paths.append(tmp)
-        # Phase 2: swap every staged file into place.
-        staged: list[str] = list(tmp_paths)
-        for (path, _), tmp in zip(writes, staged):
-            os.replace(tmp, path)
+        staged: list[tuple[str, str]] = list(zip([p for p, _ in writes], tmp_paths))
+        for index, (path, tmp) in enumerate(staged):
+            try:
+                os.replace(tmp, path)
+            except OSError as exc:
+                remaining = [p for p, _ in staged[index:]]
+                raise PartialWriteError(swapped, remaining, exc) from exc
+            swapped.append(path)
             tmp_paths.remove(tmp)
     finally:
-        # Clean up any tmp files left over after a mid-phase failure.
         for leftover in tmp_paths:
             try:
                 os.remove(leftover)
@@ -296,7 +318,8 @@ def main(argv: list[str] | None = None) -> int:
             "error: version drift detected before bump — "
             + ", ".join(f"{k}={v}" for k, v in versions.items())
             + "; run `python skill-system-foundry/scripts/audit_skill_system.py "
-            ". --allow-orchestration` and reconcile before bumping.",
+            + repo_root
+            + "` and reconcile before bumping.",
             file=sys.stderr,
         )
         return EXIT_DRIFT
@@ -378,6 +401,19 @@ def main(argv: list[str] | None = None) -> int:
     # Execute the staged writes.
     try:
         commit_writes(writes)
+    except PartialWriteError as exc:
+        print(
+            f"error: partial write — {exc.cause}.  Version drift is now "
+            "present on disk and must be reconciled manually:",
+            file=sys.stderr,
+        )
+        for path in exc.swapped:
+            rel = os.path.relpath(path, repo_root)
+            print(f"  swapped to {new_version}: {rel}", file=sys.stderr)
+        for path in exc.remaining:
+            rel = os.path.relpath(path, repo_root)
+            print(f"  still at  {current}: {rel}", file=sys.stderr)
+        return EXIT_PLAN_FAILED
     except OSError as exc:
         print(f"error: write failed: {exc}", file=sys.stderr)
         return EXIT_PLAN_FAILED

--- a/scripts/lib/version.py
+++ b/scripts/lib/version.py
@@ -53,10 +53,10 @@ def compare(a: str, b: str) -> int:
     prerelease strings.  This is a deliberate simplification; document it
     at call sites if strict ranking becomes necessary.
     """
-    ma, mi, pa, pre_a = parse(a)
-    mb, ni, pb, pre_b = parse(b)
-    core_a = (ma, mi, pa)
-    core_b = (mb, ni, pb)
+    major_a, minor_a, patch_a, pre_a = parse(a)
+    major_b, minor_b, patch_b, pre_b = parse(b)
+    core_a = (major_a, minor_a, patch_a)
+    core_b = (major_b, minor_b, patch_b)
     if core_a < core_b:
         return -1
     if core_a > core_b:

--- a/scripts/lib/version.py
+++ b/scripts/lib/version.py
@@ -2,9 +2,14 @@
 
 This module is local to the top-level ``scripts/`` tree.  It is intentionally
 independent from the meta-skill tree at ``skill-system-foundry/scripts/`` —
-no imports cross between the two trees.  The regex shape mirrors
-``RE_METADATA_VERSION`` inside the meta-skill's ``configuration.yaml``; keep
-them in lockstep by hand.
+no imports cross between the two trees.  ``SEMVER_RE`` here implements the
+strict SemVer 2.0.0 grammar (sans build metadata) needed by the release
+primitive: it rejects leading zeros, empty prerelease identifiers, and
+trailing newlines.  The meta-skill's ``RE_METADATA_VERSION`` in
+``configuration.yaml`` is intentionally looser because it acts as a foundry
+recommendation for skill authors rather than a release input validator;
+the two patterns are *not* kept in lockstep — release tooling depends only
+on the strict regex defined here.
 
 The module exposes three kinds of primitives:
 
@@ -30,10 +35,14 @@ import re
 # - prerelease identifiers must be non-empty, dot-separated, and either
 #   purely numeric (no leading zero) or alphanumeric/hyphen with at least
 #   one non-digit character.  ``1.2.3-alpha.`` is rejected.
+# The end anchor is ``\Z`` (end of string) rather than ``$`` because
+# Python's ``$`` also matches before a final ``\n``; combined with the
+# ``.match()`` calls below, ``$`` would accept ``"1.2.3\n"`` and silently
+# pass invalid CLI input through to the planner.
 SEMVER_RE = re.compile(
-    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"\A(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
     r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
-    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?\Z"
 )
 
 

--- a/scripts/lib/version.py
+++ b/scripts/lib/version.py
@@ -39,10 +39,13 @@ import re
 # Python's ``$`` also matches before a final ``\n``; combined with the
 # ``.match()`` calls below, ``$`` would accept ``"1.2.3\n"`` and silently
 # pass invalid CLI input through to the planner.
+# Digits are written as ``[0-9]`` rather than ``\d`` so non-ASCII
+# decimal-digit codepoints (e.g., Arabic-Indic ``٢``) cannot satisfy
+# the grammar — SemVer identifiers are ASCII-only.
 SEMVER_RE = re.compile(
-    r"\A(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
-    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
-    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?\Z"
+    r"\A(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+    r"(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?\Z"
 )
 
 
@@ -151,33 +154,64 @@ def _strip_yaml_scalar_quotes(value: str) -> str:
     return value
 
 
-def read_skill_md_version(path: str) -> str | None:
-    """Read ``metadata.version`` from a SKILL.md file.
+def _direct_metadata_version_match(frontmatter: str) -> tuple[int, str] | None:
+    """Locate ``metadata.version`` as a *direct* child of ``metadata:``.
 
-    Returns ``None`` when the file has no frontmatter, when the frontmatter
-    has no ``metadata`` block, or when ``metadata.version`` is absent.
-    Raises ``OSError`` when the file cannot be read.
+    Returns ``(indent_width, raw_value)`` for the matched line, or ``None``
+    when no such direct child exists.  ``indent_width`` is the number of
+    leading whitespace columns for direct children of the metadata block;
+    callers can use it to anchor a planner regex at the same depth.
+
+    Tracking the indent width is necessary because YAML permits nested
+    mappings under ``metadata`` — a deeper ``metadata.compatibility.version``
+    must not be returned in place of the canonical
+    ``metadata.version`` when the latter is absent.
     """
-    with open(path, "r", encoding="utf-8") as fh:
-        content = fh.read()
-    frontmatter = _extract_frontmatter(content)
-    if frontmatter is None:
-        return None
     in_metadata = False
+    metadata_indent: int | None = None
     for line in frontmatter.splitlines():
         if not line.strip():
             continue
         if line.rstrip() == "metadata:":
             in_metadata = True
             continue
-        if in_metadata:
-            if line and not line[0].isspace():
-                # Left the metadata block without finding version.
-                return None
-            match = re.match(r"^\s+version:\s*(\S.*)$", line)
-            if match:
-                return _strip_yaml_scalar_quotes(match.group(1))
+        if not in_metadata:
+            continue
+        if line[0:1] and not line[0].isspace():
+            # Left the metadata block (next top-level key) without
+            # finding a direct version child.
+            return None
+        indent = len(line) - len(line.lstrip())
+        if metadata_indent is None:
+            metadata_indent = indent
+        if indent != metadata_indent:
+            # Nested mapping at deeper indent — not a direct child.
+            continue
+        match = re.match(r"^[ \t]+version:\s*(\S.*)$", line)
+        if match:
+            return metadata_indent, match.group(1)
     return None
+
+
+def read_skill_md_version(path: str) -> str | None:
+    """Read ``metadata.version`` from a SKILL.md file.
+
+    Returns ``None`` when the file has no frontmatter, when the frontmatter
+    has no ``metadata`` block, or when ``metadata.version`` is absent
+    **as a direct child** of ``metadata:``.  Nested keys at deeper
+    indentation (e.g., ``metadata.compatibility.version``) are not
+    accepted in place of the canonical field.  Raises ``OSError`` when
+    the file cannot be read.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        content = fh.read()
+    frontmatter = _extract_frontmatter(content)
+    if frontmatter is None:
+        return None
+    found = _direct_metadata_version_match(frontmatter)
+    if found is None:
+        return None
+    return _strip_yaml_scalar_quotes(found[1])
 
 
 def read_plugin_json_version(path: str) -> str | None:
@@ -234,13 +268,14 @@ def read_plugin_name(path: str) -> str | None:
 def plan_skill_md_edit(content: str, current: str, new: str) -> str:
     """Return *content* with ``metadata.version`` changed from *current* to *new*.
 
-    Edits are restricted to the frontmatter block so a stray ``version:`` line
-    in the body cannot be rewritten.  Raises ``ValueError`` when the
-    opening delimiter is malformed, when the frontmatter is unterminated,
-    or when the anchored version pattern does not match exactly once.
-    The opener check is line-wise (matching ``_FRONTMATTER_OPEN_RE``) so
-    inputs that begin with ``---oops`` are rejected rather than treated
-    as frontmatter.
+    The edit is anchored to the **direct child** of the frontmatter
+    ``metadata:`` block, scoped by the indent width discovered while
+    reading.  A nested key like ``metadata.compatibility.version`` is
+    therefore neither read by the reader nor edited by this planner.
+    Raises ``ValueError`` when the opening delimiter is malformed, when
+    the frontmatter is unterminated, when the metadata block lacks a
+    direct ``version`` child, or when the anchored pattern does not
+    match exactly once at the expected depth.
     """
     open_match = _FRONTMATTER_OPEN_RE.match(content)
     if open_match is None:
@@ -252,12 +287,23 @@ def plan_skill_md_edit(content: str, current: str, new: str) -> str:
     fm_end = fm_start + close_match.start()
     frontmatter = content[fm_start:fm_end]
 
+    found = _direct_metadata_version_match(frontmatter)
+    if found is None:
+        raise ValueError(
+            "SKILL.md frontmatter has no direct 'metadata.version' "
+            "child to edit"
+        )
+    indent_width, _ = found
+
     # ``read_skill_md_version`` strips matched surrounding YAML quotes, so
     # the same plan must accept both ``version: 1.2.3`` and
     # ``version: "1.2.3"`` (and the single-quote form), preserving whichever
     # the file already uses.  ``(?P=q)`` enforces matching open/close quotes.
+    # The prefix is anchored at exactly the metadata-child indent width
+    # so a nested ``version:`` at deeper indentation cannot be edited
+    # in place of the canonical field.
     pattern = re.compile(
-        rf"^(?P<prefix>\s+version:\s*)"
+        rf"^(?P<prefix>[ \t]{{{indent_width}}}version:\s*)"
         rf"(?P<q>['\"]?){re.escape(current)}(?P=q)"
         rf"(?P<suffix>\s*)$",
         re.MULTILINE,
@@ -265,8 +311,8 @@ def plan_skill_md_edit(content: str, current: str, new: str) -> str:
     matches = pattern.findall(frontmatter)
     if len(matches) != 1:
         raise ValueError(
-            f"expected exactly one 'version: {current}' line in SKILL.md "
-            f"frontmatter, found {len(matches)}"
+            f"expected exactly one 'version: {current}' line at the "
+            f"metadata indent in SKILL.md frontmatter, found {len(matches)}"
         )
     new_frontmatter = pattern.sub(
         lambda m: (

--- a/scripts/lib/version.py
+++ b/scripts/lib/version.py
@@ -112,23 +112,26 @@ def compare(a: str, b: str) -> int:
 # ---------------------------------------------------------------------------
 
 
+_FRONTMATTER_OPEN_RE = re.compile(r"\A---\s*(?:\r\n|\r|\n)")
+
+
 def _extract_frontmatter(content: str) -> str | None:
     """Return the YAML frontmatter block of *content*, or ``None`` when absent.
 
-    A frontmatter block opens with ``---`` on the first line and closes on
-    the next line that is exactly ``---`` (trailing whitespace allowed).
+    A frontmatter block opens when the first line is exactly ``---``
+    (trailing whitespace allowed) and closes on the next line that is
+    exactly ``---`` (trailing whitespace allowed).  ``startswith('---')``
+    alone would also match malformed inputs like ``---oops``, so the
+    opener is checked line-wise.
     """
-    if not content.startswith("---"):
+    open_match = _FRONTMATTER_OPEN_RE.match(content)
+    if open_match is None:
         return None
-    first_newline = content.find("\n")
-    if first_newline < 0:
-        return None
-    close_match = re.search(
-        r"^---\s*$", content[first_newline + 1:], re.MULTILINE
-    )
+    fm_start = open_match.end()
+    close_match = re.search(r"^---\s*$", content[fm_start:], re.MULTILINE)
     if close_match is None:
         return None
-    return content[first_newline + 1:first_newline + 1 + close_match.start()]
+    return content[fm_start:fm_start + close_match.start()]
 
 
 def _strip_yaml_scalar_quotes(value: str) -> str:
@@ -224,19 +227,19 @@ def plan_skill_md_edit(content: str, current: str, new: str) -> str:
 
     Edits are restricted to the frontmatter block so a stray ``version:`` line
     in the body cannot be rewritten.  Raises ``ValueError`` when the
-    anchored pattern does not match exactly once.
+    opening delimiter is malformed, when the frontmatter is unterminated,
+    or when the anchored version pattern does not match exactly once.
+    The opener check is line-wise (matching ``_FRONTMATTER_OPEN_RE``) so
+    inputs that begin with ``---oops`` are rejected rather than treated
+    as frontmatter.
     """
-    if not content.startswith("---"):
+    open_match = _FRONTMATTER_OPEN_RE.match(content)
+    if open_match is None:
         raise ValueError("SKILL.md missing opening '---' frontmatter delimiter")
-    first_newline = content.find("\n")
-    if first_newline < 0:
-        raise ValueError("SKILL.md frontmatter is truncated")
-    close_match = re.search(
-        r"^---\s*$", content[first_newline + 1:], re.MULTILINE
-    )
+    fm_start = open_match.end()
+    close_match = re.search(r"^---\s*$", content[fm_start:], re.MULTILINE)
     if close_match is None:
         raise ValueError("SKILL.md frontmatter is not terminated")
-    fm_start = first_newline + 1
     fm_end = fm_start + close_match.start()
     frontmatter = content[fm_start:fm_end]
 
@@ -307,17 +310,61 @@ def _plan_json_version_edit(
 
 
 def plan_plugin_json_edit(content: str, current: str, new: str) -> str:
-    """Return *content* of plugin.json with ``version`` changed to *new*."""
-    return _plan_json_version_edit(content, current, new, "plugin.json")
+    """Return *content* of plugin.json with the **top-level** ``version`` set to *new*.
 
-
-def plan_marketplace_json_edit(content: str, current: str, new: str) -> str:
-    """Return *content* of marketplace.json with the plugin ``version`` set to *new*.
-
-    The marketplace file is expected to contain exactly one plugin entry
-    whose version matches *current*; the single-match guard enforces that.
+    The text-level regex is followed by a structural verification step:
+    after substitution, the result is reparsed and the top-level
+    ``"version"`` field must equal *new*.  This catches the otherwise
+    silent failure mode where a compact top-level version coexists with
+    a pretty-printed nested ``"version"`` line — the regex would match
+    the nested line and report success while leaving the canonical
+    top-level field untouched.
     """
-    return _plan_json_version_edit(content, current, new, "marketplace.json")
+    result = _plan_json_version_edit(content, current, new, "plugin.json")
+    parsed = json.loads(result)
+    if not isinstance(parsed, dict) or parsed.get("version") != new:
+        raise ValueError(
+            "plugin.json: planner did not update the top-level "
+            "'version' field — the manifest must be pretty-printed "
+            "with the canonical top-level version key on its own "
+            "indented line"
+        )
+    return result
+
+
+def plan_marketplace_json_edit(
+    content: str, current: str, new: str, plugin_name: str
+) -> str:
+    """Return *content* of marketplace.json with the matching plugin's ``version`` set to *new*.
+
+    The matching plugin entry is identified by *plugin_name* (the same
+    convention used by :func:`read_marketplace_json_version`).  After
+    the text-level regex substitution, the result is reparsed and the
+    plugin entry whose ``"name"`` equals *plugin_name* must carry the
+    new version — otherwise the regex matched an unrelated nested
+    ``"version"`` line (e.g., inside a different plugin entry or a
+    sidecar object) and we refuse rather than silently corrupting the
+    file.
+    """
+    result = _plan_json_version_edit(content, current, new, "marketplace.json")
+    parsed = json.loads(result)
+    plugins = parsed.get("plugins") if isinstance(parsed, dict) else None
+    target_version: str | None = None
+    if isinstance(plugins, list):
+        for entry in plugins:
+            if isinstance(entry, dict) and entry.get("name") == plugin_name:
+                value = entry.get("version")
+                if isinstance(value, str):
+                    target_version = value
+                break
+    if target_version != new:
+        raise ValueError(
+            f"marketplace.json: planner did not update the version of "
+            f"the plugin entry named {plugin_name!r} — the manifest "
+            "must be pretty-printed with the matching plugin's version "
+            "key on its own indented line"
+        )
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/version.py
+++ b/scripts/lib/version.py
@@ -25,7 +25,16 @@ import os
 import re
 
 
-SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?$")
+# Strict SemVer 2.0.0 (sans build metadata, which the foundry forbids):
+# - core identifiers reject leading zeros (``01.2.3`` is invalid);
+# - prerelease identifiers must be non-empty, dot-separated, and either
+#   purely numeric (no leading zero) or alphanumeric/hyphen with at least
+#   one non-digit character.  ``1.2.3-alpha.`` is rejected.
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$"
+)
 
 
 def parse(version: str) -> tuple[int, int, int, str]:
@@ -42,16 +51,44 @@ def parse(version: str) -> tuple[int, int, int, str]:
     return (int(major), int(minor), int(patch), pre)
 
 
+def _compare_prerelease(a: str, b: str) -> int:
+    """Compare two non-empty prerelease strings per SemVer 2.0.0 §11.4.
+
+    Identifiers are compared dot-by-dot: numeric identifiers compare
+    numerically and have lower precedence than alphanumeric ones; equal
+    identifiers fall through to the next position, and a shorter list of
+    identifiers (with all preceding equal) has lower precedence.
+    """
+    ids_a = a.split(".")
+    ids_b = b.split(".")
+    for x, y in zip(ids_a, ids_b):
+        x_num = x.isdigit()
+        y_num = y.isdigit()
+        if x_num and y_num:
+            xi, yi = int(x), int(y)
+            if xi != yi:
+                return -1 if xi < yi else 1
+        elif x_num and not y_num:
+            return -1
+        elif y_num and not x_num:
+            return 1
+        else:
+            if x != y:
+                return -1 if x < y else 1
+    if len(ids_a) == len(ids_b):
+        return 0
+    return -1 if len(ids_a) < len(ids_b) else 1
+
+
 def compare(a: str, b: str) -> int:
     """Return -1/0/1 comparing semver *a* against *b*.
 
-    Integer-tuple compare on ``(major, minor, patch)``.  Prerelease tie-breaker
-    follows the essential semver rule — a version with a prerelease is less
-    than the same version without one — but does not attempt to rank
-    prerelease identifiers against each other.  When both sides carry a
-    prerelease, the comparison falls back to lexicographic order of the
-    prerelease strings.  This is a deliberate simplification; document it
-    at call sites if strict ranking becomes necessary.
+    Integer-tuple compare on ``(major, minor, patch)``.  When the cores
+    are equal, prerelease precedence follows SemVer 2.0.0 §11: a version
+    with a prerelease is less than the same version without one, and two
+    prerelease strings are compared identifier-by-identifier (numeric
+    identifiers numerically, alphanumeric lexically, numerics ranking
+    below alphanumerics, fewer identifiers ranking below more).
     """
     major_a, minor_a, patch_a, pre_a = parse(a)
     major_b, minor_b, patch_b, pre_b = parse(b)
@@ -67,9 +104,7 @@ def compare(a: str, b: str) -> int:
         return 1
     if not pre_b:
         return -1
-    if pre_a < pre_b:
-        return -1
-    return 1
+    return _compare_prerelease(pre_a, pre_b)
 
 
 # ---------------------------------------------------------------------------
@@ -205,8 +240,14 @@ def plan_skill_md_edit(content: str, current: str, new: str) -> str:
     fm_end = fm_start + close_match.start()
     frontmatter = content[fm_start:fm_end]
 
+    # ``read_skill_md_version`` strips matched surrounding YAML quotes, so
+    # the same plan must accept both ``version: 1.2.3`` and
+    # ``version: "1.2.3"`` (and the single-quote form), preserving whichever
+    # the file already uses.  ``(?P=q)`` enforces matching open/close quotes.
     pattern = re.compile(
-        rf"^(?P<prefix>\s+version:\s*){re.escape(current)}(?P<suffix>\s*)$",
+        rf"^(?P<prefix>\s+version:\s*)"
+        rf"(?P<q>['\"]?){re.escape(current)}(?P=q)"
+        rf"(?P<suffix>\s*)$",
         re.MULTILINE,
     )
     matches = pattern.findall(frontmatter)
@@ -216,7 +257,10 @@ def plan_skill_md_edit(content: str, current: str, new: str) -> str:
             f"frontmatter, found {len(matches)}"
         )
     new_frontmatter = pattern.sub(
-        lambda m: f"{m.group('prefix')}{new}{m.group('suffix')}",
+        lambda m: (
+            f"{m.group('prefix')}{m.group('q')}{new}{m.group('q')}"
+            f"{m.group('suffix')}"
+        ),
         frontmatter,
         count=1,
     )

--- a/scripts/lib/version.py
+++ b/scripts/lib/version.py
@@ -347,33 +347,69 @@ def plan_marketplace_json_edit(
     """Return *content* of marketplace.json with the matching plugin's ``version`` set to *new*.
 
     The matching plugin entry is identified by *plugin_name* (the same
-    convention used by :func:`read_marketplace_json_version`).  After
-    the text-level regex substitution, the result is reparsed and the
-    plugin entry whose ``"name"`` equals *plugin_name* must carry the
-    new version — otherwise the regex matched an unrelated nested
-    ``"version"`` line (e.g., inside a different plugin entry or a
-    sidecar object) and we refuse rather than silently corrupting the
-    file.
+    convention used by :func:`read_marketplace_json_version`).  Unlike
+    :func:`plan_plugin_json_edit`, this planner does **not** require
+    the file to contain exactly one ``"version"`` line — a marketplace
+    is allowed to ship multiple plugin entries that may share a
+    version, plus arbitrary sidecar metadata.  Instead, it iterates
+    every candidate ``"version": "<current>"`` line, simulates the
+    substitution, reparses, and accepts the unique simulation that
+    sets the named plugin's ``"version"`` field to *new*.
+
+    Raises ``ValueError`` when zero candidate substitutions hit the
+    target plugin (the manifest does not contain the named plugin in
+    the supported pretty-printed shape) or more than one does (the
+    edit is ambiguous and would silently corrupt unrelated metadata).
+    The same ``ValueError`` flavor as :func:`_plan_json_version_edit`
+    is preserved so the bump primitive's exit-code mapping stays
+    consistent.
     """
-    result = _plan_json_version_edit(content, current, new, "marketplace.json")
-    parsed = json.loads(result)
-    plugins = parsed.get("plugins") if isinstance(parsed, dict) else None
-    target_version: str | None = None
-    if isinstance(plugins, list):
-        for entry in plugins:
-            if isinstance(entry, dict) and entry.get("name") == plugin_name:
-                value = entry.get("version")
-                if isinstance(value, str):
-                    target_version = value
-                break
-    if target_version != new:
+    pattern = re.compile(
+        rf'^(?P<prefix>\s+"version"\s*:\s*"){re.escape(current)}'
+        rf'(?P<suffix>"\s*,?\s*)$',
+        re.MULTILINE,
+    )
+    matches = list(pattern.finditer(content))
+    if not matches:
         raise ValueError(
-            f"marketplace.json: planner did not update the version of "
-            f"the plugin entry named {plugin_name!r} — the manifest "
-            "must be pretty-printed with the matching plugin's version "
-            "key on its own indented line"
+            f"expected at least one '\"version\": \"{current}\"' line in "
+            f"marketplace.json, found 0 (the planner requires a "
+            "pretty-printed JSON manifest with the version key on its "
+            "own line)"
         )
-    return result
+
+    accepted: list[str] = []
+    for match in matches:
+        candidate = (
+            content[:match.start()]
+            + f"{match.group('prefix')}{new}{match.group('suffix')}"
+            + content[match.end():]
+        )
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        plugins = parsed.get("plugins") if isinstance(parsed, dict) else None
+        if not isinstance(plugins, list):
+            continue
+        for entry in plugins:
+            if (
+                isinstance(entry, dict)
+                and entry.get("name") == plugin_name
+                and entry.get("version") == new
+            ):
+                accepted.append(candidate)
+                break
+
+    if len(accepted) != 1:
+        raise ValueError(
+            f"marketplace.json: expected exactly one candidate edit "
+            f"that updates the version of the plugin entry named "
+            f"{plugin_name!r}, found {len(accepted)} (the manifest must "
+            "be pretty-printed with the matching plugin's version key "
+            "on its own indented line)"
+        )
+    return accepted[0]
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/version.py
+++ b/scripts/lib/version.py
@@ -272,6 +272,16 @@ def _plan_json_version_edit(
 ) -> str:
     """Replace a ``"version": "<current>"`` line with *new*.
 
+    **Formatting contract.**  This helper edits the file as text — it
+    does not parse and re-emit JSON, so file shape (key order,
+    indentation, trailing newline) is preserved verbatim.  In return it
+    requires the manifest to be **pretty-printed** with the
+    ``"version"`` key on its own indented line.  A compact one-line JSON
+    document will pass JSON validation and the precondition read but
+    fail the planner with a ``ValueError`` — reformat the manifest or
+    use a structural JSON editor instead.  All foundry-shipped
+    manifests follow the pretty-printed convention.
+
     The anchored pattern targets an indented key at any depth but refuses to
     run unless exactly one line matches.  *label* is used only in error
     messages so the caller's ``ValueError`` is actionable.
@@ -285,7 +295,9 @@ def _plan_json_version_edit(
     if len(matches) != 1:
         raise ValueError(
             f"expected exactly one '\"version\": \"{current}\"' line in "
-            f"{label}, found {len(matches)}"
+            f"{label}, found {len(matches)} (the planner requires a "
+            "pretty-printed JSON manifest with the version key on its "
+            "own line)"
         )
     return pattern.sub(
         lambda m: f"{m.group('prefix')}{new}{m.group('suffix')}",
@@ -314,12 +326,15 @@ def plan_marketplace_json_edit(content: str, current: str, new: str) -> str:
 
 
 def skill_md_path(repo_root: str) -> str:
+    """Return the path to ``skill-system-foundry/SKILL.md`` under *repo_root*."""
     return os.path.join(repo_root, "skill-system-foundry", "SKILL.md")
 
 
 def plugin_json_path(repo_root: str) -> str:
+    """Return the path to ``.claude-plugin/plugin.json`` under *repo_root*."""
     return os.path.join(repo_root, ".claude-plugin", "plugin.json")
 
 
 def marketplace_json_path(repo_root: str) -> str:
+    """Return the path to ``.claude-plugin/marketplace.json`` under *repo_root*."""
     return os.path.join(repo_root, ".claude-plugin", "marketplace.json")

--- a/scripts/lib/version.py
+++ b/scripts/lib/version.py
@@ -1,0 +1,281 @@
+"""Shared version-string helpers for repo-infrastructure scripts.
+
+This module is local to the top-level ``scripts/`` tree.  It is intentionally
+independent from the meta-skill tree at ``skill-system-foundry/scripts/`` —
+no imports cross between the two trees.  The regex shape mirrors
+``RE_METADATA_VERSION`` inside the meta-skill's ``configuration.yaml``; keep
+them in lockstep by hand.
+
+The module exposes three kinds of primitives:
+
+* semver validation (``SEMVER_RE``, ``parse``, ``compare``)
+* read helpers that extract the current version from each manifest file
+  (``read_skill_md_version``, ``read_plugin_json_version``,
+  ``read_marketplace_json_version``)
+* plan-edit helpers that return new file content with the version field
+  replaced (``plan_skill_md_edit``, ``plan_plugin_json_edit``,
+  ``plan_marketplace_json_edit``).  Each plan-edit helper raises
+  ``ValueError`` when the anchored regex matches zero or multiple times,
+  so callers can surface a structural failure instead of writing a
+  subtly wrong file.
+"""
+
+import json
+import os
+import re
+
+
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.-]+)?$")
+
+
+def parse(version: str) -> tuple[int, int, int, str]:
+    """Split *version* into ``(major, minor, patch, prerelease)``.
+
+    The prerelease component is the substring after the first ``-`` (empty
+    string when absent).  Build metadata is rejected by ``SEMVER_RE``.
+    Raises ``ValueError`` when *version* does not match ``SEMVER_RE``.
+    """
+    if not SEMVER_RE.match(version):
+        raise ValueError(f"not a valid semver: {version!r}")
+    core, _, pre = version.partition("-")
+    major, minor, patch = core.split(".")
+    return (int(major), int(minor), int(patch), pre)
+
+
+def compare(a: str, b: str) -> int:
+    """Return -1/0/1 comparing semver *a* against *b*.
+
+    Integer-tuple compare on ``(major, minor, patch)``.  Prerelease tie-breaker
+    follows the essential semver rule — a version with a prerelease is less
+    than the same version without one — but does not attempt to rank
+    prerelease identifiers against each other.  When both sides carry a
+    prerelease, the comparison falls back to lexicographic order of the
+    prerelease strings.  This is a deliberate simplification; document it
+    at call sites if strict ranking becomes necessary.
+    """
+    ma, mi, pa, pre_a = parse(a)
+    mb, ni, pb, pre_b = parse(b)
+    core_a = (ma, mi, pa)
+    core_b = (mb, ni, pb)
+    if core_a < core_b:
+        return -1
+    if core_a > core_b:
+        return 1
+    if pre_a == pre_b:
+        return 0
+    if not pre_a:
+        return 1
+    if not pre_b:
+        return -1
+    if pre_a < pre_b:
+        return -1
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# read helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_frontmatter(content: str) -> str | None:
+    """Return the YAML frontmatter block of *content*, or ``None`` when absent.
+
+    A frontmatter block opens with ``---`` on the first line and closes on
+    the next line that is exactly ``---`` (trailing whitespace allowed).
+    """
+    if not content.startswith("---"):
+        return None
+    first_newline = content.find("\n")
+    if first_newline < 0:
+        return None
+    close_match = re.search(
+        r"^---\s*$", content[first_newline + 1:], re.MULTILINE
+    )
+    if close_match is None:
+        return None
+    return content[first_newline + 1:first_newline + 1 + close_match.start()]
+
+
+def _strip_yaml_scalar_quotes(value: str) -> str:
+    """Strip matched surrounding single/double quotes from a YAML scalar."""
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+        return value[1:-1]
+    return value
+
+
+def read_skill_md_version(path: str) -> str | None:
+    """Read ``metadata.version`` from a SKILL.md file.
+
+    Returns ``None`` when the file has no frontmatter, when the frontmatter
+    has no ``metadata`` block, or when ``metadata.version`` is absent.
+    Raises ``OSError`` when the file cannot be read.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        content = fh.read()
+    frontmatter = _extract_frontmatter(content)
+    if frontmatter is None:
+        return None
+    in_metadata = False
+    for line in frontmatter.splitlines():
+        if not line.strip():
+            continue
+        if line.rstrip() == "metadata:":
+            in_metadata = True
+            continue
+        if in_metadata:
+            if line and not line[0].isspace():
+                # Left the metadata block without finding version.
+                return None
+            match = re.match(r"^\s+version:\s*(\S.*)$", line)
+            if match:
+                return _strip_yaml_scalar_quotes(match.group(1))
+    return None
+
+
+def read_plugin_json_version(path: str) -> str | None:
+    """Read the top-level ``version`` field from ``plugin.json``.
+
+    Returns ``None`` when the key is absent or not a string.  Raises
+    ``OSError`` / ``json.JSONDecodeError`` on file or parse errors — the
+    caller decides whether to surface those as a FAIL or a crash.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    value = data.get("version") if isinstance(data, dict) else None
+    return value if isinstance(value, str) else None
+
+
+def read_marketplace_json_version(
+    path: str, plugin_name: str
+) -> str | None:
+    """Read ``plugins[name=<plugin_name>].version`` from ``marketplace.json``.
+
+    Matches the plugin entry by ``name`` (mirroring the convention used by
+    ``tests/test_claude_distribution_metadata.py``).  Returns ``None`` when
+    no matching entry exists or when the entry lacks a string ``version``.
+    """
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        return None
+    plugins = data.get("plugins")
+    if not isinstance(plugins, list):
+        return None
+    for entry in plugins:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("name") == plugin_name:
+            value = entry.get("version")
+            return value if isinstance(value, str) else None
+    return None
+
+
+def read_plugin_name(path: str) -> str | None:
+    """Read the top-level ``name`` field from ``plugin.json``."""
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    value = data.get("name") if isinstance(data, dict) else None
+    return value if isinstance(value, str) else None
+
+
+# ---------------------------------------------------------------------------
+# plan-edit helpers
+# ---------------------------------------------------------------------------
+
+
+def plan_skill_md_edit(content: str, current: str, new: str) -> str:
+    """Return *content* with ``metadata.version`` changed from *current* to *new*.
+
+    Edits are restricted to the frontmatter block so a stray ``version:`` line
+    in the body cannot be rewritten.  Raises ``ValueError`` when the
+    anchored pattern does not match exactly once.
+    """
+    if not content.startswith("---"):
+        raise ValueError("SKILL.md missing opening '---' frontmatter delimiter")
+    first_newline = content.find("\n")
+    if first_newline < 0:
+        raise ValueError("SKILL.md frontmatter is truncated")
+    close_match = re.search(
+        r"^---\s*$", content[first_newline + 1:], re.MULTILINE
+    )
+    if close_match is None:
+        raise ValueError("SKILL.md frontmatter is not terminated")
+    fm_start = first_newline + 1
+    fm_end = fm_start + close_match.start()
+    frontmatter = content[fm_start:fm_end]
+
+    pattern = re.compile(
+        rf"^(?P<prefix>\s+version:\s*){re.escape(current)}(?P<suffix>\s*)$",
+        re.MULTILINE,
+    )
+    matches = pattern.findall(frontmatter)
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected exactly one 'version: {current}' line in SKILL.md "
+            f"frontmatter, found {len(matches)}"
+        )
+    new_frontmatter = pattern.sub(
+        lambda m: f"{m.group('prefix')}{new}{m.group('suffix')}",
+        frontmatter,
+        count=1,
+    )
+    return content[:fm_start] + new_frontmatter + content[fm_end:]
+
+
+def _plan_json_version_edit(
+    content: str, current: str, new: str, label: str
+) -> str:
+    """Replace a ``"version": "<current>"`` line with *new*.
+
+    The anchored pattern targets an indented key at any depth but refuses to
+    run unless exactly one line matches.  *label* is used only in error
+    messages so the caller's ``ValueError`` is actionable.
+    """
+    pattern = re.compile(
+        rf'^(?P<prefix>\s+"version"\s*:\s*"){re.escape(current)}'
+        rf'(?P<suffix>"\s*,?\s*)$',
+        re.MULTILINE,
+    )
+    matches = pattern.findall(content)
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected exactly one '\"version\": \"{current}\"' line in "
+            f"{label}, found {len(matches)}"
+        )
+    return pattern.sub(
+        lambda m: f"{m.group('prefix')}{new}{m.group('suffix')}",
+        content,
+        count=1,
+    )
+
+
+def plan_plugin_json_edit(content: str, current: str, new: str) -> str:
+    """Return *content* of plugin.json with ``version`` changed to *new*."""
+    return _plan_json_version_edit(content, current, new, "plugin.json")
+
+
+def plan_marketplace_json_edit(content: str, current: str, new: str) -> str:
+    """Return *content* of marketplace.json with the plugin ``version`` set to *new*.
+
+    The marketplace file is expected to contain exactly one plugin entry
+    whose version matches *current*; the single-match guard enforces that.
+    """
+    return _plan_json_version_edit(content, current, new, "marketplace.json")
+
+
+# ---------------------------------------------------------------------------
+# path helpers
+# ---------------------------------------------------------------------------
+
+
+def skill_md_path(repo_root: str) -> str:
+    return os.path.join(repo_root, "skill-system-foundry", "SKILL.md")
+
+
+def plugin_json_path(repo_root: str) -> str:
+    return os.path.join(repo_root, ".claude-plugin", "plugin.json")
+
+
+def marketplace_json_path(repo_root: str) -> str:
+    return os.path.join(repo_root, ".claude-plugin", "marketplace.json")

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -99,7 +99,13 @@ def _skill_md_version(system_root: str) -> tuple[str | None, str | None]:
     path = os.path.join(system_root, "skill-system-foundry", FILE_SKILL_MD)
     if not os.path.exists(path):
         return None, f"{path} does not exist"
-    fm, _, _ = load_frontmatter(path)
+    try:
+        fm, _, _ = load_frontmatter(path)
+    except OSError as exc:
+        # A present-but-unreadable file (permissions, transient FS error)
+        # must surface as a structured finding instead of aborting the
+        # audit, mirroring how _read_plugin_json handles its own errors.
+        return None, f"{path} cannot be read: {exc}"
     if fm is None:
         return None, f"{path} has no frontmatter"
     if "_parse_error" in fm:

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -39,6 +39,7 @@ Examples:
 """
 
 import argparse
+import json
 import sys
 import os
 
@@ -72,6 +73,153 @@ from lib.constants import (
     collect_foundry_config_findings,
 )
 from lib.prose_yaml import collect_prose_findings, format_finding_as_string
+
+
+def _read_plugin_json(path: str) -> tuple[dict | None, str | None]:
+    """Load and return (data, error_message) from a plugin/marketplace JSON file.
+
+    The tuple's error slot is populated with a human-readable message when
+    the file is unreadable or not valid JSON, so the caller can emit a
+    FAIL finding without crashing the audit.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except OSError as exc:
+        return None, f"cannot read: {exc}"
+    except json.JSONDecodeError as exc:
+        return None, f"invalid JSON: {exc.msg} (line {exc.lineno}, col {exc.colno})"
+    if not isinstance(data, dict):
+        return None, f"expected top-level object, got {type(data).__name__}"
+    return data, None
+
+
+def _skill_md_version(system_root: str) -> tuple[str | None, str | None]:
+    """Return ``(version, error)`` for ``skill-system-foundry/SKILL.md``."""
+    path = os.path.join(system_root, "skill-system-foundry", FILE_SKILL_MD)
+    if not os.path.exists(path):
+        return None, f"{path} does not exist"
+    fm, _, _ = load_frontmatter(path)
+    if fm is None:
+        return None, f"{path} has no frontmatter"
+    if "_parse_error" in fm:
+        return None, f"{path} YAML parse error: {fm['_parse_error']}"
+    metadata = fm.get("metadata")
+    if not isinstance(metadata, dict):
+        return None, f"{path} has no 'metadata' mapping"
+    value = metadata.get("version")
+    if not isinstance(value, str):
+        return None, f"{path} missing 'metadata.version' string"
+    return value, None
+
+
+def check_version_consistency(system_root: str) -> list[str]:
+    """Assert SKILL.md, plugin.json, and marketplace.json agree on version.
+
+    The rule is a pre-loop, repo-level check — it runs once before the
+    per-skill audit and is gated by the presence of
+    ``.claude-plugin/plugin.json`` so integrator skill systems (which do
+    not ship the plugin manifest) are unaffected.
+
+    Canonical source is ``skill-system-foundry/SKILL.md`` →
+    ``metadata.version``.  The rule emits one FAIL finding per file that
+    fails to expose a readable version, and a single summary FAIL when
+    the three known versions disagree.  No finding is emitted when all
+    three agree.
+    """
+    plugin_path = os.path.join(system_root, ".claude-plugin", "plugin.json")
+    if not os.path.exists(plugin_path):
+        return []
+
+    findings: list[str] = []
+
+    marketplace_path = os.path.join(
+        system_root, ".claude-plugin", "marketplace.json"
+    )
+
+    # SKILL.md
+    skill_version, skill_err = _skill_md_version(system_root)
+    if skill_err:
+        findings.append(f"{LEVEL_FAIL}: version drift — SKILL.md: {skill_err}")
+
+    # plugin.json
+    plugin_data, plugin_err = _read_plugin_json(plugin_path)
+    plugin_version: str | None = None
+    plugin_name: str | None = None
+    if plugin_err:
+        findings.append(
+            f"{LEVEL_FAIL}: version drift — plugin.json: {plugin_err}"
+        )
+    elif plugin_data is not None:
+        value = plugin_data.get("version")
+        if isinstance(value, str):
+            plugin_version = value
+        else:
+            findings.append(
+                f"{LEVEL_FAIL}: version drift — plugin.json: missing "
+                f"top-level 'version' string"
+            )
+        name_value = plugin_data.get("name")
+        if isinstance(name_value, str):
+            plugin_name = name_value
+
+    # marketplace.json
+    marketplace_version: str | None = None
+    if not os.path.exists(marketplace_path):
+        findings.append(
+            f"{LEVEL_FAIL}: version drift — marketplace.json: "
+            f"{marketplace_path} does not exist"
+        )
+    else:
+        market_data, market_err = _read_plugin_json(marketplace_path)
+        if market_err:
+            findings.append(
+                f"{LEVEL_FAIL}: version drift — marketplace.json: {market_err}"
+            )
+        elif market_data is not None:
+            plugins = market_data.get("plugins")
+            if not isinstance(plugins, list):
+                findings.append(
+                    f"{LEVEL_FAIL}: version drift — marketplace.json: "
+                    f"'plugins' is not a list"
+                )
+            elif plugin_name is None:
+                findings.append(
+                    f"{LEVEL_FAIL}: version drift — marketplace.json: "
+                    f"cannot match plugin entry because plugin.json 'name' is unavailable"
+                )
+            else:
+                matched = None
+                for entry in plugins:
+                    if isinstance(entry, dict) and entry.get("name") == plugin_name:
+                        matched = entry
+                        break
+                if matched is None:
+                    findings.append(
+                        f"{LEVEL_FAIL}: version drift — marketplace.json: "
+                        f"no plugin entry matches name '{plugin_name}'"
+                    )
+                else:
+                    value = matched.get("version")
+                    if isinstance(value, str):
+                        marketplace_version = value
+                    else:
+                        findings.append(
+                            f"{LEVEL_FAIL}: version drift — marketplace.json: "
+                            f"plugin '{plugin_name}' missing 'version' string"
+                        )
+
+    # Only compare when all three were successfully read.
+    if skill_version and plugin_version and marketplace_version:
+        if not (skill_version == plugin_version == marketplace_version):
+            findings.append(
+                f"{LEVEL_FAIL}: version drift — "
+                f"SKILL.md={skill_version}, plugin.json={plugin_version}, "
+                f"marketplace.json={marketplace_version} "
+                f"(canonical: SKILL.md)"
+            )
+
+    return findings
 
 
 def check_upward_references(content: str, component_type: str, allow_orchestration: bool = False) -> list[tuple[str, str]]:
@@ -172,6 +320,12 @@ def audit_skill_system(
     # When auditing the foundry itself, surface configuration.yaml
     # divergences detected at constants.py import.
     errors.extend(collect_foundry_config_findings(system_root))
+
+    # Repo-level rule: SKILL.md, plugin.json, and marketplace.json must
+    # declare the same version.  Silent skip when .claude-plugin/plugin.json
+    # is absent — that is how we distinguish the foundry repo root from an
+    # integrator's skill system.
+    errors.extend(check_version_consistency(system_root))
 
     skills_dir = os.path.join(system_root, DIR_SKILLS)
     has_skills_dir = os.path.isdir(skills_dir)

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -173,7 +173,12 @@ def check_version_consistency(system_root: str) -> list[str]:
             )
         name_value = plugin_data.get("name")
         if isinstance(name_value, str) and name_value.strip():
-            plugin_name = name_value
+            # Store the stripped form so the marketplace lookup matches
+            # consistently — a manifest like ``"name": "  demo  "`` would
+            # otherwise pass validation here but never match a
+            # marketplace plugin entry whose ``"name": "demo"`` is
+            # already canonical.
+            plugin_name = name_value.strip()
         else:
             # Surface the root cause at plugin.json — the marketplace
             # lookup further down would otherwise emit a misleading

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -172,16 +172,18 @@ def check_version_consistency(system_root: str) -> list[str]:
                 f"top-level 'version' string"
             )
         name_value = plugin_data.get("name")
-        if isinstance(name_value, str):
+        if isinstance(name_value, str) and name_value.strip():
             plugin_name = name_value
         else:
             # Surface the root cause at plugin.json — the marketplace
-            # lookup further down would otherwise emit a "name is
-            # unavailable" finding without pointing the operator at the
-            # file that actually needs editing.
+            # lookup further down would otherwise emit a misleading
+            # "no plugin entry matches name ''" finding without
+            # pointing the operator at the file that actually needs
+            # editing.  Whitespace-only names are treated the same as
+            # missing because they cannot match any plugin entry.
             findings.append(
                 f"{LEVEL_FAIL}: version drift — plugin.json: "
-                f"top-level 'name' is missing or not a string"
+                f"top-level 'name' is missing, empty, or not a string"
             )
 
     # marketplace.json

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -174,6 +174,15 @@ def check_version_consistency(system_root: str) -> list[str]:
         name_value = plugin_data.get("name")
         if isinstance(name_value, str):
             plugin_name = name_value
+        else:
+            # Surface the root cause at plugin.json — the marketplace
+            # lookup further down would otherwise emit a "name is
+            # unavailable" finding without pointing the operator at the
+            # file that actually needs editing.
+            findings.append(
+                f"{LEVEL_FAIL}: version drift — plugin.json: "
+                f"top-level 'name' is missing or not a string"
+            )
 
     # marketplace.json
     marketplace_version: str | None = None

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -209,8 +209,14 @@ def check_version_consistency(system_root: str) -> list[str]:
                             f"plugin '{plugin_name}' missing 'version' string"
                         )
 
-    # Only compare when all three were successfully read.
-    if skill_version and plugin_version and marketplace_version:
+    # Only compare when all three were successfully read.  Use ``is not None``
+    # so an empty-string version (e.g., ``"version": ""`` in plugin.json) is
+    # still compared and reported as drift instead of silently skipping.
+    if (
+        skill_version is not None
+        and plugin_version is not None
+        and marketplace_version is not None
+    ):
         if not (skill_version == plugin_version == marketplace_version):
             findings.append(
                 f"{LEVEL_FAIL}: version drift — "

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -117,9 +117,12 @@ def check_version_consistency(system_root: str) -> list[str]:
     """Assert SKILL.md, plugin.json, and marketplace.json agree on version.
 
     The rule is a pre-loop, repo-level check — it runs once before the
-    per-skill audit and is gated by the presence of
-    ``.claude-plugin/plugin.json`` so integrator skill systems (which do
-    not ship the plugin manifest) are unaffected.
+    per-skill audit.  It is gated on the presence of **both**
+    ``.claude-plugin/plugin.json`` *and* ``skill-system-foundry/SKILL.md``
+    under the audit root, so it only fires for the foundry distribution
+    repository itself.  Integrator skill systems that ship their own
+    Claude plugin manifest (and therefore have ``.claude-plugin/plugin.json``)
+    but lay out their canonical SKILL.md elsewhere are unaffected.
 
     Canonical source is ``skill-system-foundry/SKILL.md`` →
     ``metadata.version``.  The rule emits one FAIL finding per file that
@@ -128,7 +131,10 @@ def check_version_consistency(system_root: str) -> list[str]:
     three agree.
     """
     plugin_path = os.path.join(system_root, ".claude-plugin", "plugin.json")
-    if not os.path.exists(plugin_path):
+    foundry_skill_path = os.path.join(
+        system_root, "skill-system-foundry", FILE_SKILL_MD
+    )
+    if not (os.path.exists(plugin_path) and os.path.exists(foundry_skill_path)):
         return []
 
     findings: list[str] = []

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1765,6 +1765,32 @@ class CheckVersionConsistencyTests(unittest.TestCase):
                         f"expected plugin.json name-finding in {findings}",
                     )
 
+    def test_padded_plugin_name_matches_marketplace_after_strip(self) -> None:
+        """``plugin.json`` ``name`` with whitespace must match the canonical
+        marketplace entry after stripping.
+
+        Earlier the audit stored the raw ``name_value`` for the
+        marketplace lookup, so ``"  demo  "`` would pass the strip-truthy
+        gate but never match a marketplace plugin whose ``"name"`` is
+        ``"demo"``, producing a misleading "no plugin entry matches name
+        '  demo  '" finding.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")
+            with open(
+                os.path.join(tmp, ".claude-plugin", "plugin.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write('{\n  "name": "  demo  ",\n  "version": "1.1.0"\n}\n')
+            findings = check_version_consistency(tmp)
+            self.assertFalse(
+                any(
+                    "no plugin entry matches name" in f for f in findings
+                ),
+                f"unexpected mismatch finding in {findings}",
+            )
+
     def test_fails_when_no_matching_marketplace_plugin(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1756,6 +1756,29 @@ class CheckVersionConsistencyTests(unittest.TestCase):
             drift_errors = [e for e in errors if "version drift" in e]
             self.assertEqual(len(drift_errors), 1)
 
+    def test_unreadable_skill_md_produces_finding_not_traceback(self) -> None:
+        """A present-but-unreadable SKILL.md must surface as a finding.
+
+        ``_skill_md_version`` mirrors ``_read_plugin_json``'s contract:
+        OS-level read failures should turn into structured FAIL findings
+        rather than aborting the audit run.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")
+            from unittest import mock
+
+            with mock.patch(
+                "audit_skill_system.load_frontmatter",
+                side_effect=OSError(13, "permission denied"),
+            ):
+                findings = check_version_consistency(tmp)
+            self.assertTrue(
+                any(
+                    "SKILL.md" in f and "cannot be read" in f
+                    for f in findings
+                )
+            )
+
     def test_empty_string_version_is_treated_as_drift(self) -> None:
         """``"version": ""`` must not silently bypass the comparison.
 

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1752,6 +1752,26 @@ class CheckVersionConsistencyTests(unittest.TestCase):
             drift_errors = [e for e in errors if "version drift" in e]
             self.assertEqual(len(drift_errors), 1)
 
+    def test_empty_string_version_is_treated_as_drift(self) -> None:
+        """``"version": ""`` must not silently bypass the comparison.
+
+        Truthiness-based gating would skip the diff when any value is the
+        empty string; an explicit ``is not None`` check ensures the rule
+        still reports a mismatch between SKILL.md and the empty manifest.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="", market="1.1.0")
+            findings = check_version_consistency(tmp)
+            drift = [f for f in findings if "version drift" in f]
+            self.assertTrue(
+                any(
+                    "SKILL.md=1.1.0" in f
+                    and "plugin.json=" in f
+                    and "marketplace.json=1.1.0" in f
+                    for f in drift
+                )
+            )
+
 
 class AuditProseYamlAggregationTests(unittest.TestCase):
     """``--check-prose-yaml`` and ``--foundry-self`` on audit_skill_system."""

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -29,6 +29,7 @@ from audit_skill_system import (
     _build_parser,
     check_upward_references,
     check_role_composition,
+    check_version_consistency,
     audit_skill_system,
     main,
 )
@@ -1565,6 +1566,191 @@ class AuditFoundryConfigFindingsTests(unittest.TestCase):
             if e.startswith("FAIL: [foundry] scripts/lib/configuration.yaml")
         ]
         self.assertEqual(len(tagged), 1)
+
+
+class CheckVersionConsistencyTests(unittest.TestCase):
+    """``check_version_consistency`` compares versions across three manifests.
+
+    The rule fires only when ``.claude-plugin/plugin.json`` is present under
+    the audit root (the foundry-repo heuristic), so every test builds that
+    file.  Skipped-path behavior has its own test.
+    """
+
+    def _write(self, root: str, *, skill: str, plugin: str, market: str) -> None:
+        os.makedirs(os.path.join(root, "skill-system-foundry"), exist_ok=True)
+        os.makedirs(os.path.join(root, ".claude-plugin"), exist_ok=True)
+        with open(
+            os.path.join(root, "skill-system-foundry", "SKILL.md"),
+            "w",
+            encoding="utf-8",
+        ) as fh:
+            fh.write(
+                "---\n"
+                "name: demo\n"
+                "description: >\n"
+                "  Demo skill used for drift tests.\n"
+                "metadata:\n"
+                f"  version: {skill}\n"
+                "---\n\n# Demo\n"
+            )
+        with open(
+            os.path.join(root, ".claude-plugin", "plugin.json"),
+            "w",
+            encoding="utf-8",
+        ) as fh:
+            fh.write(
+                '{\n'
+                '  "name": "demo",\n'
+                f'  "version": "{plugin}"\n'
+                '}\n'
+            )
+        with open(
+            os.path.join(root, ".claude-plugin", "marketplace.json"),
+            "w",
+            encoding="utf-8",
+        ) as fh:
+            fh.write(
+                '{\n'
+                '  "name": "demo",\n'
+                '  "plugins": [\n'
+                '    {\n'
+                '      "name": "demo",\n'
+                f'      "version": "{market}"\n'
+                '    }\n'
+                '  ]\n'
+                '}\n'
+            )
+
+    def test_skipped_when_plugin_json_absent(self) -> None:
+        """Integrator skill systems without .claude-plugin/ are unaffected."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(check_version_consistency(tmp), [])
+
+    def test_passes_when_all_three_agree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")
+            self.assertEqual(check_version_consistency(tmp), [])
+
+    def test_fails_on_single_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="1.2.0", market="1.1.0")
+            findings = check_version_consistency(tmp)
+            self.assertEqual(len(findings), 1)
+            msg = findings[0]
+            self.assertIn(LEVEL_FAIL, msg)
+            self.assertIn("SKILL.md=1.1.0", msg)
+            self.assertIn("plugin.json=1.2.0", msg)
+            self.assertIn("marketplace.json=1.1.0", msg)
+            self.assertIn("canonical: SKILL.md", msg)
+
+    def test_fails_on_three_way_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="1.2.0", market="1.3.0")
+            findings = check_version_consistency(tmp)
+            self.assertEqual(len(findings), 1)
+            self.assertIn("SKILL.md=1.1.0", findings[0])
+            self.assertIn("plugin.json=1.2.0", findings[0])
+            self.assertIn("marketplace.json=1.3.0", findings[0])
+
+    def test_fails_when_skill_md_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, ".claude-plugin"))
+            with open(
+                os.path.join(tmp, ".claude-plugin", "plugin.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write('{"name":"demo","version":"1.1.0"}')
+            with open(
+                os.path.join(tmp, ".claude-plugin", "marketplace.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write(
+                    '{"plugins":[{"name":"demo","version":"1.1.0"}]}'
+                )
+            findings = check_version_consistency(tmp)
+            self.assertTrue(findings)
+            self.assertTrue(any("SKILL.md" in f for f in findings))
+
+    def test_fails_on_malformed_plugin_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")
+            with open(
+                os.path.join(tmp, ".claude-plugin", "plugin.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write("{ not valid json")
+            findings = check_version_consistency(tmp)
+            self.assertTrue(findings)
+            self.assertTrue(
+                any("plugin.json" in f and "invalid JSON" in f for f in findings)
+            )
+
+    def test_fails_when_plugin_version_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")
+            with open(
+                os.path.join(tmp, ".claude-plugin", "plugin.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write('{"name":"demo"}')
+            findings = check_version_consistency(tmp)
+            self.assertTrue(
+                any("missing top-level 'version'" in f for f in findings)
+            )
+
+    def test_fails_when_marketplace_json_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "skill-system-foundry"))
+            os.makedirs(os.path.join(tmp, ".claude-plugin"))
+            with open(
+                os.path.join(tmp, "skill-system-foundry", "SKILL.md"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write(
+                    "---\nname: demo\ndescription: y\nmetadata:\n"
+                    "  version: 1.1.0\n---\n"
+                )
+            with open(
+                os.path.join(tmp, ".claude-plugin", "plugin.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write('{"name":"demo","version":"1.1.0"}')
+            findings = check_version_consistency(tmp)
+            self.assertTrue(
+                any("marketplace.json" in f and "does not exist" in f
+                    for f in findings)
+            )
+
+    def test_fails_when_no_matching_marketplace_plugin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")
+            with open(
+                os.path.join(tmp, ".claude-plugin", "marketplace.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write(
+                    '{"plugins":[{"name":"other","version":"1.1.0"}]}'
+                )
+            findings = check_version_consistency(tmp)
+            self.assertTrue(
+                any("no plugin entry matches name 'demo'" in f
+                    for f in findings)
+            )
+
+    def test_audit_skill_system_surfaces_rule(self) -> None:
+        """The rule runs as part of ``audit_skill_system()`` output."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="9.9.9", market="1.1.0")
+            errors = audit_skill_system(tmp, verbose=False)
+            drift_errors = [e for e in errors if "version drift" in e]
+            self.assertEqual(len(drift_errors), 1)
 
 
 class AuditProseYamlAggregationTests(unittest.TestCase):

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1736,25 +1736,34 @@ class CheckVersionConsistencyTests(unittest.TestCase):
 
         Without an explicit plugin.json finding the operator only sees a
         downstream "marketplace.json: name is unavailable" message and
-        is left to discover that plugin.json is the file to edit.
+        is left to discover that plugin.json is the file to edit.  An
+        empty or whitespace-only name is treated the same as missing
+        because it cannot match any plugin entry in marketplace.json.
         """
-        with tempfile.TemporaryDirectory() as tmp:
-            self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")
-            with open(
-                os.path.join(tmp, ".claude-plugin", "plugin.json"),
-                "w",
-                encoding="utf-8",
-            ) as fh:
-                fh.write('{\n  "version": "1.1.0"\n}\n')
-            findings = check_version_consistency(tmp)
-            self.assertTrue(
-                any(
-                    "plugin.json" in f
-                    and "'name' is missing or not a string" in f
-                    for f in findings
-                ),
-                f"expected plugin.json name-finding in {findings}",
-            )
+        for variant_name, plugin_body in [
+            ("missing", '{\n  "version": "1.1.0"\n}\n'),
+            ("empty", '{\n  "name": "",\n  "version": "1.1.0"\n}\n'),
+            ("whitespace", '{\n  "name": "   ",\n  "version": "1.1.0"\n}\n'),
+        ]:
+            with self.subTest(variant=variant_name):
+                with tempfile.TemporaryDirectory() as tmp:
+                    self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")
+                    with open(
+                        os.path.join(tmp, ".claude-plugin", "plugin.json"),
+                        "w",
+                        encoding="utf-8",
+                    ) as fh:
+                        fh.write(plugin_body)
+                    findings = check_version_consistency(tmp)
+                    self.assertTrue(
+                        any(
+                            "plugin.json" in f
+                            and "'name' is missing, empty, or not a string"
+                            in f
+                            for f in findings
+                        ),
+                        f"expected plugin.json name-finding in {findings}",
+                    )
 
     def test_fails_when_no_matching_marketplace_plugin(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1652,7 +1652,13 @@ class CheckVersionConsistencyTests(unittest.TestCase):
             self.assertIn("plugin.json=1.2.0", findings[0])
             self.assertIn("marketplace.json=1.3.0", findings[0])
 
-    def test_fails_when_skill_md_missing(self) -> None:
+    def test_skipped_when_foundry_skill_md_missing(self) -> None:
+        """An integrator skill system with its own plugin manifest but no
+        ``skill-system-foundry/SKILL.md`` must not trigger the rule.
+
+        The gate requires both files to exist so the audit only fires for
+        the foundry distribution repository itself.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             os.makedirs(os.path.join(tmp, ".claude-plugin"))
             with open(
@@ -1669,9 +1675,7 @@ class CheckVersionConsistencyTests(unittest.TestCase):
                 fh.write(
                     '{"plugins":[{"name":"demo","version":"1.1.0"}]}'
                 )
-            findings = check_version_consistency(tmp)
-            self.assertTrue(findings)
-            self.assertTrue(any("SKILL.md" in f for f in findings))
+            self.assertEqual(check_version_consistency(tmp), [])
 
     def test_fails_on_malformed_plugin_json(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1731,6 +1731,31 @@ class CheckVersionConsistencyTests(unittest.TestCase):
                     for f in findings)
             )
 
+    def test_emits_plugin_json_finding_when_name_invalid(self) -> None:
+        """Missing/invalid plugin.json 'name' must be flagged at its source.
+
+        Without an explicit plugin.json finding the operator only sees a
+        downstream "marketplace.json: name is unavailable" message and
+        is left to discover that plugin.json is the file to edit.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")
+            with open(
+                os.path.join(tmp, ".claude-plugin", "plugin.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write('{\n  "version": "1.1.0"\n}\n')
+            findings = check_version_consistency(tmp)
+            self.assertTrue(
+                any(
+                    "plugin.json" in f
+                    and "'name' is missing or not a string" in f
+                    for f in findings
+                ),
+                f"expected plugin.json name-finding in {findings}",
+            )
+
     def test_fails_when_no_matching_marketplace_plugin(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             self._write(tmp, skill="1.1.0", plugin="1.1.0", market="1.1.0")

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -541,6 +541,35 @@ class ArgparseExitTests(unittest.TestCase):
         self.assertEqual(rc, bump_version.EXIT_OK)
 
 
+class TempFileSafetyTests(unittest.TestCase):
+    """``commit_writes`` must not clobber pre-existing sibling files."""
+
+    def test_pre_existing_dot_tmp_is_preserved(self) -> None:
+        """A maintainer's adjacent ``.tmp`` artifact must survive a bump.
+
+        Earlier versions of ``commit_writes`` staged through a
+        deterministic ``<target>.tmp`` path, which would truncate any
+        pre-existing file at that name and then remove it during
+        cleanup.  Use ``tempfile.mkstemp`` for unique sibling names.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            # Plant a file at the deterministic name an earlier version
+            # would have used; it must still exist with its original
+            # content after the bump.
+            sentinel = os.path.join(
+                repo, ".claude-plugin", "plugin.json.tmp"
+            )
+            with open(sentinel, "w", encoding="utf-8") as fh:
+                fh.write("MAINTAINER ARTIFACT — DO NOT TOUCH")
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, _ = _invoke(["1.2.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_OK)
+            self.assertTrue(os.path.exists(sentinel))
+            with open(sentinel, encoding="utf-8") as fh:
+                self.assertEqual(fh.read(), "MAINTAINER ARTIFACT — DO NOT TOUCH")
+
+
 class HeadShaTests(unittest.TestCase):
     def test_returns_none_outside_git(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -479,6 +479,46 @@ class PartialWriteTests(unittest.TestCase):
 # ===================================================================
 
 
+class MalformedManifestTests(unittest.TestCase):
+    """Malformed manifests must surface as EXIT_DRIFT, not as tracebacks."""
+
+    def test_invalid_plugin_json_returns_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            with open(
+                os.path.join(repo, ".claude-plugin", "plugin.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write("{not valid json")
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(["1.2.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_DRIFT)
+            self.assertIn("plugin.json", err)
+            self.assertIn("cannot read manifest", err)
+
+    def test_missing_marketplace_json_returns_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            os.remove(os.path.join(repo, ".claude-plugin", "marketplace.json"))
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(["1.2.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_DRIFT)
+            self.assertIn("marketplace.json", err)
+
+
+class ArgparseExitTests(unittest.TestCase):
+    """``main()`` must return an int even when argparse exits."""
+
+    def test_missing_required_arg_returns_invalid_input(self) -> None:
+        rc, _, _ = _invoke([], cwd=os.getcwd())
+        self.assertEqual(rc, bump_version.EXIT_INVALID_INPUT)
+
+    def test_help_flag_returns_ok(self) -> None:
+        rc, _, _ = _invoke(["--help"], cwd=os.getcwd())
+        self.assertEqual(rc, bump_version.EXIT_OK)
+
+
 class HeadShaTests(unittest.TestCase):
     def test_returns_none_outside_git(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -426,6 +426,37 @@ class PlanFailureTests(unittest.TestCase):
 
 
 # ===================================================================
+# Partial write (phase 2 failure introduces drift; caller must report)
+# ===================================================================
+
+
+class PartialWriteTests(unittest.TestCase):
+    def test_phase2_failure_reports_swapped_and_remaining(self) -> None:
+        """When ``os.replace`` fails partway, the operator sees which files drifted."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+
+            real_replace = os.replace
+            call_count = {"n": 0}
+
+            def fail_on_second(src: str, dst: str) -> None:
+                call_count["n"] += 1
+                if call_count["n"] == 2:
+                    raise OSError(13, "simulated phase-2 failure")
+                real_replace(src, dst)
+
+            with mock.patch.object(bump_version.os, "replace", side_effect=fail_on_second):
+                rc, _, err = _invoke(
+                    ["1.2.0"], cwd=repo, generator_stub_path=gen
+                )
+            self.assertEqual(rc, bump_version.EXIT_PLAN_FAILED)
+            self.assertIn("partial write", err)
+            self.assertIn("swapped to 1.2.0", err)
+            self.assertIn("still at  1.1.0", err)
+
+
+# ===================================================================
 # Helper units (head_sha returns None outside git)
 # ===================================================================
 

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -619,6 +619,29 @@ class TempFileSafetyTests(unittest.TestCase):
                 self.assertEqual(fh.read(), "MAINTAINER ARTIFACT — DO NOT TOUCH")
 
 
+class PermissionPreservationTests(unittest.TestCase):
+    """``commit_writes`` must restore the target's mode on the staged file.
+
+    ``tempfile.mkstemp`` creates files with mode ``0o600``; without an
+    explicit ``chmod`` step a successful bump would silently downgrade
+    the manifests to owner-only.  Skipped on Windows where POSIX mode
+    bits do not survive the round trip.
+    """
+
+    @unittest.skipIf(os.name == "nt", "POSIX mode bits not meaningful on Windows")
+    def test_target_mode_is_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            plugin_path = os.path.join(repo, ".claude-plugin", "plugin.json")
+            os.chmod(plugin_path, 0o644)
+            before_mode = os.stat(plugin_path).st_mode & 0o777
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, _ = _invoke(["1.2.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_OK)
+            after_mode = os.stat(plugin_path).st_mode & 0o777
+            self.assertEqual(after_mode, before_mode)
+
+
 class HeadShaTests(unittest.TestCase):
     def test_returns_none_outside_git(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -506,6 +506,28 @@ class MalformedManifestTests(unittest.TestCase):
             self.assertEqual(rc, bump_version.EXIT_DRIFT)
             self.assertIn("marketplace.json", err)
 
+    def test_missing_plugin_name_surfaces_as_precondition(self) -> None:
+        """An empty/missing plugin name must surface as plugin.json error.
+
+        Previously the marketplace read was silently skipped when
+        ``plugin_name`` was falsy, which then surfaced as a misleading
+        "could not read marketplace.json" finding.  The real precondition
+        failure is the missing name in plugin.json.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            with open(
+                os.path.join(repo, ".claude-plugin", "plugin.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write('{\n  "version": "1.1.0"\n}\n')
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(["1.2.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_DRIFT)
+            self.assertIn("plugin.json", err)
+            self.assertIn("missing or empty 'name'", err)
+
 
 class ArgparseExitTests(unittest.TestCase):
     """``main()`` must return an int even when argparse exits."""

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -450,10 +450,28 @@ class PartialWriteTests(unittest.TestCase):
                 rc, _, err = _invoke(
                     ["1.2.0"], cwd=repo, generator_stub_path=gen
                 )
-            self.assertEqual(rc, bump_version.EXIT_PLAN_FAILED)
+            self.assertEqual(rc, bump_version.EXIT_PARTIAL_WRITE)
             self.assertIn("partial write", err)
             self.assertIn("swapped to 1.2.0", err)
             self.assertIn("still at  1.1.0", err)
+
+    def test_first_write_failure_is_not_partial(self) -> None:
+        """A failure before any swap is a plain write failure — no drift."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+
+            def fail_every_call(src: str, dst: str) -> None:
+                raise OSError(13, "simulated phase-2 failure")
+
+            with mock.patch.object(bump_version.os, "replace", side_effect=fail_every_call):
+                rc, _, err = _invoke(
+                    ["1.2.0"], cwd=repo, generator_stub_path=gen
+                )
+            self.assertEqual(rc, bump_version.EXIT_PLAN_FAILED)
+            self.assertIn("write failed", err)
+            self.assertNotIn("partial write", err)
+            self.assertNotIn("drift is now present", err)
 
 
 # ===================================================================

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -7,13 +7,16 @@ the subprocess path is exercised without pulling in git history or the
 real generator.
 """
 
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from collections.abc import Iterator
 from unittest import mock
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -154,15 +157,12 @@ class _CapturedIO:
         self.stdout = ""
         self.stderr = ""
 
-    def capture(self):
-        import contextlib
-        import io
-
+    def capture(self) -> contextlib.AbstractContextManager[None]:
         out, err = io.StringIO(), io.StringIO()
         owner = self
 
         @contextlib.contextmanager
-        def _ctx():
+        def _ctx() -> Iterator[None]:
             with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
                 yield
             owner.stdout = out.getvalue()

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -183,7 +183,10 @@ class InputValidationTests(unittest.TestCase):
             gen = os.path.join(repo, "scripts", "generate_changelog.py")
             rc, _, err = _invoke(["v1.2.0"], cwd=repo, generator_stub_path=gen)
             self.assertEqual(rc, bump_version.EXIT_INVALID_INPUT)
-            self.assertIn("must be X.Y.Z", err)
+            # The targeted v/+build check runs first so the operator
+            # sees the specific mistake rather than the generic shape
+            # error.
+            self.assertIn("'v' prefix", err)
 
     def test_rejects_build_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -193,7 +196,7 @@ class InputValidationTests(unittest.TestCase):
                 ["1.2.0+build"], cwd=repo, generator_stub_path=gen
             )
             self.assertEqual(rc, bump_version.EXIT_INVALID_INPUT)
-            self.assertIn("must be X.Y.Z", err)
+            self.assertIn("'+build'", err)
 
     def test_rejects_unparseable(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,0 +1,446 @@
+"""Tests for scripts/bump_version.py.
+
+Most tests operate on a scratch directory that mirrors the three manifest
+files the bump script touches.  A fake ``generate_changelog.py`` stub is
+installed at ``scripts/generate_changelog.py`` within the scratch repo so
+the subprocess path is exercised without pulling in git history or the
+real generator.
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+_BUMP_PATH = os.path.join(REPO_ROOT, "scripts", "bump_version.py")
+_spec = importlib.util.spec_from_file_location(
+    "repo_infra_bump_version", _BUMP_PATH
+)
+assert _spec is not None and _spec.loader is not None
+bump_version = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bump_version)
+
+
+SKILL_MD = """\
+---
+name: demo
+description: >
+  Demo skill.
+metadata:
+  author: Test
+  version: {version}
+  spec: agentskills.io
+---
+
+# Demo
+"""
+
+PLUGIN_JSON = """\
+{{
+  "name": "demo",
+  "description": "Demo plugin.",
+  "version": "{version}"
+}}
+"""
+
+MARKETPLACE_JSON = """\
+{{
+  "name": "demo",
+  "plugins": [
+    {{
+      "name": "demo",
+      "description": "Demo plugin.",
+      "version": "{version}"
+    }}
+  ]
+}}
+"""
+
+
+# A generator stub that always succeeds.  Prints the arguments on stdout so
+# tests can confirm the invocation shape.
+GENERATOR_STUB_OK = """\
+#!/usr/bin/env python3
+import sys
+print("generator ok:", " ".join(sys.argv[1:]))
+sys.exit(0)
+"""
+
+# A stub that simulates the real generator's exit-3 path (unmapped commits).
+GENERATOR_STUB_FAIL = """\
+#!/usr/bin/env python3
+import sys
+print("unmapped — review manually: deadbeef Stub failure", file=sys.stderr)
+sys.exit(3)
+"""
+
+
+def _build_fake_repo(
+    tmp: str,
+    *,
+    skill: str = "1.1.0",
+    plugin: str = "1.1.0",
+    market: str = "1.1.0",
+    with_changelog: bool = True,
+    generator_stub: str | None = GENERATOR_STUB_OK,
+) -> str:
+    """Plant a minimal repo layout under *tmp* and return the repo root."""
+    os.makedirs(os.path.join(tmp, ".git"))  # Minimum marker for find_repo_root.
+    os.makedirs(os.path.join(tmp, "skill-system-foundry"))
+    os.makedirs(os.path.join(tmp, ".claude-plugin"))
+    os.makedirs(os.path.join(tmp, "scripts"))
+    with open(
+        os.path.join(tmp, "skill-system-foundry", "SKILL.md"),
+        "w",
+        encoding="utf-8",
+    ) as fh:
+        fh.write(SKILL_MD.format(version=skill))
+    with open(
+        os.path.join(tmp, ".claude-plugin", "plugin.json"),
+        "w",
+        encoding="utf-8",
+    ) as fh:
+        fh.write(PLUGIN_JSON.format(version=plugin))
+    with open(
+        os.path.join(tmp, ".claude-plugin", "marketplace.json"),
+        "w",
+        encoding="utf-8",
+    ) as fh:
+        fh.write(MARKETPLACE_JSON.format(version=market))
+    if with_changelog:
+        with open(
+            os.path.join(tmp, "CHANGELOG.md"), "w", encoding="utf-8"
+        ) as fh:
+            fh.write("# Changelog\n\n## [1.1.0] - 2026-04-01\n\n- seed\n")
+    if generator_stub is not None:
+        stub_path = os.path.join(tmp, "scripts", "generate_changelog.py")
+        with open(stub_path, "w", encoding="utf-8") as fh:
+            fh.write(generator_stub)
+    return tmp
+
+
+def _invoke(
+    argv: list[str], *, cwd: str, generator_stub_path: str | None = None
+) -> tuple[int, str, str]:
+    """Invoke ``main(argv)`` with ``os.getcwd`` patched and optional generator override."""
+    patches = [mock.patch("os.getcwd", return_value=cwd)]
+    if generator_stub_path is not None:
+        patches.append(
+            mock.patch.object(
+                bump_version, "GENERATOR_SCRIPT", generator_stub_path
+            )
+        )
+    out = _CapturedIO()
+    with out.capture():
+        with patches[0]:
+            if len(patches) > 1:
+                with patches[1]:
+                    rc = bump_version.main(argv)
+            else:
+                rc = bump_version.main(argv)
+    return rc, out.stdout, out.stderr
+
+
+class _CapturedIO:
+    """Capture stdout+stderr around a block of code."""
+
+    def __init__(self) -> None:
+        self.stdout = ""
+        self.stderr = ""
+
+    def capture(self):
+        import contextlib
+        import io
+
+        out, err = io.StringIO(), io.StringIO()
+        owner = self
+
+        @contextlib.contextmanager
+        def _ctx():
+            with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+                yield
+            owner.stdout = out.getvalue()
+            owner.stderr = err.getvalue()
+
+        return _ctx()
+
+
+# ===================================================================
+# Semver and CLI input validation
+# ===================================================================
+
+
+class InputValidationTests(unittest.TestCase):
+    def test_rejects_v_prefix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(["v1.2.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_INVALID_INPUT)
+            self.assertIn("must be X.Y.Z", err)
+
+    def test_rejects_build_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(
+                ["1.2.0+build"], cwd=repo, generator_stub_path=gen
+            )
+            self.assertEqual(rc, bump_version.EXIT_INVALID_INPUT)
+            self.assertIn("must be X.Y.Z", err)
+
+    def test_rejects_unparseable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, _ = _invoke(["garbage"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_INVALID_INPUT)
+
+
+class RepoDetectionTests(unittest.TestCase):
+    def test_outside_git_repo_exits_invalid_input(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            rc, _, err = _invoke(["1.2.0"], cwd=tmp)
+            self.assertEqual(rc, bump_version.EXIT_INVALID_INPUT)
+            self.assertIn("not inside a git repository", err)
+
+    def test_worktree_style_git_file_is_accepted(self) -> None:
+        """A ``.git`` file (as used by git worktrees) is treated as a repo root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            # Build the normal layout but replace .git/ with a .git file.
+            repo = _build_fake_repo(tmp)
+            os.rmdir(os.path.join(repo, ".git"))
+            with open(os.path.join(repo, ".git"), "w", encoding="utf-8") as fh:
+                fh.write("gitdir: /tmp/fake\n")
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, out, _ = _invoke(
+                ["1.2.0", "--dry-run"], cwd=repo, generator_stub_path=gen
+            )
+            self.assertEqual(rc, bump_version.EXIT_OK)
+            self.assertIn("Planned bump: 1.1.0 → 1.2.0", out)
+
+
+# ===================================================================
+# Precondition / drift
+# ===================================================================
+
+
+class DriftPreconditionTests(unittest.TestCase):
+    def test_rejects_when_files_already_disagree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp, skill="1.1.0", plugin="1.2.0")
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(["1.3.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_DRIFT)
+            self.assertIn("version drift detected", err)
+
+    def test_rejects_when_skill_md_version_unreadable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            # Corrupt SKILL.md frontmatter.
+            with open(
+                os.path.join(repo, "skill-system-foundry", "SKILL.md"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write("no frontmatter here\n")
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(["1.2.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_DRIFT)
+            self.assertIn("could not read current version", err)
+
+
+# ===================================================================
+# Equal / downgrade guard
+# ===================================================================
+
+
+class EqualAndDowngradeTests(unittest.TestCase):
+    def test_equal_version_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(["1.1.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_INVALID_INPUT)
+            self.assertIn("equals the current version", err)
+
+    def test_downgrade_rejected_without_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(["1.0.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_INVALID_INPUT)
+            self.assertIn("lower than the current version", err)
+
+    def test_downgrade_allowed_with_flag(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, out, _ = _invoke(
+                ["1.0.0", "--allow-downgrade", "--dry-run"],
+                cwd=repo,
+                generator_stub_path=gen,
+            )
+            self.assertEqual(rc, bump_version.EXIT_OK)
+            self.assertIn("Planned bump: 1.1.0 → 1.0.0", out)
+
+
+# ===================================================================
+# Happy paths (dry-run and real write)
+# ===================================================================
+
+
+class DryRunTests(unittest.TestCase):
+    def test_dry_run_writes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, out, _ = _invoke(
+                ["1.2.0", "--dry-run"], cwd=repo, generator_stub_path=gen
+            )
+            self.assertEqual(rc, bump_version.EXIT_OK)
+            # Files are untouched.
+            with open(
+                os.path.join(repo, "skill-system-foundry", "SKILL.md"),
+                encoding="utf-8",
+            ) as fh:
+                self.assertIn("version: 1.1.0", fh.read())
+            with open(
+                os.path.join(repo, ".claude-plugin", "plugin.json"),
+                encoding="utf-8",
+            ) as fh:
+                self.assertIn('"version": "1.1.0"', fh.read())
+            # Output names the planned edits.
+            self.assertIn("would update skill-system-foundry/SKILL.md", out)
+            self.assertIn("would update .claude-plugin/plugin.json", out)
+            self.assertIn("would update .claude-plugin/marketplace.json", out)
+
+    def test_dry_run_without_changelog_notes_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp, with_changelog=False)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, out, _ = _invoke(
+                ["1.2.0", "--dry-run"], cwd=repo, generator_stub_path=gen
+            )
+            self.assertEqual(rc, bump_version.EXIT_OK)
+            self.assertIn("CHANGELOG.md absent", out)
+
+
+class HappyPathWriteTests(unittest.TestCase):
+    def test_writes_all_three_files_and_invokes_generator(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, out, _ = _invoke(
+                ["1.2.0"], cwd=repo, generator_stub_path=gen
+            )
+            self.assertEqual(rc, bump_version.EXIT_OK)
+            with open(
+                os.path.join(repo, "skill-system-foundry", "SKILL.md"),
+                encoding="utf-8",
+            ) as fh:
+                self.assertIn("version: 1.2.0", fh.read())
+            with open(
+                os.path.join(repo, ".claude-plugin", "plugin.json"),
+                encoding="utf-8",
+            ) as fh:
+                plugin = json.load(fh)
+            self.assertEqual(plugin["version"], "1.2.0")
+            with open(
+                os.path.join(repo, ".claude-plugin", "marketplace.json"),
+                encoding="utf-8",
+            ) as fh:
+                market = json.load(fh)
+            self.assertEqual(market["plugins"][0]["version"], "1.2.0")
+            self.assertIn("Bumped version: 1.1.0 → 1.2.0", out)
+
+    def test_skips_generator_when_changelog_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp, with_changelog=False)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, out, _ = _invoke(["1.2.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_OK)
+            self.assertNotIn("updated CHANGELOG.md", out)
+
+
+# ===================================================================
+# Changelog probe failure
+# ===================================================================
+
+
+class ChangelogProbeFailureTests(unittest.TestCase):
+    def test_probe_failure_aborts_before_writes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp, generator_stub=GENERATOR_STUB_FAIL)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(
+                ["1.2.0"], cwd=repo, generator_stub_path=gen
+            )
+            self.assertEqual(rc, bump_version.EXIT_CHANGELOG_FAILED)
+            self.assertIn("changelog probe failed", err)
+            # Files are untouched.
+            with open(
+                os.path.join(repo, "skill-system-foundry", "SKILL.md"),
+                encoding="utf-8",
+            ) as fh:
+                self.assertIn("version: 1.1.0", fh.read())
+
+
+# ===================================================================
+# Plan failure (anchored regex matched != 1 time)
+# ===================================================================
+
+
+class PlanFailureTests(unittest.TestCase):
+    def test_duplicate_version_line_fails_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            # Inject a second matching line inside plugin.json via a nested
+            # object so the anchored regex matches twice.
+            with open(
+                os.path.join(repo, ".claude-plugin", "plugin.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write(
+                    '{\n'
+                    '  "name": "demo",\n'
+                    '  "version": "1.1.0",\n'
+                    '  "sidecar": {\n'
+                    '    "version": "1.1.0"\n'
+                    '  }\n'
+                    '}\n'
+                )
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(
+                ["1.2.0"], cwd=repo, generator_stub_path=gen
+            )
+            self.assertEqual(rc, bump_version.EXIT_PLAN_FAILED)
+            self.assertIn("plan failed", err)
+
+
+# ===================================================================
+# Helper units (head_sha returns None outside git)
+# ===================================================================
+
+
+class HeadShaTests(unittest.TestCase):
+    def test_returns_none_outside_git(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(bump_version.head_sha(tmp))
+
+    def test_returns_none_when_git_missing(self) -> None:
+        with mock.patch(
+            "subprocess.run", side_effect=FileNotFoundError()
+        ):
+            self.assertIsNone(bump_version.head_sha("/anywhere"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -529,7 +529,26 @@ class MalformedManifestTests(unittest.TestCase):
             rc, _, err = _invoke(["1.2.0"], cwd=repo, generator_stub_path=gen)
             self.assertEqual(rc, bump_version.EXIT_DRIFT)
             self.assertIn("plugin.json", err)
-            self.assertIn("missing or empty 'name'", err)
+            self.assertIn(
+                "missing, empty, or whitespace-only 'name'", err
+            )
+
+    def test_whitespace_only_plugin_name_is_rejected(self) -> None:
+        """Whitespace-only ``name`` must be treated as missing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            with open(
+                os.path.join(repo, ".claude-plugin", "plugin.json"),
+                "w",
+                encoding="utf-8",
+            ) as fh:
+                fh.write('{\n  "name": "   ",\n  "version": "1.1.0"\n}\n')
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, err = _invoke(["1.2.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_DRIFT)
+            self.assertIn(
+                "missing, empty, or whitespace-only 'name'", err
+            )
 
 
 class ArgparseExitTests(unittest.TestCase):
@@ -542,6 +561,33 @@ class ArgparseExitTests(unittest.TestCase):
     def test_help_flag_returns_ok(self) -> None:
         rc, _, _ = _invoke(["--help"], cwd=os.getcwd())
         self.assertEqual(rc, bump_version.EXIT_OK)
+
+
+class NewlineHandlingTests(unittest.TestCase):
+    """``commit_writes`` pins LF newlines on disk for cross-platform reproducibility."""
+
+    def test_writes_lf_newlines_regardless_of_platform_default(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = _build_fake_repo(tmp)
+            gen = os.path.join(repo, "scripts", "generate_changelog.py")
+            rc, _, _ = _invoke(["1.2.0"], cwd=repo, generator_stub_path=gen)
+            self.assertEqual(rc, bump_version.EXIT_OK)
+            # Open in binary so we see the on-disk bytes verbatim.
+            for rel in (
+                "skill-system-foundry/SKILL.md",
+                ".claude-plugin/plugin.json",
+                ".claude-plugin/marketplace.json",
+            ):
+                with self.subTest(file=rel):
+                    with open(
+                        os.path.join(repo, *rel.split("/")), "rb"
+                    ) as fh:
+                        raw = fh.read()
+                    self.assertNotIn(
+                        b"\r\n",
+                        raw,
+                        f"expected LF-only on disk for {rel}",
+                    )
 
 
 class TempFileSafetyTests(unittest.TestCase):

--- a/tests/test_version_lib.py
+++ b/tests/test_version_lib.py
@@ -305,6 +305,15 @@ class PlanPluginJsonEditTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             version.plan_plugin_json_edit(content, "1.1.0", "1.2.0")
 
+    def test_rejects_compact_json_with_pretty_format_hint(self) -> None:
+        # A compact one-line JSON document is valid JSON but the planner
+        # cannot anchor on it — surface the formatting contract in the
+        # error message so the operator knows how to recover.
+        content = '{"name":"demo","version":"1.1.0"}\n'
+        with self.assertRaises(ValueError) as ctx:
+            version.plan_plugin_json_edit(content, "1.1.0", "1.2.0")
+        self.assertIn("pretty-printed", str(ctx.exception))
+
 
 class PlanMarketplaceJsonEditTests(unittest.TestCase):
     def test_replaces_nested_version(self) -> None:

--- a/tests/test_version_lib.py
+++ b/tests/test_version_lib.py
@@ -1,0 +1,295 @@
+"""Tests for scripts/lib/version.py.
+
+The helpers are pure functions with no I/O except the ``read_*`` group,
+so most tests operate on in-memory strings.  File-backed tests use
+``tempfile`` to stay hermetic across Linux and Windows runners.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "scripts")
+)
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib import version  # noqa: E402
+
+
+SAMPLE_SKILL_MD = """\
+---
+name: example
+description: >
+  A test skill.
+metadata:
+  author: Someone
+  version: 1.1.0
+  spec: agentskills.io
+---
+
+# Example
+
+Body mentions version: 9.9.9 which must NOT be rewritten.
+
+```yaml
+metadata:
+  version: 7.7.7
+```
+"""
+
+SAMPLE_PLUGIN_JSON = """\
+{
+  "name": "example",
+  "description": "A plugin.",
+  "keywords": [
+    "version-tag-in-keyword"
+  ],
+  "version": "1.1.0"
+}
+"""
+
+SAMPLE_MARKETPLACE_JSON = """\
+{
+  "name": "example",
+  "owner": {"name": "Someone"},
+  "plugins": [
+    {
+      "name": "example",
+      "description": "A plugin.",
+      "version": "1.1.0",
+      "tags": ["version-tag-in-tag"]
+    }
+  ]
+}
+"""
+
+
+# ===================================================================
+# Semver regex
+# ===================================================================
+
+
+class SemverRegexTests(unittest.TestCase):
+    def test_accepts_basic_semver(self) -> None:
+        for value in ("0.0.0", "1.2.3", "10.20.30", "1.0.0-rc.1", "2.0.0-alpha-2"):
+            with self.subTest(value=value):
+                self.assertTrue(version.SEMVER_RE.match(value))
+
+    def test_rejects_v_prefix_and_build_metadata(self) -> None:
+        for value in ("v1.2.3", "1.2.3+build", "1.2.3-rc.1+42", ""):
+            with self.subTest(value=value):
+                self.assertIsNone(version.SEMVER_RE.match(value))
+
+    def test_rejects_non_numeric_core(self) -> None:
+        for value in ("1.2", "1.2.3.4", "one.two.three", "1.2.3-"):
+            with self.subTest(value=value):
+                self.assertIsNone(version.SEMVER_RE.match(value))
+
+
+# ===================================================================
+# parse / compare
+# ===================================================================
+
+
+class ParseTests(unittest.TestCase):
+    def test_splits_core_and_prerelease(self) -> None:
+        self.assertEqual(version.parse("1.2.3"), (1, 2, 3, ""))
+        self.assertEqual(version.parse("1.2.3-rc.1"), (1, 2, 3, "rc.1"))
+
+    def test_rejects_invalid(self) -> None:
+        with self.assertRaises(ValueError):
+            version.parse("v1.2.3")
+        with self.assertRaises(ValueError):
+            version.parse("")
+
+
+class CompareTests(unittest.TestCase):
+    def test_core_ordering(self) -> None:
+        self.assertEqual(version.compare("1.0.0", "1.0.1"), -1)
+        self.assertEqual(version.compare("2.0.0", "1.9.9"), 1)
+        self.assertEqual(version.compare("1.0.0", "1.0.0"), 0)
+
+    def test_prerelease_rules(self) -> None:
+        # A version with a prerelease is less than the same version without.
+        self.assertEqual(version.compare("1.0.0-rc.1", "1.0.0"), -1)
+        self.assertEqual(version.compare("1.0.0", "1.0.0-rc.1"), 1)
+        # Lexicographic fallback between two prereleases.
+        self.assertEqual(version.compare("1.0.0-alpha", "1.0.0-beta"), -1)
+        self.assertEqual(version.compare("1.0.0-rc.2", "1.0.0-rc.1"), 1)
+        self.assertEqual(version.compare("1.0.0-rc.1", "1.0.0-rc.1"), 0)
+
+
+# ===================================================================
+# read_* helpers
+# ===================================================================
+
+
+class ReadSkillMdVersionTests(unittest.TestCase):
+    def test_reads_metadata_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "SKILL.md")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(SAMPLE_SKILL_MD)
+            self.assertEqual(version.read_skill_md_version(path), "1.1.0")
+
+    def test_returns_none_when_no_frontmatter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "SKILL.md")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("# Title only\n")
+            self.assertIsNone(version.read_skill_md_version(path))
+
+    def test_returns_none_when_metadata_missing_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "SKILL.md")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("---\nname: x\nmetadata:\n  author: A\n---\n")
+            self.assertIsNone(version.read_skill_md_version(path))
+
+
+class ReadPluginJsonVersionTests(unittest.TestCase):
+    def test_reads_top_level_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "plugin.json")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(SAMPLE_PLUGIN_JSON)
+            self.assertEqual(version.read_plugin_json_version(path), "1.1.0")
+
+    def test_returns_none_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "plugin.json")
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump({"name": "x"}, fh)
+            self.assertIsNone(version.read_plugin_json_version(path))
+
+    def test_returns_none_when_non_string(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "plugin.json")
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump({"version": 1}, fh)
+            self.assertIsNone(version.read_plugin_json_version(path))
+
+
+class ReadMarketplaceJsonVersionTests(unittest.TestCase):
+    def test_matches_plugin_by_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "marketplace.json")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(SAMPLE_MARKETPLACE_JSON)
+            self.assertEqual(
+                version.read_marketplace_json_version(path, "example"),
+                "1.1.0",
+            )
+
+    def test_returns_none_when_name_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "marketplace.json")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(SAMPLE_MARKETPLACE_JSON)
+            self.assertIsNone(
+                version.read_marketplace_json_version(path, "other")
+            )
+
+    def test_returns_none_when_plugins_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "marketplace.json")
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump({"name": "x"}, fh)
+            self.assertIsNone(
+                version.read_marketplace_json_version(path, "example")
+            )
+
+
+# ===================================================================
+# plan_* helpers
+# ===================================================================
+
+
+class PlanSkillMdEditTests(unittest.TestCase):
+    def test_replaces_frontmatter_version_only(self) -> None:
+        out = version.plan_skill_md_edit(SAMPLE_SKILL_MD, "1.1.0", "1.2.0")
+        self.assertIn("  version: 1.2.0", out)
+        # The body mention and the fenced-code example must stay intact.
+        self.assertIn("Body mentions version: 9.9.9", out)
+        self.assertIn("  version: 7.7.7", out)
+
+    def test_rejects_missing_current(self) -> None:
+        with self.assertRaises(ValueError):
+            version.plan_skill_md_edit(SAMPLE_SKILL_MD, "9.9.9", "1.2.0")
+
+    def test_rejects_missing_frontmatter(self) -> None:
+        with self.assertRaises(ValueError):
+            version.plan_skill_md_edit(
+                "# no frontmatter\n", "1.0.0", "1.1.0"
+            )
+
+    def test_rejects_unterminated_frontmatter(self) -> None:
+        with self.assertRaises(ValueError):
+            version.plan_skill_md_edit(
+                "---\nname: x\nmetadata:\n  version: 1.0.0\n", "1.0.0", "1.1.0"
+            )
+
+
+class PlanPluginJsonEditTests(unittest.TestCase):
+    def test_replaces_version(self) -> None:
+        out = version.plan_plugin_json_edit(SAMPLE_PLUGIN_JSON, "1.1.0", "1.2.0")
+        self.assertIn('"version": "1.2.0"', out)
+        # Keyword content containing the substring "version" must not change.
+        self.assertIn("version-tag-in-keyword", out)
+
+    def test_rejects_missing_current(self) -> None:
+        with self.assertRaises(ValueError):
+            version.plan_plugin_json_edit(SAMPLE_PLUGIN_JSON, "9.9.9", "1.2.0")
+
+    def test_rejects_multiple_version_lines(self) -> None:
+        # Two structurally valid top-level version lines would be a plan failure.
+        content = (
+            '{\n  "version": "1.1.0",\n  "sidecar": {\n    "version": "1.1.0"\n  }\n}\n'
+        )
+        with self.assertRaises(ValueError):
+            version.plan_plugin_json_edit(content, "1.1.0", "1.2.0")
+
+
+class PlanMarketplaceJsonEditTests(unittest.TestCase):
+    def test_replaces_nested_version(self) -> None:
+        out = version.plan_marketplace_json_edit(
+            SAMPLE_MARKETPLACE_JSON, "1.1.0", "1.2.0"
+        )
+        self.assertIn('"version": "1.2.0"', out)
+        self.assertIn("version-tag-in-tag", out)
+
+    def test_rejects_missing_current(self) -> None:
+        with self.assertRaises(ValueError):
+            version.plan_marketplace_json_edit(
+                SAMPLE_MARKETPLACE_JSON, "9.9.9", "1.2.0"
+            )
+
+
+# ===================================================================
+# path helpers
+# ===================================================================
+
+
+class PathHelperTests(unittest.TestCase):
+    def test_paths_are_joined_correctly(self) -> None:
+        root = os.path.join("a", "b")
+        self.assertEqual(
+            version.skill_md_path(root),
+            os.path.join(root, "skill-system-foundry", "SKILL.md"),
+        )
+        self.assertEqual(
+            version.plugin_json_path(root),
+            os.path.join(root, ".claude-plugin", "plugin.json"),
+        )
+        self.assertEqual(
+            version.marketplace_json_path(root),
+            os.path.join(root, ".claude-plugin", "marketplace.json"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version_lib.py
+++ b/tests/test_version_lib.py
@@ -109,6 +109,14 @@ class SemverRegexTests(unittest.TestCase):
         self.assertIsNone(version.SEMVER_RE.match("1.2.3-rc.01"))
         self.assertTrue(version.SEMVER_RE.match("1.2.3-rc.10"))
 
+    def test_rejects_trailing_newline(self) -> None:
+        # Python's ``$`` matches before a final ``\n``; the ``\Z``
+        # anchor rejects ``"1.2.3\n"`` so trailing newlines fail the
+        # CLI's stable invalid-input contract instead of leaking into
+        # the planner.
+        self.assertIsNone(version.SEMVER_RE.match("1.2.3\n"))
+        self.assertIsNone(version.SEMVER_RE.match("1.2.3-rc.1\n"))
+
 
 # ===================================================================
 # parse / compare

--- a/tests/test_version_lib.py
+++ b/tests/test_version_lib.py
@@ -181,6 +181,15 @@ class ReadSkillMdVersionTests(unittest.TestCase):
                 fh.write("# Title only\n")
             self.assertIsNone(version.read_skill_md_version(path))
 
+    def test_returns_none_for_malformed_opening_delimiter(self) -> None:
+        # ``---oops\n`` must not be treated as an opener — the line-wise
+        # check rejects anything other than ``---`` on the first line.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "SKILL.md")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("---oops\nmetadata:\n  version: 1.0.0\n---\n")
+            self.assertIsNone(version.read_skill_md_version(path))
+
     def test_returns_none_when_metadata_missing_version(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "SKILL.md")
@@ -271,6 +280,15 @@ class PlanSkillMdEditTests(unittest.TestCase):
                 "---\nname: x\nmetadata:\n  version: 1.0.0\n", "1.0.0", "1.1.0"
             )
 
+    def test_rejects_malformed_opening_delimiter(self) -> None:
+        # ``---oops`` on the first line must not pass for a frontmatter
+        # opener; the line-wise opener check rejects it instead of
+        # treating the body as YAML.
+        bad = "---oops\nmetadata:\n  version: 1.0.0\n---\n"
+        with self.assertRaises(ValueError) as ctx:
+            version.plan_skill_md_edit(bad, "1.0.0", "1.1.0")
+        self.assertIn("missing opening", str(ctx.exception))
+
     def test_plans_quoted_version_and_preserves_quote_style(self) -> None:
         # ``read_skill_md_version`` strips matched surrounding quotes, so a
         # quoted manifest must round-trip through the planner — preserving
@@ -314,11 +332,35 @@ class PlanPluginJsonEditTests(unittest.TestCase):
             version.plan_plugin_json_edit(content, "1.1.0", "1.2.0")
         self.assertIn("pretty-printed", str(ctx.exception))
 
+    def test_refuses_when_top_level_version_is_compact(self) -> None:
+        # Top-level version is compact (and therefore not edited by the
+        # text regex), but a nested object has a pretty-printed
+        # ``"version"`` line at the same value.  The text regex would
+        # silently update the wrong field; the structural post-check
+        # must raise instead.
+        content = (
+            '{"version":"1.1.0",\n'
+            '  "sidecar": {\n'
+            '    "version": "1.1.0"\n'
+            '  }\n'
+            '}\n'
+        )
+        with self.assertRaises(ValueError) as ctx:
+            version.plan_plugin_json_edit(content, "1.1.0", "1.2.0")
+        msg = str(ctx.exception)
+        # The first failure may be the text regex (1 match → success path)
+        # caught by the post-check, OR the post-check itself.  Either
+        # way the canonical top-level version is left unchanged.
+        self.assertTrue(
+            "top-level" in msg or "pretty-printed" in msg,
+            f"unexpected error message: {msg}",
+        )
+
 
 class PlanMarketplaceJsonEditTests(unittest.TestCase):
     def test_replaces_nested_version(self) -> None:
         out = version.plan_marketplace_json_edit(
-            SAMPLE_MARKETPLACE_JSON, "1.1.0", "1.2.0"
+            SAMPLE_MARKETPLACE_JSON, "1.1.0", "1.2.0", "example"
         )
         self.assertIn('"version": "1.2.0"', out)
         self.assertIn("version-tag-in-tag", out)
@@ -326,8 +368,33 @@ class PlanMarketplaceJsonEditTests(unittest.TestCase):
     def test_rejects_missing_current(self) -> None:
         with self.assertRaises(ValueError):
             version.plan_marketplace_json_edit(
-                SAMPLE_MARKETPLACE_JSON, "9.9.9", "1.2.0"
+                SAMPLE_MARKETPLACE_JSON, "9.9.9", "1.2.0", "example"
             )
+
+    def test_refuses_when_named_plugin_not_updated(self) -> None:
+        # If the regex matches a "version" line in the wrong plugin (e.g.,
+        # because the named plugin's version is in a non-supported
+        # format), the post-sub structural check must fail rather than
+        # silently corrupting the file.
+        content = (
+            '{\n'
+            '  "plugins": [\n'
+            '    {\n'
+            '      "name": "example",\n'
+            '      "version": "1.1.0"\n'
+            '    },\n'
+            '    {\n'
+            '      "name": "other",\n'
+            '      "version": "1.1.0"\n'
+            '    }\n'
+            '  ]\n'
+            '}\n'
+        )
+        # Two matching lines exist → planner already rejects via
+        # "found 2" ValueError.  Verify the message.
+        with self.assertRaises(ValueError) as ctx:
+            version.plan_marketplace_json_edit(content, "1.1.0", "1.2.0", "example")
+        self.assertIn("found 2", str(ctx.exception))
 
 
 # ===================================================================

--- a/tests/test_version_lib.py
+++ b/tests/test_version_lib.py
@@ -5,19 +5,23 @@ so most tests operate on in-memory strings.  File-backed tests use
 ``tempfile`` to stay hermetic across Linux and Windows runners.
 """
 
+import importlib.util
 import json
 import os
-import sys
 import tempfile
 import unittest
 
-SCRIPTS_DIR = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "..", "scripts")
+# Load the module by explicit path so the import does not collide with the
+# meta-skill's ``lib`` package (which other tests pull onto sys.path first).
+_VERSION_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "scripts", "lib", "version.py")
 )
-if SCRIPTS_DIR not in sys.path:
-    sys.path.insert(0, SCRIPTS_DIR)
-
-from lib import version  # noqa: E402
+_spec = importlib.util.spec_from_file_location(
+    "repo_infra_version", _VERSION_PATH
+)
+assert _spec is not None and _spec.loader is not None
+version = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(version)
 
 
 SAMPLE_SKILL_MD = """\

--- a/tests/test_version_lib.py
+++ b/tests/test_version_lib.py
@@ -93,6 +93,22 @@ class SemverRegexTests(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertIsNone(version.SEMVER_RE.match(value))
 
+    def test_rejects_leading_zero_in_core(self) -> None:
+        for value in ("01.2.3", "1.02.3", "1.2.03"):
+            with self.subTest(value=value):
+                self.assertIsNone(version.SEMVER_RE.match(value))
+
+    def test_rejects_empty_or_trailing_prerelease_identifiers(self) -> None:
+        for value in ("1.2.3-alpha.", "1.2.3-.alpha", "1.2.3-alpha..1"):
+            with self.subTest(value=value):
+                self.assertIsNone(version.SEMVER_RE.match(value))
+
+    def test_rejects_leading_zero_in_numeric_prerelease(self) -> None:
+        # Per SemVer §9, numeric prerelease identifiers must not include
+        # leading zeros.  ``rc.01`` is invalid; ``rc.10`` is valid.
+        self.assertIsNone(version.SEMVER_RE.match("1.2.3-rc.01"))
+        self.assertTrue(version.SEMVER_RE.match("1.2.3-rc.10"))
+
 
 # ===================================================================
 # parse / compare
@@ -121,10 +137,28 @@ class CompareTests(unittest.TestCase):
         # A version with a prerelease is less than the same version without.
         self.assertEqual(version.compare("1.0.0-rc.1", "1.0.0"), -1)
         self.assertEqual(version.compare("1.0.0", "1.0.0-rc.1"), 1)
-        # Lexicographic fallback between two prereleases.
+        # Alphanumeric identifiers compare lexically.
         self.assertEqual(version.compare("1.0.0-alpha", "1.0.0-beta"), -1)
         self.assertEqual(version.compare("1.0.0-rc.2", "1.0.0-rc.1"), 1)
         self.assertEqual(version.compare("1.0.0-rc.1", "1.0.0-rc.1"), 0)
+
+    def test_prerelease_numeric_identifiers_compare_numerically(self) -> None:
+        # Lex order would put ``rc.10`` below ``rc.2``; SemVer §11 ranks
+        # numeric identifiers numerically.
+        self.assertEqual(version.compare("1.0.0-rc.10", "1.0.0-rc.2"), 1)
+        self.assertEqual(version.compare("1.0.0-rc.2", "1.0.0-rc.10"), -1)
+
+    def test_prerelease_numeric_below_alphanumeric(self) -> None:
+        # SemVer §11.4.3: numeric identifiers always have lower precedence
+        # than alphanumeric identifiers.
+        self.assertEqual(version.compare("1.0.0-1", "1.0.0-alpha"), -1)
+        self.assertEqual(version.compare("1.0.0-alpha", "1.0.0-1"), 1)
+
+    def test_prerelease_shorter_identifier_set_is_lower(self) -> None:
+        # SemVer §11.4.4: a smaller set of identifiers (with all preceding
+        # equal) has lower precedence than a larger set.
+        self.assertEqual(version.compare("1.0.0-alpha", "1.0.0-alpha.1"), -1)
+        self.assertEqual(version.compare("1.0.0-alpha.1", "1.0.0-alpha"), 1)
 
 
 # ===================================================================
@@ -236,6 +270,20 @@ class PlanSkillMdEditTests(unittest.TestCase):
             version.plan_skill_md_edit(
                 "---\nname: x\nmetadata:\n  version: 1.0.0\n", "1.0.0", "1.1.0"
             )
+
+    def test_plans_quoted_version_and_preserves_quote_style(self) -> None:
+        # ``read_skill_md_version`` strips matched surrounding quotes, so a
+        # quoted manifest must round-trip through the planner — preserving
+        # the exact quote character the file used.
+        for quote in ('"', "'"):
+            content = (
+                "---\nname: x\nmetadata:\n  "
+                f"version: {quote}1.0.0{quote}\n---\n"
+            )
+            with self.subTest(quote=quote):
+                out = version.plan_skill_md_edit(content, "1.0.0", "1.1.0")
+                self.assertIn(f"version: {quote}1.1.0{quote}", out)
+                self.assertNotIn(f"version: {quote}1.0.0{quote}", out)
 
 
 class PlanPluginJsonEditTests(unittest.TestCase):

--- a/tests/test_version_lib.py
+++ b/tests/test_version_lib.py
@@ -379,11 +379,11 @@ class PlanMarketplaceJsonEditTests(unittest.TestCase):
                 SAMPLE_MARKETPLACE_JSON, "9.9.9", "1.2.0", "example"
             )
 
-    def test_refuses_when_named_plugin_not_updated(self) -> None:
-        # If the regex matches a "version" line in the wrong plugin (e.g.,
-        # because the named plugin's version is in a non-supported
-        # format), the post-sub structural check must fail rather than
-        # silently corrupting the file.
+    def test_updates_named_plugin_when_others_share_version(self) -> None:
+        # A marketplace with two plugin entries at the same current
+        # version must still be editable — the planner scopes to the
+        # named entry by trying each candidate substitution and
+        # accepting the unique one that lands on the target plugin.
         content = (
             '{\n'
             '  "plugins": [\n'
@@ -398,11 +398,31 @@ class PlanMarketplaceJsonEditTests(unittest.TestCase):
             '  ]\n'
             '}\n'
         )
-        # Two matching lines exist → planner already rejects via
-        # "found 2" ValueError.  Verify the message.
+        out = version.plan_marketplace_json_edit(
+            content, "1.1.0", "1.2.0", "example"
+        )
+        parsed = json.loads(out)
+        # The named plugin moves to 1.2.0; the other stays at 1.1.0.
+        plugins_by_name = {p["name"]: p["version"] for p in parsed["plugins"]}
+        self.assertEqual(plugins_by_name["example"], "1.2.0")
+        self.assertEqual(plugins_by_name["other"], "1.1.0")
+
+    def test_refuses_when_named_plugin_absent(self) -> None:
+        content = (
+            '{\n'
+            '  "plugins": [\n'
+            '    {\n'
+            '      "name": "other",\n'
+            '      "version": "1.1.0"\n'
+            '    }\n'
+            '  ]\n'
+            '}\n'
+        )
         with self.assertRaises(ValueError) as ctx:
-            version.plan_marketplace_json_edit(content, "1.1.0", "1.2.0", "example")
-        self.assertIn("found 2", str(ctx.exception))
+            version.plan_marketplace_json_edit(
+                content, "1.1.0", "1.2.0", "example"
+            )
+        self.assertIn("found 0", str(ctx.exception))
 
 
 # ===================================================================

--- a/tests/test_version_lib.py
+++ b/tests/test_version_lib.py
@@ -117,6 +117,14 @@ class SemverRegexTests(unittest.TestCase):
         self.assertIsNone(version.SEMVER_RE.match("1.2.3\n"))
         self.assertIsNone(version.SEMVER_RE.match("1.2.3-rc.1\n"))
 
+    def test_rejects_non_ascii_digits(self) -> None:
+        # ``\d`` is Unicode-aware in Python; ``[0-9]`` keeps the
+        # grammar ASCII-only as SemVer requires.  Arabic-Indic digit
+        # ``٢`` (U+0662) and Bengali ``২`` (U+09E8) must not satisfy
+        # core or prerelease numeric identifiers.
+        self.assertIsNone(version.SEMVER_RE.match("1.2.٣"))  # core
+        self.assertIsNone(version.SEMVER_RE.match("1.2.3-rc.٢"))  # prerelease
+
 
 # ===================================================================
 # parse / compare
@@ -197,6 +205,47 @@ class ReadSkillMdVersionTests(unittest.TestCase):
             with open(path, "w", encoding="utf-8") as fh:
                 fh.write("---oops\nmetadata:\n  version: 1.0.0\n---\n")
             self.assertIsNone(version.read_skill_md_version(path))
+
+    def test_does_not_pick_up_nested_version_under_metadata(self) -> None:
+        """A nested ``metadata.compatibility.version`` must not be returned.
+
+        Once the scan enters ``metadata:``, an indent-only check would
+        accept any deeper ``version:`` line as the canonical value.  The
+        reader anchors on the first child indent and rejects deeper
+        keys so the bump primitive cannot mistake a compatibility hint
+        for the canonical release version.
+        """
+        body = (
+            "---\n"
+            "name: x\n"
+            "metadata:\n"
+            "  compatibility:\n"
+            "    version: 9.9.9\n"
+            "  author: Someone\n"
+            "---\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "SKILL.md")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(body)
+            self.assertIsNone(version.read_skill_md_version(path))
+
+    def test_returns_direct_version_alongside_nested_block(self) -> None:
+        """Direct ``metadata.version`` is returned even with deeper siblings."""
+        body = (
+            "---\n"
+            "name: x\n"
+            "metadata:\n"
+            "  compatibility:\n"
+            "    version: 9.9.9\n"
+            "  version: 1.1.0\n"
+            "---\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "SKILL.md")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(body)
+            self.assertEqual(version.read_skill_md_version(path), "1.1.0")
 
     def test_returns_none_when_metadata_missing_version(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -296,6 +345,40 @@ class PlanSkillMdEditTests(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             version.plan_skill_md_edit(bad, "1.0.0", "1.1.0")
         self.assertIn("missing opening", str(ctx.exception))
+
+    def test_does_not_edit_nested_version_under_metadata(self) -> None:
+        """The planner edits the direct ``metadata.version`` only.
+
+        With a deeper ``compatibility.version`` matching the same
+        current value, the planner must edit only the canonical line
+        — the nested key stays at its original value.
+        """
+        body = (
+            "---\n"
+            "name: x\n"
+            "metadata:\n"
+            "  compatibility:\n"
+            "    version: 1.0.0\n"
+            "  version: 1.0.0\n"
+            "---\n"
+        )
+        out = version.plan_skill_md_edit(body, "1.0.0", "1.1.0")
+        # The direct child moved to 1.1.0; the deeper sibling stays.
+        self.assertIn("  version: 1.1.0", out)
+        self.assertIn("    version: 1.0.0", out)
+
+    def test_rejects_when_no_direct_version_child(self) -> None:
+        """No direct ``metadata.version`` is a planner error, not a mis-edit."""
+        body = (
+            "---\n"
+            "metadata:\n"
+            "  compatibility:\n"
+            "    version: 1.0.0\n"
+            "---\n"
+        )
+        with self.assertRaises(ValueError) as ctx:
+            version.plan_skill_md_edit(body, "1.0.0", "1.1.0")
+        self.assertIn("direct 'metadata.version'", str(ctx.exception))
 
     def test_plans_quoted_version_and_preserves_quote_style(self) -> None:
         # ``read_skill_md_version`` strips matched surrounding quotes, so a


### PR DESCRIPTION
## Summary
- Add `audit_skill_system.py` rule that fails when `skill-system-foundry/SKILL.md`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` disagree on version (gated on `.claude-plugin/plugin.json` so integrator skill systems are unaffected).
- Add `scripts/bump_version.py` — stdlib-only entry point that reads the current version from all three files, rejects bad semver / equal / unflagged downgrades, probes the changelog generator in `--dry-run`, writes each manifest via `os.replace`, and reports partial-write drift through a dedicated `EXIT_PARTIAL_WRITE=6` with a per-file "swapped / still at" breakdown.
- Add `scripts/lib/version.py` — stdlib semver, readers, and anchored plan-edit helpers, intentionally independent from the meta-skill tree at `skill-system-foundry/scripts/`.
- Document the new primitive and the audit-invocation gap in `AGENTS.md` (the canonical `cd skill-system-foundry; audit .` invocation silently skips the repo-level rule by design).

## Design notes
- **Duplication over bridging** — `scripts/lib/version.py` does not import from `skill-system-foundry/scripts/lib/`; the regex shape mirrors `RE_METADATA_VERSION` and is kept in lockstep by hand. Matches the repo's isolation rule for top-level scripts.
- **Exit codes are stable** so a release-prep CI workflow can branch on outcome without parsing prose. `5` = plan regex mismatch or first-swap failure (no drift); `6` = partial write (drift present on disk).
- **Canonical source is `SKILL.md`** — the FAIL message names it explicitly so the operator knows which value to propagate.

## Test plan
- [x] 1741 tests pass (`python -m coverage run -m unittest discover -s tests -p "test_*.py"`)
- [x] Branch coverage ≥ 70% on every file (91% on `scripts/bump_version.py`, 91% on `scripts/lib/version.py`, 91% on `skill-system-foundry/scripts/audit_skill_system.py`)
- [x] `shellcheck .github/scripts/*.sh` clean
- [x] `python scripts/validate_skill.py . --allow-nested-references --foundry-self --check-prose-yaml` — 17/17 pass
- [x] `python skill-system-foundry/scripts/audit_skill_system.py .` from repo root — 0 failures (validates the new rule against current state)
- [x] Simulated phase-2 `os.replace` failure reports partial-write drift with `EXIT_PARTIAL_WRITE` (`PartialWriteTests.test_phase2_failure_reports_swapped_and_remaining`)
- [x] Simulated phase-2 first-call failure reports plain write failure with `EXIT_PLAN_FAILED` — no drift (`test_first_write_failure_is_not_partial`)

## Not covered by this PR
- No CI job wired to `bump_version.py` yet — it's a primitive; the release workflow can adopt it in a follow-up.
- The `scripts/lib/version.py` semver regex and `RE_METADATA_VERSION` in `configuration.yaml` are kept in lockstep by hand per the isolation rule; a drift between them won't be caught automatically.