### PR TITLE
Add release-prep dispatch workflow

### DIFF
--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -40,7 +40,7 @@ This is the single source of truth for the current version. Git tags mirror it a
 The `Release prep` workflow (`.github/workflows/release-prep.yml`) is the primary release-prep path. Trigger it from the GitHub Actions UI (or `gh workflow run release-prep.yml -f version=X.Y.Z`):
 
 1. Dispatch the workflow with the target version (`X.Y.Z`, no leading `v`, no prerelease).
-2. The workflow creates `release/v<X.Y.Z>`, runs `bump_version.py` (manifest lockstep), prepends a generated section to `CHANGELOG.md`, runs `validate_skill.py` and `audit_skill_system.py` (the latter from repo root, which fires the version-drift rule), runs the full test matrix via the reusable `python-tests.yaml`, and opens a PR titled `Release v<X.Y.Z>`.
+2. The workflow creates `release/v<X.Y.Z>`, runs the `bump_version.py` helper (manifest lockstep), prepends a generated section to `CHANGELOG.md`, runs `validate_skill.py` and `audit_skill_system.py` (the latter from repo root, which fires the version-drift rule), runs the full test matrix via the reusable `python-tests.yaml`, and opens a PR titled `Release v<X.Y.Z>`.
 3. Review the PR. The PR body lists any manual follow-ups (notably: edit `.agents/skills/git-release/SKILL.md` prose if any examples reference an outdated release).
 4. Re-trigger CI on the PR by closing and reopening it (GitHub does not fire PR workflows for PRs opened by `GITHUB_TOKEN`).
 5. Merge the PR to `main`.
@@ -93,7 +93,7 @@ All validation checks must pass (zero failures). Coverage must meet the 70% thre
 
 ### Step 2: Bump the Version
 
-Use `scripts/bump_version.py` to update all three manifest files (SKILL.md, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`) in lockstep:
+Use the `bump_version.py` helper (under the repo's top-level `./scripts/`) to update all three manifest files (SKILL.md, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`) in lockstep:
 
 ```bash
 python scripts/bump_version.py 1.1.0 --dry-run   # preview
@@ -104,7 +104,7 @@ The `audit_skill_system.py` version-drift rule will fail if these three files di
 
 ### Step 2.5: Prepend the Changelog Section
 
-Use `scripts/generate_changelog.py` to add a new release section to `CHANGELOG.md`. See the "Release Process" section of `CLAUDE.md` for the full preview-then-write checklist; the short form is:
+Use the `generate_changelog.py` helper (also under the repo's top-level `./scripts/`) to add a new release section to `CHANGELOG.md`. See the "Release Process" section of `CLAUDE.md` for the full preview-then-write checklist; the short form is:
 
 ```bash
 PREV=$(git describe --tags --abbrev=0)
@@ -112,7 +112,7 @@ python scripts/generate_changelog.py --since "$PREV" --version 1.1.0 \
   --until "$(git rev-parse HEAD)" --date "$(date -u +%Y-%m-%d)" --in-place
 ```
 
-Reclassify any commits the generator reports on stderr as `unmapped — review manually` (either by adding their first-word verb to `scripts/lib/changelog.yaml` or by rewording the commit subject) before re-running.
+Reclassify any commits the generator reports on stderr as `unmapped — review manually` (either by adding their first-word verb to the generator's `changelog.yaml` config or by rewording the commit subject) before re-running.
 
 ### Step 3: Commit and Push
 

--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -35,7 +35,28 @@ This is the single source of truth for the current version. Git tags mirror it a
 - **MINOR** (1.0.2 → 1.1.0) — new features: new validation checks, new scripts, new reference documents, new template types, new bundling targets
 - **MAJOR** (1.0.2 → 2.0.0) — breaking changes: configuration.yaml schema changes that break existing setups, removed validation checks, renamed scripts, changed CLI arguments
 
-## Release Checklist
+## Dispatch-Driven Prep (Preferred)
+
+The `Release prep` workflow (`.github/workflows/release-prep.yml`) is the primary release-prep path. Trigger it from the GitHub Actions UI (or `gh workflow run release-prep.yml -f version=X.Y.Z`):
+
+1. Dispatch the workflow with the target version (`X.Y.Z`, no leading `v`, no prerelease).
+2. The workflow creates `release/v<X.Y.Z>`, runs `bump_version.py` (manifest lockstep), prepends a generated section to `CHANGELOG.md`, runs `validate_skill.py` and `audit_skill_system.py` (the latter from repo root, which fires the version-drift rule), runs the full test matrix via the reusable `python-tests.yaml`, and opens a PR titled `Release v<X.Y.Z>`.
+3. Review the PR. The PR body lists any manual follow-ups (notably: edit `.agents/skills/git-release/SKILL.md` prose if any examples reference an outdated release).
+4. Re-trigger CI on the PR by closing and reopening it (GitHub does not fire PR workflows for PRs opened by `GITHUB_TOKEN`).
+5. Merge the PR to `main`.
+6. Tag and publish:
+   ```bash
+   gh release create v<X.Y.Z> --generate-notes
+   ```
+   The post-merge `release.yml` workflow bundles the zip, computes the SHA256 checksum, and uploads both as release assets.
+
+The workflow exposes a `dry_run` input that runs validation, bump, changelog generation, validate, and audit but skips the push and the PR — useful to verify a target version's gates before committing to a real prep.
+
+## Manual Release Checklist (Fallback)
+
+Use this path when the dispatch workflow is unavailable (for example, when running offline against a pre-tag commit, or when retrospectively regenerating a past release).
+
+### Step 1: Verify Pre-Release State
 
 ### Step 1: Verify Pre-Release State
 
@@ -72,26 +93,36 @@ All validation checks must pass (zero failures). Coverage must meet the 70% thre
 
 ### Step 2: Bump the Version
 
-Update `metadata.version` in `skill-system-foundry/SKILL.md`:
+Use `scripts/bump_version.py` to update all three manifest files (SKILL.md, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`) in lockstep:
 
-```yaml
-metadata:
-  author: Milan Horvatovič
-  version: 1.1.0       # ← update this
-  spec: agentskills.io
+```bash
+python scripts/bump_version.py 1.1.0 --dry-run   # preview
+python scripts/bump_version.py 1.1.0             # write
 ```
 
-This is the only file where the version lives. There is no `pyproject.toml`, `setup.py`, or `package.json` to synchronize.
+The `audit_skill_system.py` version-drift rule will fail if these three files disagree, so editing only `SKILL.md` is no longer sufficient.
+
+### Step 2.5: Prepend the Changelog Section
+
+Use `scripts/generate_changelog.py` to add a new release section to `CHANGELOG.md`. See the "Release Process" section of `CLAUDE.md` for the full preview-then-write checklist; the short form is:
+
+```bash
+PREV=$(git describe --tags --abbrev=0)
+python scripts/generate_changelog.py --since "$PREV" --version 1.1.0 \
+  --until "$(git rev-parse HEAD)" --date "$(date -u +%Y-%m-%d)" --in-place
+```
+
+Reclassify any commits the generator reports on stderr as `unmapped — review manually` (either by adding their first-word verb to `scripts/lib/changelog.yaml` or by rewording the commit subject) before re-running.
 
 ### Step 3: Commit and Push
 
 ```bash
-git add skill-system-foundry/SKILL.md
-git commit -m "Update version to 1.1.0"
+git add skill-system-foundry/SKILL.md .claude-plugin/plugin.json .claude-plugin/marketplace.json CHANGELOG.md
+git commit -m "Release v1.1.0"
 git push origin main
 ```
 
-Use the commit message format: `Update version to X.Y.Z`.
+Use the commit message format `Release vX.Y.Z` so the changelog generator filters the bump commit out of future regenerations (the generator skips subjects matching `^Release v\d+\.\d+\.\d+`).
 
 ### Step 4: Create the GitHub Release
 
@@ -161,10 +192,11 @@ The full CI pipeline for a release involves multiple workflows:
 
 | Workflow | Trigger | What It Does |
 |---|---|---|
-| `python-tests.yaml` | Push to `main`, PRs | Tests + coverage + badge update |
+| `python-tests.yaml` | Push to `main`, PRs, `workflow_call` | Tests + coverage + badge update; reusable from `release-prep.yml` |
 | `shellcheck.yaml` | Changes to `.github/scripts/*.sh` | Lints shell scripts |
 | `codex-code-review.yaml` | PRs (non-draft) | AI-assisted code review |
-| `release.yml` | Release published | Bundles zip + uploads asset |
+| `release-prep.yml` | `workflow_dispatch` | Bumps version, prepends changelog, opens release PR |
+| `release.yml` | Release published | Bundles zip + uploads asset (zip + SHA256) |
 
 The coverage badge updates automatically on pushes to `main` via the `update-badge` job. It writes `coverage.json` to an orphan `badges` branch, which shields.io reads.
 
@@ -193,10 +225,10 @@ The bundle script applies stricter validation than the release workflow — it c
 
 ## Common Mistakes
 
-- Forgetting to bump `metadata.version` in SKILL.md before tagging
-- Version in SKILL.md not matching the git tag (e.g., `1.1.0` vs `v1.1.0`)
-- Tagging before pushing the version bump commit to `main`
-- Creating a release from a branch other than `main`
-- Not running validation before release — a broken SKILL.md ships in the zip
-- Writing release notes that reference internal details instead of user-facing changes
-- Forgetting to verify the zip asset downloads and validates after the workflow runs
+- Editing only `SKILL.md` and missing `.claude-plugin/plugin.json` or `.claude-plugin/marketplace.json` — the version-drift audit rule will fail. Use `bump_version.py` (or the dispatch workflow) to keep the three files in lockstep.
+- Version in the manifests not matching the git tag (e.g., `1.1.0` vs `v1.1.0`).
+- Tagging before pushing the bump commit to `main`.
+- Creating a release from a branch other than `main`.
+- Skipping validation — a broken SKILL.md ships in the zip.
+- Forgetting to verify the zip asset downloads and validates after `release.yml` runs.
+- Using a commit subject other than `Release vX.Y.Z` for the bump — the changelog generator skip filter only matches that exact shape.

--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -58,8 +58,6 @@ Use this path when the dispatch workflow is unavailable (for example, when runni
 
 ### Step 1: Verify Pre-Release State
 
-### Step 1: Verify Pre-Release State
-
 Confirm the release gate is green on `main` for the commit being tagged **before** publishing the release. `release.yml` triggers on `release: published` and does not run tests; `python-tests.yaml` on `main` is the only workflow that gates a release — `shellcheck.yaml` and `codex-code-review.yaml` are advisory and can be red at release time. Check the gate via the GitHub Actions UI or:
 
 ```bash

--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -20,17 +20,18 @@ Guides the full release lifecycle for the Skill System Foundry — from version 
 
 The repository uses **semver** (MAJOR.MINOR.PATCH) tracked across three manifest files that must agree:
 
-- `skill-system-foundry/SKILL.md` — `metadata.version` in the frontmatter (the canonical declaration; the other two manifests are bumped to match):
-
-  ```yaml
-  metadata:
-    author: Milan Horvatovič
-    version: 1.0.2
-    spec: agentskills.io
-  ```
-
+- `skill-system-foundry/SKILL.md` — `metadata.version` in the frontmatter (the canonical declaration; the other two manifests are bumped to match)
 - `.claude-plugin/plugin.json` — `version` field
 - `.claude-plugin/marketplace.json` — `version` field for this skill's entry
+
+The canonical `SKILL.md` declaration looks like:
+
+```yaml
+metadata:
+  author: Milan Horvatovič
+  version: 1.0.2
+  spec: agentskills.io
+```
 
 The `audit_skill_system.py` version-drift rule (run from the repo root) fails the audit when these three files disagree, so editing only `SKILL.md` is no longer sufficient. Always bump them in lockstep via `scripts/bump_version.py` (or the dispatch workflow, which calls it). Git tags mirror the version as `v1.0.2`.
 

--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -18,16 +18,21 @@ Guides the full release lifecycle for the Skill System Foundry — from version 
 
 ## Version Convention
 
-The repository uses **semver** (MAJOR.MINOR.PATCH) tracked in the `metadata.version` field of `skill-system-foundry/SKILL.md` frontmatter:
+The repository uses **semver** (MAJOR.MINOR.PATCH) tracked across three manifest files that must agree:
 
-```yaml
-metadata:
-  author: Milan Horvatovič
-  version: 1.0.2
-  spec: agentskills.io
-```
+- `skill-system-foundry/SKILL.md` — `metadata.version` in the frontmatter (the canonical declaration; the other two manifests are bumped to match):
 
-This is the single source of truth for the current version. Git tags mirror it as `v1.0.2`.
+  ```yaml
+  metadata:
+    author: Milan Horvatovič
+    version: 1.0.2
+    spec: agentskills.io
+  ```
+
+- `.claude-plugin/plugin.json` — `version` field
+- `.claude-plugin/marketplace.json` — `version` field for this skill's entry
+
+The `audit_skill_system.py` version-drift rule (run from the repo root) fails the audit when these three files disagree, so editing only `SKILL.md` is no longer sufficient. Always bump them in lockstep via `scripts/bump_version.py` (or the dispatch workflow, which calls it). Git tags mirror the version as `v1.0.2`.
 
 ### When to Bump
 

--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -105,10 +105,12 @@ The `audit_skill_system.py` version-drift rule will fail if these three files di
 Use the `generate_changelog.py` helper (also under the repo's top-level `./scripts/`) to add a new release section to `CHANGELOG.md`. See the "Release Process" section of `CLAUDE.md` for the full preview-then-write checklist; the short form is:
 
 ```bash
-PREV=$(git describe --tags --abbrev=0)
+PREV=$(git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*')
 python scripts/generate_changelog.py --since "$PREV" --version 1.1.0 \
   --until "$(git rev-parse HEAD)" --date "$(date -u +%Y-%m-%d)" --in-place
 ```
+
+The `--match` glob filters `git describe` to release-shaped tags so a stray non-release tag (debug, hotfix experiment) cannot widen or narrow the changelog range — the dispatch workflow uses the same glob for the same reason.
 
 Reclassify any commits the generator reports on stderr as `unmapped — review manually` (either by adding their first-word verb to the generator's `changelog.yaml` config or by rewording the commit subject) before re-running.
 
@@ -120,7 +122,7 @@ git commit -m "Release v1.1.0"
 git push origin main
 ```
 
-Use the commit message format `Release vX.Y.Z` so the changelog generator filters the bump commit out of future regenerations (the generator skips subjects matching `^Release v\d+\.\d+\.\d+`).
+Use the commit message format `Release vX.Y.Z` so the changelog generator filters the bump commit out of future regenerations. The full subject is matched against `_RELEASE_COMMIT_RE` in `scripts/generate_changelog.py`, which mirrors the strict SemVer grammar the generator already enforces on `--version` (no leading zeros, optional dot-separated prerelease suffix; build metadata is intentionally unsupported). Off-grammar subjects like `Release v1.2.0 (RC)` or `Release v1.2.3-..1` are deliberately not skipped — they route to `unmapped — review manually` so the operator either fixes the subject or reclassifies it deliberately.
 
 ### Step 4: Create the GitHub Release
 

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -10,7 +10,8 @@ on:
       ref:
         description: >-
           Git ref (branch, tag, or commit SHA) to check out for testing.
-          When empty, actions/checkout uses the event's default ref.
+          When empty (or unset, as on push/pull_request), checkout falls
+          back to ``github.sha`` so the triggering commit is tested.
           Used by release-prep.yml to test the bumped release branch
           before opening the release PR.
         required: false
@@ -33,7 +34,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
         with:
-          ref: ${{ inputs.ref }}
+          # ``inputs.ref`` is only populated by ``workflow_call``; on
+          # push/pull_request runs it evaluates to empty.  Passing an
+          # empty ``ref:`` to actions/checkout falls back to the
+          # repository's default branch instead of the triggering
+          # commit, which on a PR would test ``main`` instead of the
+          # PR head.  Fall back to ``github.sha`` so push/PR runs
+          # check out the triggering revision and ``workflow_call``
+          # callers (release-prep.yml) still get the ref they passed.
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v5 as 5.6.0

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -5,6 +5,17 @@ on:
   push:
     branches:
       - main
+  workflow_call:
+    inputs:
+      ref:
+        description: >-
+          Git ref (branch, tag, or commit SHA) to check out for testing.
+          When empty, actions/checkout uses the event's default ref.
+          Used by release-prep.yml to test the bumped release branch
+          before opening the release PR.
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -21,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v5 as 5.6.0
@@ -83,7 +96,11 @@ jobs:
 
   update-badge:
     needs: test
-    if: github.ref == 'refs/heads/main'
+    # Restrict to genuine pushes to main; this skips reusable
+    # workflow_call invocations (e.g. release-prep.yml) where
+    # github.event_name is the caller's event (workflow_dispatch) and
+    # the badge must not be updated from a release branch's coverage.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -163,9 +163,14 @@ jobs:
 
       - name: Validate skill (foundry self)
         working-directory: skill-system-foundry
-        run: python scripts/validate_skill.py . --allow-nested-references --foundry-self --verbose
+        run: python scripts/validate_skill.py . --allow-nested-references --foundry-self
 
       - name: Audit skill system (repo root, includes version-drift rule)
+        # One warning about a missing 'skills/' directory is expected
+        # in this distribution repository (per CLAUDE.md, distribution-
+        # repo mode).  The audit script exits 0 on warnings and
+        # non-zero only on LEVEL_FAIL findings, so the warning does
+        # not fail the step.
         run: python skill-system-foundry/scripts/audit_skill_system.py .
 
       - name: Commit release bump

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -28,9 +28,13 @@ on:
         type: boolean
         default: false
 
+# Default the workflow-wide token to read-only so steps that only
+# clone, install dependencies, and run scripts cannot accidentally
+# push or open a PR.  The two jobs that actually need write scopes
+# elevate explicitly via job-level ``permissions`` (``prepare`` writes
+# the release branch, ``open-pr`` opens the release PR).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 # Workflow-wide concurrency: a release-prep PR should land before
 # another is opened.  cancel-in-progress: false so a queued dispatch
@@ -42,15 +46,24 @@ concurrency:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    # Needs write to push the release branch; the rest of the steps
+    # (checkout, dependency install, bump, changelog, validate, audit,
+    # commit) only read.  Granted at the job level so the workflow-wide
+    # default stays read-only.
+    permissions:
+      contents: write
     outputs:
       branch: ${{ steps.config.outputs.branch }}
     steps:
       - name: Validate version input
         env:
           VERSION: ${{ inputs.version }}
+        # Mirror ``bump_version.py``'s strict SemVer core grammar so a
+        # leading-zero version (``01.2.3``) is rejected at the dispatch
+        # gate rather than after checkout/setup.
         run: |
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::version input must match ^[0-9]+\\.[0-9]+\\.[0-9]+$ (X.Y.Z, no leading v, no prerelease); got '$VERSION'"
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::version input must match ^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$ (X.Y.Z, no leading zeros, no leading v, no prerelease); got '$VERSION'"
             exit 1
           fi
           echo "Version: $VERSION"
@@ -207,6 +220,12 @@ jobs:
     needs: [prepare, test]
     if: ${{ ! inputs.dry_run }}
     runs-on: ubuntu-latest
+    # Needs ``pull-requests: write`` for ``gh pr create`` and
+    # ``contents: read`` for the checkout.  Granted at the job level so
+    # the workflow-wide default stays read-only.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -1,0 +1,239 @@
+name: Release prep
+
+# Dispatch-driven release preparation: bumps the version across the
+# three manifest files in lockstep, prepends a generated changelog
+# section, runs validation/audit/tests, and opens a release PR.  See
+# issue #106 for the rationale and CLAUDE.md (Release Process) for the
+# post-merge tag/publish flow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Semver version to release (X.Y.Z, no leading v, no
+          prerelease suffix).  Pre-releases are intentionally not
+          supported by this workflow.
+        required: true
+        type: string
+      dry_run:
+        description: >-
+          When true, run validation/bump/changelog/validate/audit but
+          skip pushing the branch, running the test matrix, and
+          opening the PR.  Use to verify the workflow itself without
+          producing a release artifact.
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Workflow-wide concurrency: a release-prep PR should land before
+# another is opened.  cancel-in-progress: false so a queued dispatch
+# does not abort an in-flight one.
+concurrency:
+  group: release-prep
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.config.outputs.branch }}
+    steps:
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version input must match ^[0-9]+\\.[0-9]+\\.[0-9]+$ (X.Y.Z, no leading v, no prerelease); got '$VERSION'"
+            exit 1
+          fi
+          echo "Version: $VERSION"
+
+      - name: Configure outputs
+        id: config
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          echo "branch=release/v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+        with:
+          ref: main
+          # Full history so 'git describe --tags --abbrev=0' can find
+          # the previous release tag for the changelog range.
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v5 as 5.6.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Abort if release branch exists on remote
+        env:
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: |
+          if git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null 2>&1; then
+            echo "::error::remote branch '$BRANCH' already exists; another release prep is in flight or a previous one was not cleaned up."
+            exit 1
+          fi
+          echo "Remote branch '$BRANCH' is free."
+
+      - name: Create release branch
+        env:
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: git checkout -b "$BRANCH"
+
+      - name: Bump version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: python scripts/bump_version.py "$VERSION"
+
+      - name: Resolve previous tag
+        id: prev
+        run: |
+          PREV=$(git describe --tags --abbrev=0)
+          if [[ -z "$PREV" ]]; then
+            echo "::error::no previous tag found via 'git describe --tags --abbrev=0'; release-prep.yml requires at least one prior release tag."
+            exit 1
+          fi
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: $PREV"
+
+      - name: Generate changelog section (preview for PR body)
+        env:
+          VERSION: ${{ inputs.version }}
+          PREV: ${{ steps.prev.outputs.prev }}
+        # Write outside the workspace so the next 'git add -A' does
+        # not accidentally stage the artifact alongside the bump.
+        run: |
+          UNTIL=$(git rev-parse HEAD)
+          DATE=$(date -u +%Y-%m-%d)
+          python scripts/generate_changelog.py \
+            --since "$PREV" \
+            --version "$VERSION" \
+            --until "$UNTIL" \
+            --date "$DATE" \
+            > "$RUNNER_TEMP/pr-body-section.md"
+          echo "--- preview ---"
+          cat "$RUNNER_TEMP/pr-body-section.md"
+
+      - name: Apply changelog (in place)
+        env:
+          VERSION: ${{ inputs.version }}
+          PREV: ${{ steps.prev.outputs.prev }}
+        run: |
+          UNTIL=$(git rev-parse HEAD)
+          DATE=$(date -u +%Y-%m-%d)
+          python scripts/generate_changelog.py \
+            --since "$PREV" \
+            --version "$VERSION" \
+            --until "$UNTIL" \
+            --date "$DATE" \
+            --in-place
+
+      - name: Validate skill (foundry self)
+        working-directory: skill-system-foundry
+        run: python scripts/validate_skill.py . --allow-nested-references --foundry-self --verbose
+
+      - name: Audit skill system (repo root, includes version-drift rule)
+        run: python skill-system-foundry/scripts/audit_skill_system.py .
+
+      - name: Commit release bump
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git add -A
+          git commit -m "Release v$VERSION"
+
+      - name: Push release branch
+        if: ${{ ! inputs.dry_run }}
+        env:
+          BRANCH: ${{ steps.config.outputs.branch }}
+        run: git push origin "$BRANCH"
+
+      - name: Upload PR body artifact
+        if: ${{ ! inputs.dry_run }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4 as 4.6.2
+        with:
+          name: release-pr-body
+          path: ${{ runner.temp }}/pr-body-section.md
+          if-no-files-found: error
+
+  test:
+    needs: prepare
+    if: ${{ ! inputs.dry_run }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/python-tests.yaml
+    with:
+      ref: ${{ needs.prepare.outputs.branch }}
+    secrets: inherit
+
+  open-pr:
+    needs: [prepare, test]
+    if: ${{ ! inputs.dry_run }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+        with:
+          ref: main
+
+      - name: Download PR body artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # @v4 as 4.3.0
+        with:
+          name: release-pr-body
+          path: ${{ runner.temp }}
+
+      - name: Compose PR body
+        env:
+          VERSION: ${{ inputs.version }}
+          PREP_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "Prepared by [release-prep run]($PREP_RUN_URL)."
+            echo
+            echo "## Changelog section"
+            echo
+            cat "$RUNNER_TEMP/pr-body-section.md"
+            echo
+            echo "## Manual follow-up before merge"
+            echo
+            echo "- Review and edit version prose in \`.agents/skills/git-release/SKILL.md\` if any examples reference an outdated release."
+            echo "- Re-run CI: GitHub does not trigger PR workflows for PRs opened by \`GITHUB_TOKEN\`. Close and reopen the PR (a human action) to fire \`python-tests.yaml\` against the head."
+            echo
+            echo "## Post-merge"
+            echo
+            echo "After this PR merges to \`main\`:"
+            echo
+            echo '```sh'
+            echo "gh release create v$VERSION --generate-notes"
+            echo '```'
+            echo
+            echo "The existing \`release.yml\` workflow then bundles the zip, computes the SHA256 checksum, and uploads both as release assets."
+          } > "$RUNNER_TEMP/pr-body.md"
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ needs.prepare.outputs.branch }}
+        run: |
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Release v$VERSION" \
+            --body-file "$RUNNER_TEMP/pr-body.md"

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -18,10 +18,12 @@ on:
         type: string
       dry_run:
         description: >-
-          When true, run validation/bump/changelog/validate/audit but
-          skip pushing the branch, running the test matrix, and
-          opening the PR.  Use to verify the workflow itself without
-          producing a release artifact.
+          When true, run input validation, bump, changelog generation,
+          validate, and audit — but skip pushing the branch, running
+          the reusable test matrix, and opening the PR.  Useful to
+          verify input correctness and the gates against the current
+          main; it does NOT exercise the reusable workflow_call to
+          python-tests.yaml or the gh pr create step.
         required: false
         type: boolean
         default: false
@@ -101,26 +103,41 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: python scripts/bump_version.py "$VERSION"
 
-      - name: Resolve previous tag
-        id: prev
+      - name: Resolve changelog range
+        id: range
+        # Resolve PREV / UNTIL / DATE once and reuse them across the
+        # preview and the in-place write so a step that straddles
+        # midnight UTC, or a stray amend between the two calls, cannot
+        # produce two different ranges or release dates.  The
+        # --match glob filters 'git describe' to release-shaped tags
+        # only — a non-release tag (debug, hotfix experiment) would
+        # otherwise silently widen or narrow the changelog range.
         run: |
-          PREV=$(git describe --tags --abbrev=0)
+          PREV=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || true)
           if [[ -z "$PREV" ]]; then
-            echo "::error::no previous tag found via 'git describe --tags --abbrev=0'; release-prep.yml requires at least one prior release tag."
+            echo "::error::no release-shaped tag (vX.Y.Z) found via 'git describe'; release-prep.yml requires at least one prior release tag."
             exit 1
           fi
-          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+          UNTIL=$(git rev-parse HEAD)
+          DATE=$(date -u +%Y-%m-%d)
+          {
+            echo "prev=$PREV"
+            echo "until=$UNTIL"
+            echo "date=$DATE"
+          } >> "$GITHUB_OUTPUT"
           echo "Previous tag: $PREV"
+          echo "Until SHA:    $UNTIL"
+          echo "Release date: $DATE"
 
       - name: Generate changelog section (preview for PR body)
         env:
           VERSION: ${{ inputs.version }}
-          PREV: ${{ steps.prev.outputs.prev }}
+          PREV: ${{ steps.range.outputs.prev }}
+          UNTIL: ${{ steps.range.outputs.until }}
+          DATE: ${{ steps.range.outputs.date }}
         # Write outside the workspace so the next 'git add -A' does
         # not accidentally stage the artifact alongside the bump.
         run: |
-          UNTIL=$(git rev-parse HEAD)
-          DATE=$(date -u +%Y-%m-%d)
           python scripts/generate_changelog.py \
             --since "$PREV" \
             --version "$VERSION" \
@@ -133,10 +150,10 @@ jobs:
       - name: Apply changelog (in place)
         env:
           VERSION: ${{ inputs.version }}
-          PREV: ${{ steps.prev.outputs.prev }}
+          PREV: ${{ steps.range.outputs.prev }}
+          UNTIL: ${{ steps.range.outputs.until }}
+          DATE: ${{ steps.range.outputs.date }}
         run: |
-          UNTIL=$(git rev-parse HEAD)
-          DATE=$(date -u +%Y-%m-%d)
           python scripts/generate_changelog.py \
             --since "$PREV" \
             --version "$VERSION" \

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -93,8 +93,14 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install dev dependencies
-        run: pip install -r requirements-dev.txt
+      # No ``pip install`` step: ``bump_version.py``,
+      # ``generate_changelog.py``, ``validate_skill.py``, and
+      # ``audit_skill_system.py`` are stdlib-only (a non-negotiable
+      # repository constraint).  ``coverage`` is the only dev dependency
+      # and is exercised by the reusable ``python-tests.yaml``, which
+      # runs in its own ``contents: read`` job.  Skipping the install
+      # here keeps third-party package execution out of the
+      # ``contents: write`` prepare job.
 
       - name: Abort if release branch exists on remote
         env:

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -202,7 +202,6 @@ jobs:
     uses: ./.github/workflows/python-tests.yaml
     with:
       ref: ${{ needs.prepare.outputs.branch }}
-    secrets: inherit
 
   open-pr:
     needs: [prepare, test]

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -114,65 +114,35 @@ jobs:
       - name: Bump version
         env:
           VERSION: ${{ inputs.version }}
+        # ``bump_version.py`` is the single writer for both the manifest
+        # files and ``CHANGELOG.md``: it updates SKILL.md / plugin.json /
+        # marketplace.json in lockstep, then invokes
+        # ``generate_changelog.py --in-place`` to prepend the new
+        # section.  The previous-tag, until-ref, and date are derived
+        # internally from the manifest's current version, ``HEAD``, and
+        # today (UTC), so we do not run ``git describe`` ourselves and
+        # do not call the changelog generator a second time — a second
+        # ``--in-place`` invocation would trip the duplicate-section
+        # guard once a section for ``$VERSION`` is already present.
         run: python scripts/bump_version.py "$VERSION"
 
-      - name: Resolve changelog range
-        id: range
-        # Resolve PREV / UNTIL / DATE once and reuse them across the
-        # preview and the in-place write so a step that straddles
-        # midnight UTC, or a stray amend between the two calls, cannot
-        # produce two different ranges or release dates.  The
-        # --match glob filters 'git describe' to release-shaped tags
-        # only — a non-release tag (debug, hotfix experiment) would
-        # otherwise silently widen or narrow the changelog range.
+      - name: Extract release section for PR body
+        # Pull the section ``bump_version.py`` just prepended out of
+        # ``CHANGELOG.md`` (everything from the first ``## [`` heading
+        # up to — but not including — the next one).  Written outside
+        # the workspace so the later ``git add -A`` cannot accidentally
+        # stage the artifact alongside the bump.
         run: |
-          PREV=$(git describe --tags --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || true)
-          if [[ -z "$PREV" ]]; then
-            echo "::error::no release-shaped tag (vX.Y.Z) found via 'git describe'; release-prep.yml requires at least one prior release tag."
+          awk '
+            /^## \[/ { count++; if (count == 2) exit }
+            count >= 1 { print }
+          ' CHANGELOG.md > "$RUNNER_TEMP/pr-body-section.md"
+          if [[ ! -s "$RUNNER_TEMP/pr-body-section.md" ]]; then
+            echo "::error::could not extract release section from CHANGELOG.md; bump_version.py did not prepend a section."
             exit 1
           fi
-          UNTIL=$(git rev-parse HEAD)
-          DATE=$(date -u +%Y-%m-%d)
-          {
-            echo "prev=$PREV"
-            echo "until=$UNTIL"
-            echo "date=$DATE"
-          } >> "$GITHUB_OUTPUT"
-          echo "Previous tag: $PREV"
-          echo "Until SHA:    $UNTIL"
-          echo "Release date: $DATE"
-
-      - name: Generate changelog section (preview for PR body)
-        env:
-          VERSION: ${{ inputs.version }}
-          PREV: ${{ steps.range.outputs.prev }}
-          UNTIL: ${{ steps.range.outputs.until }}
-          DATE: ${{ steps.range.outputs.date }}
-        # Write outside the workspace so the next 'git add -A' does
-        # not accidentally stage the artifact alongside the bump.
-        run: |
-          python scripts/generate_changelog.py \
-            --since "$PREV" \
-            --version "$VERSION" \
-            --until "$UNTIL" \
-            --date "$DATE" \
-            > "$RUNNER_TEMP/pr-body-section.md"
-          echo "--- preview ---"
+          echo "--- extracted ---"
           cat "$RUNNER_TEMP/pr-body-section.md"
-
-      - name: Apply changelog (in place)
-        env:
-          VERSION: ${{ inputs.version }}
-          PREV: ${{ steps.range.outputs.prev }}
-          UNTIL: ${{ steps.range.outputs.until }}
-          DATE: ${{ steps.range.outputs.date }}
-        run: |
-          python scripts/generate_changelog.py \
-            --since "$PREV" \
-            --version "$VERSION" \
-            --until "$UNTIL" \
-            --date "$DATE" \
-            --in-place
 
       - name: Validate skill (foundry self)
         working-directory: skill-system-foundry

--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ On Linux and macOS the expected output is `skill-system-foundry-vX.Y.Z.zip: OK`.
      --system-root /path/to/project/.agents --output my-skill.zip
    ```
 
+## Releases
+
+Shipped versions and what changed between them are tracked in [CHANGELOG.md](CHANGELOG.md). Each release is also published as a versioned zip on the [Releases](https://github.com/milanhorvatovic/skill-system-foundry/releases) page (with a SHA256 checksum file alongside it; see the [GitHub Releases](#github-releases) installation section for verification commands).
+
+Maintainer release flow at a glance: dispatch the `Release prep` workflow with the new version → review and merge the auto-opened release PR → run `gh release create vX.Y.Z --generate-notes`. The post-merge `release.yml` workflow then bundles the zip and publishes the assets. Detailed steps live in the `git-release` skill under `.agents/skills/git-release/SKILL.md`.
+
 ## Repository Structure
 
 ```

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -150,12 +150,18 @@ _SEMVER_RE = re.compile(
 # the full subject so a hand-edited subject like ``Release v1.2.0 (RC)``
 # still routes through the verb map (and thus to unmapped) and forces
 # the operator to either fix the subject or reclassify deliberately.
-# The version grammar mirrors ``_SEMVER_RE`` (no leading zeros, optional
-# prerelease suffix) so the elision criterion stays consistent with what
-# the rest of the script considers a valid release version.
+# The version grammar mirrors ``_SEMVER_RE`` exactly (no leading zeros
+# in numeric identifiers; non-empty dot-separated prerelease
+# identifiers) so an off-grammar prerelease like ``Release v1.2.3-..1``
+# or ``Release v1.2.3-.rc`` still routes through unmapped instead of
+# being silently elided.  Build metadata (``+...``) is intentionally
+# unsupported here: release tags and bump commits are ``vX.Y.Z`` (with
+# optional prerelease suffix) only, so ``Release v1.2.0+build.1`` must
+# also surface for review rather than be elided.
 _RELEASE_COMMIT_RE = re.compile(
     r"^Release v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
-    r"(?:-[0-9A-Za-z.-]+)?$"
+    r"(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*)?$"
 )
 
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -365,19 +365,28 @@ def first_word(subject: str) -> str:
 def classify_commits(
     commits: list[tuple[str, str]],
     verb_map: dict[str, str],
-) -> tuple[dict[str, list[str]], list[tuple[str, str]]]:
-    """Split commits into ``{section: [subject]}`` and ``[(sha, subject)]`` unmapped.
+) -> tuple[dict[str, list[str]], list[tuple[str, str]], list[tuple[str, str]]]:
+    """Split commits into ``({section: [subject]}, [unmapped], [skipped_release])``.
 
     Multi-verb subjects (``Update X and add Y``) use the first word
     only; every commit subject in this repo already starts with a
     verb, so the first word is the intended classifier.
+
+    Release-bump commits matching ``_RELEASE_COMMIT_RE`` are returned
+    in the third element (``skipped_release``) rather than dropped on
+    the floor so callers can audit which meta-commits the generator
+    elided — a maintainer regenerating an old section needs to be
+    able to see why a smaller-than-expected commit count came back.
     """
     buckets: dict[str, list[str]] = {s: [] for s in SECTION_ORDER}
     unmapped: list[tuple[str, str]] = []
+    skipped_release: list[tuple[str, str]] = []
     for sha, subject in commits:
         if _RELEASE_COMMIT_RE.match(subject):
-            # Release-prep bump commits are meta — skip silently so they
-            # neither pollute the changelog nor surface as unmapped noise.
+            # Release-prep bump commits are meta — keep them out of
+            # both the buckets and the unmapped list, but expose them
+            # via skipped_release so the caller can log the elision.
+            skipped_release.append((sha, subject))
             continue
         verb = first_word(subject)
         section = verb_map.get(verb)
@@ -385,7 +394,7 @@ def classify_commits(
             unmapped.append((sha, subject))
             continue
         buckets[section].append(subject)
-    return buckets, unmapped
+    return buckets, unmapped, skipped_release
 
 
 def render_section(
@@ -724,8 +733,8 @@ def generate(
     today: str,
     verb_map: dict[str, str],
     until_override: str | None = None,
-) -> tuple[str, list[tuple[str, str]]]:
-    """Pure function — returns ``(rendered_section, unmapped_commits)``.
+) -> tuple[str, list[tuple[str, str]], list[tuple[str, str]]]:
+    """Pure function — returns ``(rendered_section, unmapped, skipped_release)``.
 
     ``until_override`` pins the upper bound explicitly (typically to
     a stable SHA / branch / tag chosen by the operator so the same
@@ -735,6 +744,11 @@ def generate(
     and ``until_override`` are qualified to ``refs/tags/<name>`` when
     they name an existing tag so a branch sharing the name cannot
     shadow the tag in the ``git log`` range.
+
+    The third tuple element lists release-bump commits that the
+    generator elided from the rendered section (see
+    ``_RELEASE_COMMIT_RE``).  Callers should surface these on stderr
+    so the elision is auditable.
     """
     since_ref = _qualified_ref(since, repo_root)
     if until_override is not None:
@@ -742,10 +756,10 @@ def generate(
     else:
         until = resolve_until(version, repo_root)
     commits = collect_commits(since_ref, until, repo_root)
-    buckets, unmapped = classify_commits(commits, verb_map)
+    buckets, unmapped, skipped_release = classify_commits(commits, verb_map)
     date = resolve_date(version, repo_root, date_override, today)
     section = render_section(normalize_version(version), date, buckets)
-    return section, unmapped
+    return section, unmapped, skipped_release
 
 
 def report_unmapped(
@@ -763,6 +777,24 @@ def report_unmapped(
     for sha, subject in unmapped:
         _write_preserving_lf(
             f"unmapped — review manually: {sha[:12]} {subject}\n",
+            stream,
+        )
+
+
+def report_skipped_release(
+    skipped: list[tuple[str, str]],
+    stream: typing.TextIO,
+) -> None:
+    """Write ``note: skipped release-bump commit: <sha> <subject>`` for each entry.
+
+    Emitted as informational stderr noise so a maintainer regenerating
+    an older changelog section can see which release-prep meta-commits
+    the generator elided.  Does not affect exit codes — these are
+    intentional drops, not classification gaps.
+    """
+    for sha, subject in skipped:
+        _write_preserving_lf(
+            f"note: skipped release-bump commit: {sha[:12]} {subject}\n",
             stream,
         )
 
@@ -878,7 +910,7 @@ def main(argv: list[str] | None = None) -> int:
                 f"plan to tag) or create the tag first."
             )
 
-        section, unmapped = generate(
+        section, unmapped, skipped_release = generate(
             since=args.since,
             version=args.version,
             date_override=args.date,
@@ -888,6 +920,7 @@ def main(argv: list[str] | None = None) -> int:
             until_override=args.until,
         )
 
+        report_skipped_release(skipped_release, sys.stderr)
         report_unmapped(unmapped, sys.stderr)
 
         changelog_path = os.path.join(repo_root, "CHANGELOG.md")

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -150,6 +150,9 @@ _SEMVER_RE = re.compile(
 # the full subject so a hand-edited subject like ``Release v1.2.0 (RC)``
 # still routes through the verb map (and thus to unmapped) and forces
 # the operator to either fix the subject or reclassify deliberately.
+# The version grammar mirrors ``_SEMVER_RE`` (no leading zeros, optional
+# prerelease suffix) so the elision criterion stays consistent with what
+# the rest of the script considers a valid release version.
 _RELEASE_COMMIT_RE = re.compile(
     r"^Release v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
     r"(?:-[0-9A-Za-z.-]+)?$"

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -140,6 +140,21 @@ _SEMVER_RE = re.compile(
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 
+# Subjects produced by the ``release-prep.yml`` workflow's bump commit.
+# These are meta-commits that should not appear in the changelog of the
+# version they introduce — the section they prepend already records the
+# real changes.  They are also not candidates for "unmapped — review
+# manually" stderr noise: the verb ``Release`` is intentionally absent
+# from ``changelog.yaml`` (see issue #106), so without this filter every
+# subsequent release would surface a stale warning.  The pattern matches
+# the full subject so a hand-edited subject like ``Release v1.2.0 (RC)``
+# still routes through the verb map (and thus to unmapped) and forces
+# the operator to either fix the subject or reclassify deliberately.
+_RELEASE_COMMIT_RE = re.compile(
+    r"^Release v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z.-]+)?$"
+)
+
 
 def _is_iso_date(value: str) -> bool:
     """Return ``True`` when *value* is a real ``YYYY-MM-DD`` calendar date.
@@ -360,6 +375,10 @@ def classify_commits(
     buckets: dict[str, list[str]] = {s: [] for s in SECTION_ORDER}
     unmapped: list[tuple[str, str]] = []
     for sha, subject in commits:
+        if _RELEASE_COMMIT_RE.match(subject):
+            # Release-prep bump commits are meta — skip silently so they
+            # neither pollute the changelog nor surface as unmapped noise.
+            continue
         verb = first_word(subject)
         section = verb_map.get(verb)
         if section is None:

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -150,14 +150,16 @@ _SEMVER_RE = re.compile(
 # the full subject so a hand-edited subject like ``Release v1.2.0 (RC)``
 # still routes through the verb map (and thus to unmapped) and forces
 # the operator to either fix the subject or reclassify deliberately.
-# The version grammar mirrors ``_SEMVER_RE`` exactly (no leading zeros
-# in numeric identifiers; non-empty dot-separated prerelease
-# identifiers) so an off-grammar prerelease like ``Release v1.2.3-..1``
-# or ``Release v1.2.3-.rc`` still routes through unmapped instead of
-# being silently elided.  Build metadata (``+...``) is intentionally
-# unsupported here: release tags and bump commits are ``vX.Y.Z`` (with
-# optional prerelease suffix) only, so ``Release v1.2.0+build.1`` must
-# also surface for review rather than be elided.
+# The version grammar mirrors the core-version and prerelease portions
+# of ``_SEMVER_RE`` (no leading zeros in numeric identifiers; non-empty
+# dot-separated prerelease identifiers), so an off-grammar prerelease
+# like ``Release v1.2.3-..1`` or ``Release v1.2.3-.rc`` still routes
+# through unmapped instead of being silently elided.  Build metadata
+# (``+...``) is intentionally unsupported here — release tags and bump
+# commits are ``vX.Y.Z`` (with optional prerelease suffix) only, so
+# ``Release v1.2.0+build.1`` must also surface for review rather than
+# be elided.  This is a deliberate divergence from ``_SEMVER_RE``,
+# which does accept ``+build`` metadata on the ``--version`` input.
 _RELEASE_COMMIT_RE = re.compile(
     r"^Release v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
     r"(?:-(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)"

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -339,9 +339,12 @@ class ClassifyCommitsTests(unittest.TestCase):
 
     def test_release_with_malformed_prerelease_is_not_skipped(self) -> None:
         # Off-grammar prereleases ("-..1", "-.rc", leading zero in a
-        # numeric prerelease identifier) and build metadata are not
-        # valid SemVer.  The skip filter mirrors _SEMVER_RE so these
-        # subjects route to unmapped rather than being silently elided
+        # numeric prerelease identifier) are not valid SemVer; build
+        # metadata ("+build.1") IS valid SemVer but is intentionally
+        # off-policy for release-bump commits in this repo (release
+        # tags and bump subjects are vX.Y.Z with optional prerelease
+        # only).  The skip filter therefore leaves all of these
+        # subjects in unmapped rather than silently eliding them
         # (which would defeat the "force a deliberate reclassification"
         # guard).
         commits = [

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -242,37 +242,41 @@ class ClassifyCommitsTests(unittest.TestCase):
             ("bbb", "Fix bug Y"),
             ("ccc", "Update module Z"),
         ]
-        buckets, unmapped = gc.classify_commits(commits, VERB_MAP)
+        buckets, unmapped, skipped = gc.classify_commits(commits, VERB_MAP)
         self.assertEqual(buckets["Added"], ["Add feature X"])
         self.assertEqual(buckets["Fixed"], ["Fix bug Y"])
         self.assertEqual(buckets["Changed"], ["Update module Z"])
         self.assertEqual(buckets["Removed"], [])
         self.assertEqual(unmapped, [])
+        self.assertEqual(skipped, [])
 
     def test_unmapped_verb_routed(self) -> None:
         commits = [("zzz", "Replace bundle.py with simple zip")]
-        buckets, unmapped = gc.classify_commits(commits, VERB_MAP)
+        buckets, unmapped, skipped = gc.classify_commits(commits, VERB_MAP)
         for section in gc.SECTION_ORDER:
             self.assertEqual(buckets[section], [])
         self.assertEqual(unmapped, [("zzz", "Replace bundle.py with simple zip")])
+        self.assertEqual(skipped, [])
 
     def test_multi_verb_uses_first_word(self) -> None:
         commits = [("abc", "Update X and add Y")]
-        buckets, _ = gc.classify_commits(commits, VERB_MAP)
+        buckets, _, _ = gc.classify_commits(commits, VERB_MAP)
         self.assertEqual(buckets["Changed"], ["Update X and add Y"])
 
     def test_extended_verb_restructure(self) -> None:
         commits = [("rrr", "Restructure foundry into router")]
         map_with_restructure = {**VERB_MAP, "Restructure": "Changed"}
-        buckets, unmapped = gc.classify_commits(commits, map_with_restructure)
+        buckets, unmapped, skipped = gc.classify_commits(commits, map_with_restructure)
         self.assertEqual(buckets["Changed"], ["Restructure foundry into router"])
         self.assertEqual(unmapped, [])
+        self.assertEqual(skipped, [])
 
     def test_empty_commit_list(self) -> None:
-        buckets, unmapped = gc.classify_commits([], VERB_MAP)
+        buckets, unmapped, skipped = gc.classify_commits([], VERB_MAP)
         for section in gc.SECTION_ORDER:
             self.assertEqual(buckets[section], [])
         self.assertEqual(unmapped, [])
+        self.assertEqual(skipped, [])
 
     def test_preserves_order(self) -> None:
         commits = [
@@ -280,32 +284,35 @@ class ClassifyCommitsTests(unittest.TestCase):
             ("2", "Add B"),
             ("3", "Add C"),
         ]
-        buckets, _ = gc.classify_commits(commits, VERB_MAP)
+        buckets, _, _ = gc.classify_commits(commits, VERB_MAP)
         self.assertEqual(buckets["Added"], ["Add A", "Add B", "Add C"])
 
     def test_release_bump_commit_is_skipped(self) -> None:
         # Bump commits produced by release-prep.yml ("Release vX.Y.Z")
-        # must not appear in the section they introduce, and must not
+        # must not appear in the section they introduce, must not
         # surface on stderr as unmapped (the verb is intentionally not
-        # mapped — see issue #106).
+        # mapped — see issue #106), and must be reported via the
+        # skipped_release channel so the elision is auditable.
         commits = [
             ("aaa", "Add real feature"),
             ("bbb", "Release v1.2.0"),
             ("ccc", "Fix real bug"),
         ]
-        buckets, unmapped = gc.classify_commits(commits, VERB_MAP)
+        buckets, unmapped, skipped = gc.classify_commits(commits, VERB_MAP)
         self.assertEqual(buckets["Added"], ["Add real feature"])
         self.assertEqual(buckets["Fixed"], ["Fix real bug"])
         for section in gc.SECTION_ORDER:
             self.assertNotIn("Release v1.2.0", buckets[section])
         self.assertEqual(unmapped, [])
+        self.assertEqual(skipped, [("bbb", "Release v1.2.0")])
 
     def test_release_bump_with_prerelease_suffix_is_skipped(self) -> None:
         commits = [("rrr", "Release v2.0.0-rc.1")]
-        buckets, unmapped = gc.classify_commits(commits, VERB_MAP)
+        buckets, unmapped, skipped = gc.classify_commits(commits, VERB_MAP)
         for section in gc.SECTION_ORDER:
             self.assertEqual(buckets[section], [])
         self.assertEqual(unmapped, [])
+        self.assertEqual(skipped, [("rrr", "Release v2.0.0-rc.1")])
 
     def test_release_with_extra_text_is_not_skipped(self) -> None:
         # A hand-edited subject like "Release v1.2.0 (RC)" does not match
@@ -313,20 +320,22 @@ class ClassifyCommitsTests(unittest.TestCase):
         # (here, to unmapped) so the operator notices and either fixes
         # the subject or reclassifies deliberately.
         commits = [("ddd", "Release v1.2.0 (RC)")]
-        buckets, unmapped = gc.classify_commits(commits, VERB_MAP)
+        buckets, unmapped, skipped = gc.classify_commits(commits, VERB_MAP)
         for section in gc.SECTION_ORDER:
             self.assertEqual(buckets[section], [])
         self.assertEqual(unmapped, [("ddd", "Release v1.2.0 (RC)")])
+        self.assertEqual(skipped, [])
 
     def test_release_without_v_prefix_is_not_skipped(self) -> None:
         # The release-prep workflow always commits "Release vX.Y.Z".
         # A bare "Release 1.2.0" is therefore an off-pattern subject and
         # should still route to unmapped.
         commits = [("eee", "Release 1.2.0")]
-        buckets, unmapped = gc.classify_commits(commits, VERB_MAP)
+        buckets, unmapped, skipped = gc.classify_commits(commits, VERB_MAP)
         for section in gc.SECTION_ORDER:
             self.assertEqual(buckets[section], [])
         self.assertEqual(unmapped, [("eee", "Release 1.2.0")])
+        self.assertEqual(skipped, [])
 
 
 # ===================================================================
@@ -914,7 +923,7 @@ class GenerateTests(unittest.TestCase):
         with mock.patch.object(gc, "tag_exists", return_value=True), \
              mock.patch.object(gc, "tag_commit_date", return_value="2026-03-22"), \
              mock.patch.object(gc, "collect_commits", return_value=commits):
-            section, unmapped = gc.generate(
+            section, unmapped, _ = gc.generate(
                 since="v1.0.0",
                 version="1.1.0",
                 date_override=None,
@@ -936,7 +945,7 @@ class GenerateTests(unittest.TestCase):
         with mock.patch.object(gc, "tag_exists", return_value=True), \
              mock.patch.object(gc, "tag_commit_date", return_value="2026-03-22"), \
              mock.patch.object(gc, "collect_commits", return_value=commits):
-            section, unmapped = gc.generate(
+            section, unmapped, _ = gc.generate(
                 since="v1.0.0",
                 version="1.1.0",
                 date_override=None,
@@ -952,7 +961,7 @@ class GenerateTests(unittest.TestCase):
         with mock.patch.object(gc, "tag_exists", return_value=True), \
              mock.patch.object(gc, "tag_commit_date", return_value="2026-03-22"), \
              mock.patch.object(gc, "collect_commits", return_value=[]):
-            section, unmapped = gc.generate(
+            section, unmapped, _ = gc.generate(
                 since="v1.0.0",
                 version="1.1.0",
                 date_override=None,
@@ -985,6 +994,24 @@ class ReportUnmappedTests(unittest.TestCase):
     def test_empty_list_writes_nothing(self) -> None:
         buf = io.StringIO()
         gc.report_unmapped([], buf)
+        self.assertEqual(buf.getvalue(), "")
+
+
+class ReportSkippedReleaseTests(unittest.TestCase):
+    def test_writes_sha_prefix_and_subject(self) -> None:
+        buf = io.StringIO()
+        gc.report_skipped_release(
+            [("abcdef1234567890abc", "Release v1.2.0")],
+            buf,
+        )
+        out = buf.getvalue()
+        self.assertIn("note: skipped release-bump commit", out)
+        self.assertIn("abcdef123456", out)
+        self.assertIn("Release v1.2.0", out)
+
+    def test_empty_list_writes_nothing(self) -> None:
+        buf = io.StringIO()
+        gc.report_skipped_release([], buf)
         self.assertEqual(buf.getvalue(), "")
 
 
@@ -1024,6 +1051,23 @@ class MainCliTests(unittest.TestCase):
         self.assertEqual(rc, 3)
         self.assertIn("unmapped", err.getvalue())
         self.assertNotIn("Replace the thing", out.getvalue())
+
+    def test_release_bump_skipped_with_stderr_note_and_exit_zero(self) -> None:
+        # End-to-end: a Release vX.Y.Z bump commit must (a) be elided
+        # from rendered output, (b) produce a 'note: skipped
+        # release-bump commit' line on stderr so the elision is
+        # auditable, and (c) not change the exit code (it is an
+        # intentional drop, not a classification gap).
+        commits = [("aaa", "Add feature"), ("bbb", "Release v1.2.0")]
+        with self._patch_git(commits):
+            with mock.patch("sys.stdout", new=io.StringIO()) as out, \
+                 mock.patch("sys.stderr", new=io.StringIO()) as err:
+                rc = gc.main(["--since", "v1.0.0", "--version", "1.1.0"])
+        self.assertEqual(rc, 0)
+        self.assertIn("- Add feature", out.getvalue())
+        self.assertNotIn("Release v1.2.0", out.getvalue())
+        self.assertIn("note: skipped release-bump commit", err.getvalue())
+        self.assertIn("Release v1.2.0", err.getvalue())
 
     def test_invalid_version_is_rejected(self) -> None:
         with mock.patch("sys.stderr", new=io.StringIO()) as err:

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -283,6 +283,51 @@ class ClassifyCommitsTests(unittest.TestCase):
         buckets, _ = gc.classify_commits(commits, VERB_MAP)
         self.assertEqual(buckets["Added"], ["Add A", "Add B", "Add C"])
 
+    def test_release_bump_commit_is_skipped(self) -> None:
+        # Bump commits produced by release-prep.yml ("Release vX.Y.Z")
+        # must not appear in the section they introduce, and must not
+        # surface on stderr as unmapped (the verb is intentionally not
+        # mapped — see issue #106).
+        commits = [
+            ("aaa", "Add real feature"),
+            ("bbb", "Release v1.2.0"),
+            ("ccc", "Fix real bug"),
+        ]
+        buckets, unmapped = gc.classify_commits(commits, VERB_MAP)
+        self.assertEqual(buckets["Added"], ["Add real feature"])
+        self.assertEqual(buckets["Fixed"], ["Fix real bug"])
+        for section in gc.SECTION_ORDER:
+            self.assertNotIn("Release v1.2.0", buckets[section])
+        self.assertEqual(unmapped, [])
+
+    def test_release_bump_with_prerelease_suffix_is_skipped(self) -> None:
+        commits = [("rrr", "Release v2.0.0-rc.1")]
+        buckets, unmapped = gc.classify_commits(commits, VERB_MAP)
+        for section in gc.SECTION_ORDER:
+            self.assertEqual(buckets[section], [])
+        self.assertEqual(unmapped, [])
+
+    def test_release_with_extra_text_is_not_skipped(self) -> None:
+        # A hand-edited subject like "Release v1.2.0 (RC)" does not match
+        # the strict pattern and must still route through the verb map
+        # (here, to unmapped) so the operator notices and either fixes
+        # the subject or reclassifies deliberately.
+        commits = [("ddd", "Release v1.2.0 (RC)")]
+        buckets, unmapped = gc.classify_commits(commits, VERB_MAP)
+        for section in gc.SECTION_ORDER:
+            self.assertEqual(buckets[section], [])
+        self.assertEqual(unmapped, [("ddd", "Release v1.2.0 (RC)")])
+
+    def test_release_without_v_prefix_is_not_skipped(self) -> None:
+        # The release-prep workflow always commits "Release vX.Y.Z".
+        # A bare "Release 1.2.0" is therefore an off-pattern subject and
+        # should still route to unmapped.
+        commits = [("eee", "Release 1.2.0")]
+        buckets, unmapped = gc.classify_commits(commits, VERB_MAP)
+        for section in gc.SECTION_ORDER:
+            self.assertEqual(buckets[section], [])
+        self.assertEqual(unmapped, [("eee", "Release 1.2.0")])
+
 
 # ===================================================================
 # Rendering

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -337,6 +337,25 @@ class ClassifyCommitsTests(unittest.TestCase):
         self.assertEqual(unmapped, [("eee", "Release 1.2.0")])
         self.assertEqual(skipped, [])
 
+    def test_release_with_malformed_prerelease_is_not_skipped(self) -> None:
+        # Off-grammar prereleases ("-..1", "-.rc", leading zero in a
+        # numeric prerelease identifier) and build metadata are not
+        # valid SemVer.  The skip filter mirrors _SEMVER_RE so these
+        # subjects route to unmapped rather than being silently elided
+        # (which would defeat the "force a deliberate reclassification"
+        # guard).
+        commits = [
+            ("f1", "Release v1.2.3-..1"),
+            ("f2", "Release v1.2.3-.rc"),
+            ("f3", "Release v1.2.3-01"),
+            ("f4", "Release v1.2.0+build.1"),
+        ]
+        buckets, unmapped, skipped = gc.classify_commits(commits, VERB_MAP)
+        for section in gc.SECTION_ORDER:
+            self.assertEqual(buckets[section], [])
+        self.assertEqual(skipped, [])
+        self.assertEqual([sha for sha, _ in unmapped], ["f1", "f2", "f3", "f4"])
+
 
 # ===================================================================
 # Rendering


### PR DESCRIPTION
## Summary

Adds `release-prep.yml` — a `workflow_dispatch`-driven workflow that automates the mechanical part of cutting a release: it validates the supplied semver, creates `release/v<X.Y.Z>`, runs `bump_version.py` and `generate_changelog.py`, gates the result on `validate_skill.py` plus a repo-root `audit_skill_system.py` (so the version-drift rule fires), commits `Release v<version>`, runs the full test matrix via a reusable `workflow_call` into `python-tests.yaml`, and opens a PR with the generated changelog section in the body. A `dry_run` input exercises inputs/bump/changelog/validate/audit only — it does not push, run the test matrix, or open a PR.

The `python-tests.yaml` workflow gains a `workflow_call` trigger with an optional `ref` input so the prep run can test the bumped release branch; its `update-badge` job is now gated on `github.event_name == 'push'` so reusable invocations cannot overwrite the main-branch coverage badge from a release branch.

`generate_changelog.py` learns to elide `Release vX.Y.Z` bump commits from the rendered section (otherwise every subsequent release would surface a stale `unmapped — review manually` line, since `Release` is intentionally absent from `changelog.yaml`). Elided commits are returned on a third channel (`skipped_release`) and emitted on stderr via the new `report_skipped_release` helper so the drop is auditable when regenerating older sections; exit code is unchanged.

The `git-release` skill grows a `Dispatch-Driven Prep (Preferred)` section as the primary path; the manual checklist is retained as a fallback and updated to use `bump_version.py` and `generate_changelog.py` (the previous Step 2 incorrectly claimed `SKILL.md` was the only file holding the version, which would now fail the version-drift audit). The `README` gains a top-level `Releases` section pointing at the changelog, the Releases page, and the dispatch flow.

## Areas affected

- `.github/workflows/release-prep.yml` (new)
- `.github/workflows/python-tests.yaml` (reusable `workflow_call` trigger; badge-job gating)
- `scripts/generate_changelog.py` + `tests/test_generate_changelog.py` (release-bump elision, third return channel, stderr reporting)
- `.agents/skills/git-release/SKILL.md` (dispatch-driven flow as the primary path; manual checklist updated)
- `README.md` (new top-level `Releases` section)

## Validation

- `python -m coverage run -m unittest discover -s tests -p "test_*.py" -v` → all green; coverage above the 70% branch threshold.
- `python skill-system-foundry/scripts/validate_skill.py skill-system-foundry --allow-nested-references --foundry-self --verbose` → clean.
- `python skill-system-foundry/scripts/audit_skill_system.py .` (from repo root, so the version-drift rule fires) → clean apart from the expected single `skills/` warning documented in `CLAUDE.md`.
- Local critique + local-CI review skills run; findings addressed in the four `Address …` follow-up commits on this branch.
- `release-prep.yml` itself was not yet executed against the live repository — the workflow is intended to be exercised on the next real release, with `dry_run: true` available to rehearse inputs/bump/changelog/validate/audit without side effects.

## Notes for the reviewer

- The `Release vX.Y.Z` regex (`_RELEASE_COMMIT_RE`) deliberately mirrors `_SEMVER_RE`'s grammar (no leading zeros, optional prerelease) so a hand-edited subject like `Release v1.2.0 (RC)` still routes through the verb map and forces a deliberate reclassification rather than being silently elided.
- `PREV` / `UNTIL` / `DATE` are resolved once in the prepare job and reused across the preview and the in-place changelog write so two steps that straddle midnight UTC cannot produce divergent dates or ranges. The release-tag lookup uses `git describe --tags --abbrev=0 --match 'v[0-9]*.[0-9]*.[0-9]*'` so a hotfix or experimental tag cannot widen or narrow the range.
- `secrets: inherit` was intentionally dropped from the reusable test-job invocation — `python-tests.yaml` consumes no custom secrets, and the implicit `GITHUB_TOKEN` is sufficient.