### PR TITLE
Add router-table consistency audit to audit_skill_system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,9 @@ python scripts/validate_skill.py . --allow-nested-references --foundry-self --ve
 python scripts/audit_skill_system.py .
 ```
 
-The `--allow-nested-references` flag is needed because this meta-skill intentionally uses nested references. One warning about a missing `skills/` directory from the audit is expected in this distribution repository.
+The `--allow-nested-references` flag is needed because this meta-skill intentionally uses nested references.
+
+The audit runs in two modes. *System-root mode* applies when the target directory contains a `skills/` tree (deployed-system layout) and walks every `skills/<name>/SKILL.md`. *Skill-root mode* applies when the target directory contains a `SKILL.md` directly (single-skill layout) and audits that skill on its own. The router-table consistency rule fires per-skill in both modes, so this same invocation also catches drift in the meta-skill's own `capabilities/` directory and in any integrator-built meta-skill. Most other per-skill rules iterate only the deployed-system layout.
 
 The version-consistency rule in `audit_skill_system.py` (which compares `SKILL.md`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`) only fires when the audit root contains both `.claude-plugin/plugin.json` and `skill-system-foundry/SKILL.md` — the gate keeps the rule scoped to the foundry distribution repository so integrator skill systems that ship their own Claude plugin manifest are unaffected. The `cd skill-system-foundry` invocation above therefore skips that rule by design — it is a repo-level check, not a skill-level check. To include it, run the audit from the repo root:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ The version-consistency rule in `audit_skill_system.py` (which compares `SKILL.m
 python skill-system-foundry/scripts/audit_skill_system.py .
 ```
 
-The repo root has no `skills/` tree and no top-level `SKILL.md`, so this invocation runs in distribution-repo mode and emits one expected `WARN: No skills/ directory under system root — ran partial audit`. Skill-level checks still pass.
+The repo root has no `skills/` tree and no top-level `SKILL.md`, so this invocation runs in distribution-repo mode and emits one expected `WARN: No skills/ directory under system root — ran partial audit`. Per-skill rules (including the router-table rule) are skipped under that invocation — it only adds the repo-level version-consistency check on top of what the `cd skill-system-foundry` invocation already covers. To audit the meta-skill's own router table, the `cd skill-system-foundry && python scripts/audit_skill_system.py .` invocation above (skill-root mode) is the canonical self-check.
 
 #### Flag behavior
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,8 @@ The version-consistency rule in `audit_skill_system.py` (which compares `SKILL.m
 python skill-system-foundry/scripts/audit_skill_system.py .
 ```
 
+The repo root has no `skills/` tree and no top-level `SKILL.md`, so this invocation runs in distribution-repo mode and emits one expected `WARN: No skills/ directory under system root — ran partial audit`. Skill-level checks still pass.
+
 #### Flag behavior
 
 | Flag | Effect | When to use |

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -589,15 +589,19 @@ def audit_skill_system(
     if verbose:
         print("\n== Router Table ==")
 
-    # Router-table audit is one of two rules that intentionally scan
-    # the meta-skill itself when system_root is a skill root (top-level
-    # SKILL.md).  See lib.discovery.find_skill_root for the rationale.
+    # Router-table audit is the only per-skill rule that intentionally
+    # scans a top-level SKILL.md (skill-root mode).  See
+    # lib.discovery.find_skill_root for the rationale.
     router_skills = list(registered_skills)
     skill_root_entry = find_skill_root(system_root)
-    if skill_root_entry is not None and not any(
-        s["path"] == skill_root_entry["path"] for s in router_skills
-    ):
-        router_skills.append(skill_root_entry)
+    if skill_root_entry is not None:
+        skill_root_path = skill_root_entry["path"]
+        already_listed = any(
+            os.path.abspath(s["path"]) == skill_root_path
+            for s in router_skills
+        )
+        if not already_listed:
+            router_skills.append(skill_root_entry)
 
     for skill in router_skills:
         rt_findings = audit_router_table(skill["path"])

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -600,6 +600,24 @@ def audit_skill_system(
     if skill_root_entry is not None:
         router_skills.append(skill_root_entry)
 
+    # Also audit directories under skills/ that have capabilities/ but
+    # no SKILL.md.  find_skill_dirs filters these out, so without this
+    # second pass the router-table rule cannot see them — yet the
+    # presence of capabilities/ proves they are meant to be router
+    # skills.  audit_router_table will emit the missing-SKILL.md FAIL.
+    seen_paths = {os.path.abspath(s["path"]) for s in router_skills}
+    if has_skills_dir:
+        for entry in os.listdir(skills_dir):
+            entry_path = os.path.join(skills_dir, entry)
+            if not os.path.isdir(entry_path):
+                continue
+            if os.path.abspath(entry_path) in seen_paths:
+                continue
+            if os.path.isdir(os.path.join(entry_path, DIR_CAPABILITIES)):
+                router_skills.append(
+                    {"name": entry, "path": entry_path, "type": "registered"}
+                )
+
     for skill in router_skills:
         rt_findings = audit_router_table(skill["path"])
         for level, message in rt_findings:

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -382,6 +382,13 @@ def audit_skill_system(
     if verbose:
         print(f"Found: {len(registered_skills)} skills, {len(capabilities)} capabilities, "
               f"{len(roles)} roles")
+        if has_top_level_skill:
+            # Skill-root mode: find_skill_dirs only walks <root>/skills/,
+            # so the count above does not include the synthetic
+            # skill-root entry that the router-table rule will audit.
+            # Surface it explicitly so the verbose header agrees with
+            # the findings about to be emitted.
+            print(f"Skill-root mode: also auditing skill at {system_root}")
         print()
 
     # Partial-audit WARN fires only when the audit cannot reach any

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -59,6 +59,7 @@ from lib.reporting import (
 from lib.discovery import (
     find_skill_dirs,
     find_roles,
+    find_skill_root,
     check_line_count,
     read_file,
 )
@@ -73,6 +74,7 @@ from lib.constants import (
     collect_foundry_config_findings,
 )
 from lib.prose_yaml import collect_prose_findings, format_finding_as_string
+from lib.router_table import audit_router_table
 
 
 def _read_plugin_json(path: str) -> tuple[dict | None, str | None]:
@@ -578,6 +580,35 @@ def audit_skill_system(
             elif verbose:
                 print(
                     f"  ✓ {skill['name']}/capabilities/{cap}/{FILE_CAPABILITY_MD}"
+                )
+
+    # --- Router Table ---
+    if verbose:
+        print("\n== Router Table ==")
+
+    # Router-table audit is one of two rules that intentionally scan
+    # the meta-skill itself when system_root is a skill root (top-level
+    # SKILL.md).  See lib.discovery.find_skill_root for the rationale.
+    router_skills = list(registered_skills)
+    skill_root_entry = find_skill_root(system_root)
+    if skill_root_entry is not None and not any(
+        s["path"] == skill_root_entry["path"] for s in router_skills
+    ):
+        router_skills.append(skill_root_entry)
+
+    for skill in router_skills:
+        rt_findings = audit_router_table(skill["path"])
+        for level, message in rt_findings:
+            errors.append(f"{level}: {skill['name']} {message}")
+        if not rt_findings and verbose:
+            cap_dir = os.path.join(skill["path"], DIR_CAPABILITIES)
+            if os.path.isdir(cap_dir):
+                print(
+                    f"  ✓ {skill['name']}: router table consistent"
+                )
+            else:
+                print(
+                    f"  - {skill['name']}: standalone (no router)"
                 )
 
     # --- Manifest ---

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -591,17 +591,14 @@ def audit_skill_system(
 
     # Router-table audit is the only per-skill rule that intentionally
     # scans a top-level SKILL.md (skill-root mode).  See
-    # lib.discovery.find_skill_root for the rationale.
+    # lib.discovery.find_skill_root for the rationale.  Registered
+    # skills always live at <system_root>/skills/<name> while a
+    # skill-root entry's path is system_root itself, so the two sets
+    # are disjoint and we can append unconditionally.
     router_skills = list(registered_skills)
     skill_root_entry = find_skill_root(system_root)
     if skill_root_entry is not None:
-        skill_root_path = skill_root_entry["path"]
-        already_listed = any(
-            os.path.abspath(s["path"]) == skill_root_path
-            for s in router_skills
-        )
-        if not already_listed:
-            router_skills.append(skill_root_entry)
+        router_skills.append(skill_root_entry)
 
     for skill in router_skills:
         rt_findings = audit_router_table(skill["path"])

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -363,6 +363,9 @@ def audit_skill_system(
 
     skills_dir = os.path.join(system_root, DIR_SKILLS)
     has_skills_dir = os.path.isdir(skills_dir)
+    has_top_level_skill = os.path.isfile(
+        os.path.join(system_root, FILE_SKILL_MD)
+    )
 
     # Discover components
     skills = find_skill_dirs(system_root)
@@ -376,7 +379,10 @@ def audit_skill_system(
               f"{len(roles)} roles")
         print()
 
-    if not has_skills_dir:
+    # Partial-audit WARN fires only when the audit cannot reach any
+    # skill at all.  In skill-root mode (top-level SKILL.md), the audit
+    # is a first-class single-skill audit — not a partial run.
+    if not has_skills_dir and not has_top_level_skill:
         errors.append(
             f"{LEVEL_WARN}: No {DIR_SKILLS}/ directory under system root — ran partial audit "
             "(distribution-repo mode). Point to deployed system root for full coverage."
@@ -579,10 +585,20 @@ def audit_skill_system(
         print("\n== Manifest ==")
 
     if not has_skills_dir:
-        # No skills/ directory — this is a distribution repo, not a deployed
-        # skill system.  Manifest check is not applicable.
+        # No skills/ directory — either a distribution repo or skill-root
+        # mode (top-level SKILL.md).  Manifest is a deployed-system
+        # concept and is not applicable in either case.
         if verbose:
-            print("  - skipped (no skills/ directory \u2014 not a deployed skill system)")
+            if has_top_level_skill:
+                print(
+                    "  - skipped (skill-root mode \u2014 manifest is a "
+                    "deployed-system concept)"
+                )
+            else:
+                print(
+                    "  - skipped (no skills/ directory \u2014 not a "
+                    "deployed skill system)"
+                )
     else:
         manifest_path = os.path.join(system_root, FILE_MANIFEST)
         if not os.path.exists(manifest_path):

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -4,7 +4,8 @@ Validate the entire skill system structure for consistency.
 
 Checks: spec compliance, dependency direction, role composition,
 manifest consistency, nesting depth, shared resource usage,
-capability entry naming, and structural rules.
+capability entry naming, router-table consistency, and structural
+rules.
 
 Usage:
     python scripts/audit_skill_system.py <system-root> [--verbose]
@@ -19,22 +20,24 @@ Options:
                      roles.
     --json           Output results as machine-readable JSON.
 
-The <system-root> should contain a skills/ directory with skill
-subdirectories. This is the deployed system layout (e.g.,
-.agents/ or a standalone system directory), not the distribution
-repository root. See references/directory-structure.md for the
-expected layout.
+The audit runs in two modes:
 
-If skills/ is missing, the script runs a partial audit and emits a
-warning. Use a deployed system root for full audit coverage.
+* **System-root mode** — <system-root> contains a skills/ directory
+  with skill subdirectories.  This is the deployed system layout
+  (e.g., .agents/ or a standalone system directory).  All per-skill
+  rules iterate skills/<name>/.
+* **Skill-root mode** — <system-root> contains SKILL.md directly,
+  i.e., it is itself a skill (typically the foundry meta-skill or any
+  integrator-built meta-skill).  The router-table consistency rule
+  also fires on this skill.
 
-Note: point this at the deployed system root (the directory
-containing skills/), not at a specific skill directory or
-distribution repository root.
+If neither mode applies (no skills/ and no top-level SKILL.md), the
+script runs a partial audit and emits a warning.
 
 Examples:
     python scripts/audit_skill_system.py /path/to/project/.agents
     python scripts/audit_skill_system.py /path/to/system --verbose
+    python scripts/audit_skill_system.py /path/to/my-meta-skill
     python scripts/audit_skill_system.py /path/to/system --json
 """
 
@@ -704,9 +707,10 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "system_root",
         help=(
-            "Path to the skill system root (contains skills/, roles/). "
-            "This is the deployed system layout, not the distribution "
-            "repository root."
+            "Path to a skill system root (contains skills/, roles/) or "
+            "to a single skill root (contains SKILL.md directly).  "
+            "Skill-root mode triggers the router-table rule on the "
+            "target skill itself."
         ),
     )
     parser.add_argument(

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -592,7 +592,9 @@ def audit_skill_system(
     # Router-table audit is the only per-skill rule that intentionally
     # scans a top-level SKILL.md (skill-root mode) and also reaches
     # capability-bearing directories that find_skill_dirs filters out.
-    # find_router_audit_targets returns the union of those sources.
+    # find_router_audit_targets returns every directory where the rule
+    # could possibly fire (one half or both present); audit_router_table
+    # itself returns [] for the no-router half-case.
     router_skills = find_router_audit_targets(system_root)
 
     for skill in router_skills:
@@ -600,14 +602,15 @@ def audit_skill_system(
         for level, message in rt_findings:
             errors.append(f"{level}: {skill['name']} {message}")
         if not rt_findings and verbose:
-            cap_dir = os.path.join(skill["path"], DIR_CAPABILITIES)
-            if os.path.isdir(cap_dir):
+            # Confirm cleanliness only for actual router skills.  A
+            # registered standalone (SKILL.md, no router, no
+            # capabilities/) returns [] from audit_router_table — there
+            # is nothing to confirm, so stay quiet.
+            if os.path.isdir(
+                os.path.join(skill["path"], DIR_CAPABILITIES)
+            ):
                 print(
                     f"  ✓ {skill['name']}: router table consistent"
-                )
-            else:
-                print(
-                    f"  - {skill['name']}: standalone (no router)"
                 )
 
     # --- Manifest ---

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -28,8 +28,12 @@ The audit runs in two modes:
   rules iterate skills/<name>/.
 * **Skill-root mode** — <system-root> contains SKILL.md directly,
   i.e., it is itself a skill (typically the foundry meta-skill or any
-  integrator-built meta-skill).  The router-table consistency rule
-  also fires on this skill.
+  integrator-built meta-skill).  In this mode the top-level SKILL.md
+  is audited by the router-table consistency rule only; checks that
+  iterate discovered skills (spec compliance, dependency direction,
+  shared resources, capability entry naming, etc.) walk skills/<name>/
+  and do not treat the top-level skill as a discovered skill unless a
+  skills/ directory is also present.
 
 If neither mode applies (no skills/ and no top-level SKILL.md), the
 script runs a partial audit and emits a warning.

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -62,7 +62,7 @@ from lib.reporting import (
 from lib.discovery import (
     find_skill_dirs,
     find_roles,
-    find_skill_root,
+    find_router_audit_targets,
     check_line_count,
     read_file,
 )
@@ -590,33 +590,10 @@ def audit_skill_system(
         print("\n== Router Table ==")
 
     # Router-table audit is the only per-skill rule that intentionally
-    # scans a top-level SKILL.md (skill-root mode).  See
-    # lib.discovery.find_skill_root for the rationale.  Registered
-    # skills always live at <system_root>/skills/<name> while a
-    # skill-root entry's path is system_root itself, so the two sets
-    # are disjoint and we can append unconditionally.
-    router_skills = list(registered_skills)
-    skill_root_entry = find_skill_root(system_root)
-    if skill_root_entry is not None:
-        router_skills.append(skill_root_entry)
-
-    # Also audit directories under skills/ that have capabilities/ but
-    # no SKILL.md.  find_skill_dirs filters these out, so without this
-    # second pass the router-table rule cannot see them — yet the
-    # presence of capabilities/ proves they are meant to be router
-    # skills.  audit_router_table will emit the missing-SKILL.md FAIL.
-    seen_paths = {os.path.abspath(s["path"]) for s in router_skills}
-    if has_skills_dir:
-        for entry in os.listdir(skills_dir):
-            entry_path = os.path.join(skills_dir, entry)
-            if not os.path.isdir(entry_path):
-                continue
-            if os.path.abspath(entry_path) in seen_paths:
-                continue
-            if os.path.isdir(os.path.join(entry_path, DIR_CAPABILITIES)):
-                router_skills.append(
-                    {"name": entry, "path": entry_path, "type": "registered"}
-                )
+    # scans a top-level SKILL.md (skill-root mode) and also reaches
+    # capability-bearing directories that find_skill_dirs filters out.
+    # find_router_audit_targets returns the union of those sources.
+    router_skills = find_router_audit_targets(system_root)
 
     for skill in router_skills:
         rt_findings = audit_router_table(skill["path"])

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -71,6 +71,13 @@ PH_CAPABILITY_NAME = "<capability-name>"
 PH_CAPABILITY_TITLE = "<Capability Name>"
 PH_ROLE_TITLE = "<Role Name>"
 
+# Router Table — structural tokens for the SKILL.md router-table parser
+# (see lib/router_table.py).  Header values are matched after stripping
+# the characters in ROUTER_HEADER_STRIP_CHARS, so authors may decorate
+# the header (e.g., '**Capability**') without breaking discovery.
+ROUTER_HEADERS: tuple[str, str, str] = ("Capability", "Trigger", "Path")
+ROUTER_HEADER_STRIP_CHARS = " *`"
+
 # ===================================================================
 # Validation Rules (loaded from configuration.yaml)
 # ===================================================================

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -74,9 +74,11 @@ PH_ROLE_TITLE = "<Role Name>"
 # Router Table — structural tokens for the SKILL.md router-table parser
 # (see lib/router_table.py).  Header values are matched after stripping
 # the characters in ROUTER_HEADER_STRIP_CHARS, so authors may decorate
-# the header (e.g., '**Capability**') without breaking discovery.
+# the header (e.g., '**Capability**', '_Capability_') without breaking
+# discovery.  Both CommonMark italic forms (``*x*`` and ``_x_``) are
+# accepted.
 ROUTER_HEADERS: tuple[str, str, str] = ("Capability", "Trigger", "Path")
-ROUTER_HEADER_STRIP_CHARS = " *`"
+ROUTER_HEADER_STRIP_CHARS = " *_`"
 
 # ===================================================================
 # Validation Rules (loaded from configuration.yaml)

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -8,59 +8,13 @@ from .constants import (
 )
 
 
-def _collect_capabilities(
-    skill_path: str, parent_name: str,
-) -> list[dict[str, str]]:
-    """Walk ``<skill_path>/capabilities/*`` and return capability entries."""
-    entries: list[dict[str, str]] = []
-    cap_dir = os.path.join(skill_path, DIR_CAPABILITIES)
-    if not os.path.isdir(cap_dir):
-        return entries
-    for cap in os.listdir(cap_dir):
-        cap_path = os.path.join(cap_dir, cap)
-        cap_skill = os.path.join(cap_path, FILE_CAPABILITY_MD)
-        if os.path.isdir(cap_path) and os.path.exists(cap_skill):
-            entries.append(
-                {
-                    "name": cap,
-                    "path": cap_path,
-                    "type": "capability",
-                    "parent": parent_name,
-                }
-            )
-    return entries
-
-
 def find_skill_dirs(system_root: str) -> list[dict[str, str]]:
     """Find all skill and capability directories.
 
     Registered skills contain SKILL.md; capabilities contain capability.md.
-
-    Two discovery modes are supported:
-
-    * **System-root mode** — ``<system_root>/skills/<name>/SKILL.md`` is
-      walked.  This is the deployed-system layout.
-    * **Skill-root mode** — when ``<system_root>/SKILL.md`` exists, the
-      system root itself is registered as a skill.  This lets the audit
-      run against a single skill directory (e.g., the foundry meta-skill
-      or any integrator-built meta-skill) without first deploying it
-      under a ``skills/`` tree.
-
-    Both modes can apply at the same time and their results are
-    concatenated.
+    Walks ``<system_root>/skills/<name>/`` — the deployed-system layout.
     """
-    skills: list[dict[str, str]] = []
-
-    # Skill-root mode: system_root itself is a skill.
-    top_level_skill = os.path.join(system_root, FILE_SKILL_MD)
-    if os.path.isfile(top_level_skill):
-        skill_root_abs = os.path.abspath(system_root)
-        name = os.path.basename(skill_root_abs)
-        skills.append(
-            {"name": name, "path": skill_root_abs, "type": "registered"}
-        )
-        skills.extend(_collect_capabilities(skill_root_abs, name))
-
+    skills = []
     skills_dir = os.path.join(system_root, DIR_SKILLS)
     if not os.path.isdir(skills_dir):
         return skills
@@ -76,9 +30,46 @@ def find_skill_dirs(system_root: str) -> list[dict[str, str]]:
                 {"name": domain, "path": domain_path, "type": "registered"}
             )
 
-        skills.extend(_collect_capabilities(domain_path, domain))
+        # Check for capabilities
+        cap_dir = os.path.join(domain_path, DIR_CAPABILITIES)
+        if os.path.isdir(cap_dir):
+            for cap in os.listdir(cap_dir):
+                cap_path = os.path.join(cap_dir, cap)
+                cap_skill = os.path.join(cap_path, FILE_CAPABILITY_MD)
+                if os.path.isdir(cap_path) and os.path.exists(cap_skill):
+                    skills.append(
+                        {
+                            "name": cap,
+                            "path": cap_path,
+                            "type": "capability",
+                            "parent": domain,
+                        }
+                    )
 
     return skills
+
+
+def find_skill_root(system_root: str) -> dict[str, str] | None:
+    """Return a synthetic registered-skill entry when SKILL.md sits at *system_root*.
+
+    This complements ``find_skill_dirs`` for the *skill-root mode* —
+    auditing a single skill directory (the foundry meta-skill or any
+    integrator-built meta-skill) without first deploying it under a
+    ``skills/`` tree.
+
+    Used by rules that are intentionally meta-skill-aware (currently the
+    router-table consistency rule).  Other per-skill rules continue to
+    iterate ``find_skill_dirs`` only, because their pre-existing
+    heuristics were not designed to scan meta-skill prose.
+    """
+    if not os.path.isfile(os.path.join(system_root, FILE_SKILL_MD)):
+        return None
+    skill_root_abs = os.path.abspath(system_root)
+    return {
+        "name": os.path.basename(skill_root_abs),
+        "path": skill_root_abs,
+        "type": "registered",
+    }
 
 
 def find_roles(system_root: str) -> list[dict[str, str]]:

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -7,6 +7,7 @@ from .constants import (
     DIR_SKILLS, DIR_CAPABILITIES, DIR_ROLES,
     FILE_SKILL_MD, FILE_CAPABILITY_MD, FILE_README, EXT_MARKDOWN,
 )
+from .frontmatter import load_frontmatter
 
 
 class _SkillCandidate(NamedTuple):
@@ -94,21 +95,28 @@ def _top_level_skill_entry(system_root: str) -> dict[str, str] | None:
     ``skills/`` tree.  Only consumed by ``find_router_audit_targets``;
     promote to public when a second caller appears.
 
-    The returned ``name`` is the basename of the absolute path, not the
-    skill's declared frontmatter name.  Running the audit from a
-    worktree directory (e.g., ``worktrees/feature-foo/``) therefore
-    produces findings prefixed with the worktree name.  Reading
-    frontmatter would require pulling the parser into discovery; the
-    directory-derived name is good enough for log prefixes.
+    The returned ``name`` prefers the SKILL.md frontmatter ``name`` so
+    findings are prefixed with the canonical skill name even when the
+    audit runs from a worktree or renamed directory (e.g.,
+    ``worktrees/feature-foo/``).  Falls back to the absolute-path
+    basename when the frontmatter is unreadable, missing, or has no
+    ``name`` field, so the prefix degrades gracefully rather than
+    blocking the audit.
     """
-    if not os.path.isfile(os.path.join(system_root, FILE_SKILL_MD)):
+    skill_md = os.path.join(system_root, FILE_SKILL_MD)
+    if not os.path.isfile(skill_md):
         return None
-    # Compute name from the absolute path so callers passing "." still
-    # get a real directory name, but keep ``path`` as the input shape so
-    # it matches ``find_skill_dirs`` (which returns paths derived from
-    # the caller's ``system_root``).
+    name = os.path.basename(os.path.abspath(system_root))
+    try:
+        fm, _, _ = load_frontmatter(skill_md)
+    except OSError:
+        fm = None
+    if fm is not None and "_parse_error" not in fm:
+        fm_name = fm.get("name")
+        if isinstance(fm_name, str) and fm_name.strip():
+            name = fm_name.strip()
     return {
-        "name": os.path.basename(os.path.abspath(system_root)),
+        "name": name,
         "path": system_root,
         "type": "registered",
     }

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -93,6 +93,13 @@ def _top_level_skill_entry(system_root: str) -> dict[str, str] | None:
     integrator-built meta-skill) without first deploying it under a
     ``skills/`` tree.  Only consumed by ``find_router_audit_targets``;
     promote to public when a second caller appears.
+
+    The returned ``name`` is the basename of the absolute path, not the
+    skill's declared frontmatter name.  Running the audit from a
+    worktree directory (e.g., ``worktrees/feature-foo/``) therefore
+    produces findings prefixed with the worktree name.  Reading
+    frontmatter would require pulling the parser into discovery; the
+    directory-derived name is good enough for log prefixes.
     """
     if not os.path.isfile(os.path.join(system_root, FILE_SKILL_MD)):
         return None

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -96,10 +96,13 @@ def find_skill_root(system_root: str) -> dict[str, str] | None:
     """
     if not os.path.isfile(os.path.join(system_root, FILE_SKILL_MD)):
         return None
-    skill_root_abs = os.path.abspath(system_root)
+    # Compute name from the absolute path so callers passing "." still
+    # get a real directory name, but keep ``path`` as the input shape so
+    # it matches ``find_skill_dirs`` (which returns paths derived from
+    # the caller's ``system_root``).
     return {
-        "name": os.path.basename(skill_root_abs),
-        "path": skill_root_abs,
+        "name": os.path.basename(os.path.abspath(system_root)),
+        "path": system_root,
         "type": "registered",
     }
 

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -81,18 +81,14 @@ def find_skill_dirs(system_root: str) -> list[dict[str, str]]:
     return skills
 
 
-def find_skill_root(system_root: str) -> dict[str, str] | None:
+def _top_level_skill_entry(system_root: str) -> dict[str, str] | None:
     """Return a synthetic registered-skill entry when SKILL.md sits at *system_root*.
 
-    This complements ``find_skill_dirs`` for the *skill-root mode* —
-    auditing a single skill directory (the foundry meta-skill or any
+    Complements ``find_skill_dirs`` for the *skill-root mode* — auditing
+    a single skill directory (the foundry meta-skill or any
     integrator-built meta-skill) without first deploying it under a
-    ``skills/`` tree.
-
-    Used by rules that are intentionally meta-skill-aware (currently the
-    router-table consistency rule).  Other per-skill rules continue to
-    iterate ``find_skill_dirs`` only, because their pre-existing
-    heuristics were not designed to scan meta-skill prose.
+    ``skills/`` tree.  Only consumed by ``find_router_audit_targets``;
+    promote to public when a second caller appears.
     """
     if not os.path.isfile(os.path.join(system_root, FILE_SKILL_MD)):
         return None
@@ -148,7 +144,7 @@ def find_router_audit_targets(system_root: str) -> list[dict[str, str]]:
             "type": "registered",
         })
 
-    skill_root_entry = find_skill_root(system_root)
+    skill_root_entry = _top_level_skill_entry(system_root)
     if skill_root_entry is not None:
         targets.append(skill_root_entry)
 

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -150,10 +150,19 @@ def find_router_audit_targets(system_root: str) -> list[dict[str, str]]:
     ``capabilities/`` and without a router table simply returns ``[]``.
 
     Returned entries match the ``find_skill_dirs`` shape (``name``,
-    ``path``, ``type=registered``).  The skill-root entry (when
-    present) cannot collide with a ``skills/`` candidate because the
-    candidate iterator only walks ``<system_root>/skills/<entry>``,
-    never ``<system_root>`` itself — so no dedup is needed.
+    ``path``, ``type=registered``).  Appending the skill-root entry
+    (when present) cannot duplicate a ``skills/`` candidate's
+    ``path`` because the candidate iterator only walks
+    ``<system_root>/skills/<entry>``, never ``<system_root>``
+    itself — so no path-level dedup is needed and the same directory
+    is never audited twice.  Names may still overlap (e.g., a
+    top-level SKILL.md whose frontmatter ``name`` is ``alpha`` next
+    to a ``skills/alpha/`` candidate); each target is audited
+    independently because ``path`` is the dispatch key, but the
+    finding prefix derived from ``name`` will be ambiguous in that
+    pathological case.  Integrators are expected to keep the
+    meta-skill's frontmatter name distinct from any deployed skill
+    under ``skills/``.
     """
     skills_dir = os.path.join(system_root, DIR_SKILLS)
     targets: list[dict[str, str]] = []

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -24,7 +24,11 @@ class _SkillCandidate(NamedTuple):
 def _iter_skill_candidates(skills_dir: str) -> list[_SkillCandidate]:
     """One pass over ``<skills_dir>/<entry>``.
 
-    Returns one entry per immediate subdirectory.  Returns ``[]`` when
+    Returns one entry per immediate subdirectory, sorted by name so
+    findings emitted by downstream rules (notably the router-table
+    audit, which produces per-row findings) stay stable across
+    platforms — ``os.listdir`` order is filesystem-defined and
+    differs between APFS, ext4, and NTFS.  Returns ``[]`` when
     *skills_dir* is missing.  This is the single source of truth for
     "what is a skill candidate"; both ``find_skill_dirs`` and
     ``find_router_audit_targets`` consume it.
@@ -32,7 +36,7 @@ def _iter_skill_candidates(skills_dir: str) -> list[_SkillCandidate]:
     if not os.path.isdir(skills_dir):
         return []
     candidates: list[_SkillCandidate] = []
-    for entry in os.listdir(skills_dir):
+    for entry in sorted(os.listdir(skills_dir)):
         entry_path = os.path.join(skills_dir, entry)
         if not os.path.isdir(entry_path):
             continue

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -8,31 +8,58 @@ from .constants import (
 )
 
 
+def _iter_skill_candidates(skills_dir: str) -> list[dict[str, bool | str]]:
+    """One pass over ``<skills_dir>/<entry>``.
+
+    Returns one entry per immediate subdirectory, annotated with which
+    of the two router halves are present:
+
+    * ``has_skill_md`` — ``SKILL.md`` exists at the top of the entry.
+    * ``has_capabilities`` — ``capabilities/`` exists at the top of the
+      entry.
+
+    Returns ``[]`` when *skills_dir* is missing.  This is the single
+    source of truth for "what is a skill candidate"; both
+    ``find_skill_dirs`` and ``find_router_audit_targets`` consume it.
+    """
+    if not os.path.isdir(skills_dir):
+        return []
+    candidates: list[dict[str, bool | str]] = []
+    for entry in os.listdir(skills_dir):
+        entry_path = os.path.join(skills_dir, entry)
+        if not os.path.isdir(entry_path):
+            continue
+        candidates.append({
+            "name": entry,
+            "path": entry_path,
+            "has_skill_md": os.path.isfile(
+                os.path.join(entry_path, FILE_SKILL_MD)
+            ),
+            "has_capabilities": os.path.isdir(
+                os.path.join(entry_path, DIR_CAPABILITIES)
+            ),
+        })
+    return candidates
+
+
 def find_skill_dirs(system_root: str) -> list[dict[str, str]]:
     """Find all skill and capability directories.
 
     Registered skills contain SKILL.md; capabilities contain capability.md.
     Walks ``<system_root>/skills/<name>/`` — the deployed-system layout.
     """
-    skills = []
+    skills: list[dict[str, str]] = []
     skills_dir = os.path.join(system_root, DIR_SKILLS)
-    if not os.path.isdir(skills_dir):
-        return skills
-
-    for domain in os.listdir(skills_dir):
-        domain_path = os.path.join(skills_dir, domain)
-        if not os.path.isdir(domain_path):
-            continue
-
-        skill_md = os.path.join(domain_path, FILE_SKILL_MD)
-        if os.path.exists(skill_md):
+    for cand in _iter_skill_candidates(skills_dir):
+        domain = cand["name"]
+        domain_path = cand["path"]
+        if cand["has_skill_md"]:
             skills.append(
                 {"name": domain, "path": domain_path, "type": "registered"}
             )
 
-        # Check for capabilities
-        cap_dir = os.path.join(domain_path, DIR_CAPABILITIES)
-        if os.path.isdir(cap_dir):
+        if cand["has_capabilities"]:
+            cap_dir = os.path.join(domain_path, DIR_CAPABILITIES)
             for cap in os.listdir(cap_dir):
                 cap_path = os.path.join(cap_dir, cap)
                 cap_skill = os.path.join(cap_path, FILE_CAPABILITY_MD)
@@ -75,45 +102,49 @@ def find_skill_root(system_root: str) -> dict[str, str] | None:
 def find_router_audit_targets(system_root: str) -> list[dict[str, str]]:
     """Return every directory the router-table rule should audit.
 
-    Combines three sources, in the following priority:
+    A directory is a router-audit target when it has at least one half
+    of the router contract — ``SKILL.md`` exists at the top, or
+    ``capabilities/`` exists on disk.  Directories with neither
+    (typically empty placeholders) are dropped.
 
-    1. Registered skills under ``<system_root>/skills/<name>/`` (those
-       that have a ``SKILL.md``) — from ``find_skill_dirs``.
-    2. The skill-root entry — present when ``<system_root>/SKILL.md``
-       exists (skill-root mode for meta-skills).
-    3. Capability-bearing directories under ``<system_root>/skills/``
-       that are missing ``SKILL.md`` — ``find_skill_dirs`` filters these
-       out, but the presence of ``capabilities/`` proves they were meant
-       to be router skills, so the router-table rule needs to see them.
+    Sources:
 
-    The returned entries are in the same shape as ``find_skill_dirs``
-    items (``name``, ``path``, ``type=registered``).  Paths are
-    deduplicated by absolute path, so each directory is audited at most
-    once.
+    1. Subdirectories of ``<system_root>/skills/`` that have
+       ``SKILL.md`` and/or ``capabilities/``.  This subsumes both
+       registered skills (caught by the ``SKILL.md`` half) and orphan
+       capability-only directories (caught by the ``capabilities/``
+       half) in a single pass.
+    2. The skill-root entry — included whenever
+       ``<system_root>/SKILL.md`` exists (skill-root mode for
+       meta-skills).
+
+    ``audit_router_table`` itself decides whether the rule actually
+    applies to each target — a registered skill without
+    ``capabilities/`` and without a router table simply returns ``[]``.
+
+    Returned entries match the ``find_skill_dirs`` shape (``name``,
+    ``path``, ``type=registered``).  Paths are deduplicated by absolute
+    path.
     """
     skills_dir = os.path.join(system_root, DIR_SKILLS)
-    has_skills_dir = os.path.isdir(skills_dir)
+    targets: list[dict[str, str]] = []
+    seen_paths: set[str] = set()
 
-    targets: list[dict[str, str]] = [
-        s for s in find_skill_dirs(system_root) if s["type"] == "registered"
-    ]
+    for cand in _iter_skill_candidates(skills_dir):
+        if not (cand["has_skill_md"] or cand["has_capabilities"]):
+            continue
+        abs_path = os.path.abspath(cand["path"])
+        seen_paths.add(abs_path)
+        targets.append({
+            "name": str(cand["name"]),
+            "path": str(cand["path"]),
+            "type": "registered",
+        })
 
     skill_root_entry = find_skill_root(system_root)
     if skill_root_entry is not None:
-        targets.append(skill_root_entry)
-
-    seen_paths = {os.path.abspath(t["path"]) for t in targets}
-    if has_skills_dir:
-        for entry in os.listdir(skills_dir):
-            entry_path = os.path.join(skills_dir, entry)
-            if not os.path.isdir(entry_path):
-                continue
-            if os.path.abspath(entry_path) in seen_paths:
-                continue
-            if os.path.isdir(os.path.join(entry_path, DIR_CAPABILITIES)):
-                targets.append(
-                    {"name": entry, "path": entry_path, "type": "registered"}
-                )
+        if skill_root_entry["path"] not in seen_paths:
+            targets.append(skill_root_entry)
 
     return targets
 

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -72,6 +72,52 @@ def find_skill_root(system_root: str) -> dict[str, str] | None:
     }
 
 
+def find_router_audit_targets(system_root: str) -> list[dict[str, str]]:
+    """Return every directory the router-table rule should audit.
+
+    Combines three sources, in the following priority:
+
+    1. Registered skills under ``<system_root>/skills/<name>/`` (those
+       that have a ``SKILL.md``) — from ``find_skill_dirs``.
+    2. The skill-root entry — present when ``<system_root>/SKILL.md``
+       exists (skill-root mode for meta-skills).
+    3. Capability-bearing directories under ``<system_root>/skills/``
+       that are missing ``SKILL.md`` — ``find_skill_dirs`` filters these
+       out, but the presence of ``capabilities/`` proves they were meant
+       to be router skills, so the router-table rule needs to see them.
+
+    The returned entries are in the same shape as ``find_skill_dirs``
+    items (``name``, ``path``, ``type=registered``).  Paths are
+    deduplicated by absolute path, so each directory is audited at most
+    once.
+    """
+    skills_dir = os.path.join(system_root, DIR_SKILLS)
+    has_skills_dir = os.path.isdir(skills_dir)
+
+    targets: list[dict[str, str]] = [
+        s for s in find_skill_dirs(system_root) if s["type"] == "registered"
+    ]
+
+    skill_root_entry = find_skill_root(system_root)
+    if skill_root_entry is not None:
+        targets.append(skill_root_entry)
+
+    seen_paths = {os.path.abspath(t["path"]) for t in targets}
+    if has_skills_dir:
+        for entry in os.listdir(skills_dir):
+            entry_path = os.path.join(skills_dir, entry)
+            if not os.path.isdir(entry_path):
+                continue
+            if os.path.abspath(entry_path) in seen_paths:
+                continue
+            if os.path.isdir(os.path.join(entry_path, DIR_CAPABILITIES)):
+                targets.append(
+                    {"name": entry, "path": entry_path, "type": "registered"}
+                )
+
+    return targets
+
+
 def find_roles(system_root: str) -> list[dict[str, str]]:
     """Find all role files."""
     roles = []

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -70,7 +70,11 @@ def find_skill_dirs(system_root: str) -> list[dict[str, str]]:
 
         if cand.has_capabilities:
             cap_dir = os.path.join(cand.path, DIR_CAPABILITIES)
-            for cap in os.listdir(cap_dir):
+            # ``os.listdir`` order is filesystem-defined and differs
+            # between APFS, ext4, and NTFS — sort so downstream audit
+            # output (and any caller iterating the returned list) is
+            # deterministic, matching the skill-candidate sort above.
+            for cap in sorted(os.listdir(cap_dir)):
                 cap_path = os.path.join(cap_dir, cap)
                 cap_skill = os.path.join(cap_path, FILE_CAPABILITY_MD)
                 if os.path.isdir(cap_path) and os.path.exists(cap_skill):

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -1,6 +1,7 @@
 """Component discovery: find skills and roles in a skill system."""
 
 import os
+from typing import NamedTuple
 
 from .constants import (
     DIR_SKILLS, DIR_CAPABILITIES, DIR_ROLES,
@@ -8,37 +9,43 @@ from .constants import (
 )
 
 
-def _iter_skill_candidates(skills_dir: str) -> list[dict[str, bool | str]]:
+class _SkillCandidate(NamedTuple):
+    """One immediate subdirectory of a ``skills/`` tree.
+
+    ``has_skill_md`` and ``has_capabilities`` flag which halves of the
+    router contract are present on disk.
+    """
+    name: str
+    path: str
+    has_skill_md: bool
+    has_capabilities: bool
+
+
+def _iter_skill_candidates(skills_dir: str) -> list[_SkillCandidate]:
     """One pass over ``<skills_dir>/<entry>``.
 
-    Returns one entry per immediate subdirectory, annotated with which
-    of the two router halves are present:
-
-    * ``has_skill_md`` — ``SKILL.md`` exists at the top of the entry.
-    * ``has_capabilities`` — ``capabilities/`` exists at the top of the
-      entry.
-
-    Returns ``[]`` when *skills_dir* is missing.  This is the single
-    source of truth for "what is a skill candidate"; both
-    ``find_skill_dirs`` and ``find_router_audit_targets`` consume it.
+    Returns one entry per immediate subdirectory.  Returns ``[]`` when
+    *skills_dir* is missing.  This is the single source of truth for
+    "what is a skill candidate"; both ``find_skill_dirs`` and
+    ``find_router_audit_targets`` consume it.
     """
     if not os.path.isdir(skills_dir):
         return []
-    candidates: list[dict[str, bool | str]] = []
+    candidates: list[_SkillCandidate] = []
     for entry in os.listdir(skills_dir):
         entry_path = os.path.join(skills_dir, entry)
         if not os.path.isdir(entry_path):
             continue
-        candidates.append({
-            "name": entry,
-            "path": entry_path,
-            "has_skill_md": os.path.isfile(
+        candidates.append(_SkillCandidate(
+            name=entry,
+            path=entry_path,
+            has_skill_md=os.path.isfile(
                 os.path.join(entry_path, FILE_SKILL_MD)
             ),
-            "has_capabilities": os.path.isdir(
+            has_capabilities=os.path.isdir(
                 os.path.join(entry_path, DIR_CAPABILITIES)
             ),
-        })
+        ))
     return candidates
 
 
@@ -51,15 +58,13 @@ def find_skill_dirs(system_root: str) -> list[dict[str, str]]:
     skills: list[dict[str, str]] = []
     skills_dir = os.path.join(system_root, DIR_SKILLS)
     for cand in _iter_skill_candidates(skills_dir):
-        domain = cand["name"]
-        domain_path = cand["path"]
-        if cand["has_skill_md"]:
+        if cand.has_skill_md:
             skills.append(
-                {"name": domain, "path": domain_path, "type": "registered"}
+                {"name": cand.name, "path": cand.path, "type": "registered"}
             )
 
-        if cand["has_capabilities"]:
-            cap_dir = os.path.join(domain_path, DIR_CAPABILITIES)
+        if cand.has_capabilities:
+            cap_dir = os.path.join(cand.path, DIR_CAPABILITIES)
             for cap in os.listdir(cap_dir):
                 cap_path = os.path.join(cap_dir, cap)
                 cap_skill = os.path.join(cap_path, FILE_CAPABILITY_MD)
@@ -69,7 +74,7 @@ def find_skill_dirs(system_root: str) -> list[dict[str, str]]:
                             "name": cap,
                             "path": cap_path,
                             "type": "capability",
-                            "parent": domain,
+                            "parent": cand.name,
                         }
                     )
 
@@ -123,28 +128,26 @@ def find_router_audit_targets(system_root: str) -> list[dict[str, str]]:
     ``capabilities/`` and without a router table simply returns ``[]``.
 
     Returned entries match the ``find_skill_dirs`` shape (``name``,
-    ``path``, ``type=registered``).  Paths are deduplicated by absolute
-    path.
+    ``path``, ``type=registered``).  The skill-root entry (when
+    present) cannot collide with a ``skills/`` candidate because the
+    candidate iterator only walks ``<system_root>/skills/<entry>``,
+    never ``<system_root>`` itself — so no dedup is needed.
     """
     skills_dir = os.path.join(system_root, DIR_SKILLS)
     targets: list[dict[str, str]] = []
-    seen_paths: set[str] = set()
 
     for cand in _iter_skill_candidates(skills_dir):
-        if not (cand["has_skill_md"] or cand["has_capabilities"]):
+        if not (cand.has_skill_md or cand.has_capabilities):
             continue
-        abs_path = os.path.abspath(cand["path"])
-        seen_paths.add(abs_path)
         targets.append({
-            "name": str(cand["name"]),
-            "path": str(cand["path"]),
+            "name": cand.name,
+            "path": cand.path,
             "type": "registered",
         })
 
     skill_root_entry = find_skill_root(system_root)
     if skill_root_entry is not None:
-        if skill_root_entry["path"] not in seen_paths:
-            targets.append(skill_root_entry)
+        targets.append(skill_root_entry)
 
     return targets
 

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -166,6 +166,20 @@ def find_router_audit_targets(system_root: str) -> list[dict[str, str]]:
     skill_root_entry = _top_level_skill_entry(system_root)
     if skill_root_entry is not None:
         targets.append(skill_root_entry)
+    elif os.path.isdir(os.path.join(system_root, DIR_CAPABILITIES)):
+        # SKILL.md is missing but capabilities/ sits at the top —
+        # the canonical "broken meta-skill" shape (entry point
+        # deleted, on-disk tree left behind).  Without this branch
+        # the audit only emits the generic partial-audit WARN; with
+        # it, audit_router_table fires the specific
+        # ``capabilities/ exists but SKILL.md is missing`` FAIL.
+        # Fall back to the basename for the finding prefix because
+        # there is no SKILL.md frontmatter to canonicalize.
+        targets.append({
+            "name": os.path.basename(os.path.abspath(system_root)),
+            "path": system_root,
+            "type": "registered",
+        })
 
     return targets
 

--- a/skill-system-foundry/scripts/lib/discovery.py
+++ b/skill-system-foundry/scripts/lib/discovery.py
@@ -8,12 +8,59 @@ from .constants import (
 )
 
 
+def _collect_capabilities(
+    skill_path: str, parent_name: str,
+) -> list[dict[str, str]]:
+    """Walk ``<skill_path>/capabilities/*`` and return capability entries."""
+    entries: list[dict[str, str]] = []
+    cap_dir = os.path.join(skill_path, DIR_CAPABILITIES)
+    if not os.path.isdir(cap_dir):
+        return entries
+    for cap in os.listdir(cap_dir):
+        cap_path = os.path.join(cap_dir, cap)
+        cap_skill = os.path.join(cap_path, FILE_CAPABILITY_MD)
+        if os.path.isdir(cap_path) and os.path.exists(cap_skill):
+            entries.append(
+                {
+                    "name": cap,
+                    "path": cap_path,
+                    "type": "capability",
+                    "parent": parent_name,
+                }
+            )
+    return entries
+
+
 def find_skill_dirs(system_root: str) -> list[dict[str, str]]:
     """Find all skill and capability directories.
 
     Registered skills contain SKILL.md; capabilities contain capability.md.
+
+    Two discovery modes are supported:
+
+    * **System-root mode** — ``<system_root>/skills/<name>/SKILL.md`` is
+      walked.  This is the deployed-system layout.
+    * **Skill-root mode** — when ``<system_root>/SKILL.md`` exists, the
+      system root itself is registered as a skill.  This lets the audit
+      run against a single skill directory (e.g., the foundry meta-skill
+      or any integrator-built meta-skill) without first deploying it
+      under a ``skills/`` tree.
+
+    Both modes can apply at the same time and their results are
+    concatenated.
     """
-    skills = []
+    skills: list[dict[str, str]] = []
+
+    # Skill-root mode: system_root itself is a skill.
+    top_level_skill = os.path.join(system_root, FILE_SKILL_MD)
+    if os.path.isfile(top_level_skill):
+        skill_root_abs = os.path.abspath(system_root)
+        name = os.path.basename(skill_root_abs)
+        skills.append(
+            {"name": name, "path": skill_root_abs, "type": "registered"}
+        )
+        skills.extend(_collect_capabilities(skill_root_abs, name))
+
     skills_dir = os.path.join(system_root, DIR_SKILLS)
     if not os.path.isdir(skills_dir):
         return skills
@@ -29,21 +76,7 @@ def find_skill_dirs(system_root: str) -> list[dict[str, str]]:
                 {"name": domain, "path": domain_path, "type": "registered"}
             )
 
-        # Check for capabilities
-        cap_dir = os.path.join(domain_path, DIR_CAPABILITIES)
-        if os.path.isdir(cap_dir):
-            for cap in os.listdir(cap_dir):
-                cap_path = os.path.join(cap_dir, cap)
-                cap_skill = os.path.join(cap_path, FILE_CAPABILITY_MD)
-                if os.path.isdir(cap_path) and os.path.exists(cap_skill):
-                    skills.append(
-                        {
-                            "name": cap,
-                            "path": cap_path,
-                            "type": "capability",
-                            "parent": domain,
-                        }
-                    )
+        skills.extend(_collect_capabilities(domain_path, domain))
 
     return skills
 

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -136,6 +136,7 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
 
     Failure modes (all FAIL):
 
+    * ``capabilities/`` exists but ``SKILL.md`` is missing.
     * ``capabilities/`` exists but ``SKILL.md`` has no router-shaped
       table.
     * A router row's Path cell is not the literal
@@ -153,9 +154,14 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
 
     skill_md = os.path.join(skill_path, FILE_SKILL_MD)
     if not os.path.isfile(skill_md):
-        # The missing-SKILL.md case is reported by other rules; do not
-        # double-flag here.
-        return []
+        # find_skill_dirs silently drops directories without SKILL.md,
+        # so no other rule reaches this case.  Flag it here; the
+        # presence of capabilities/ proves the directory is meant to be
+        # a router skill.
+        return [(
+            LEVEL_FAIL,
+            f"has {DIR_CAPABILITIES}/ but no {FILE_SKILL_MD}",
+        )]
 
     with open(skill_md, "r", encoding="utf-8") as fh:
         # Pass the full content; YAML frontmatter delimiters ('---') are

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -141,7 +141,12 @@ def _is_separator_row(cells: list[str]) -> bool:
 
 
 def _normalize_header_cell(cell: str) -> str:
-    """Strip ``*``, backticks, and surrounding whitespace from a header cell."""
+    """Strip emphasis markers, backticks, and whitespace from a header cell.
+
+    The strip set covers both CommonMark italic forms (``*x*`` and
+    ``_x_``), bold (``**x**``), and inline code (``` `x` ```).  See
+    ``ROUTER_HEADER_STRIP_CHARS`` in ``constants.py``.
+    """
     return cell.strip().strip(ROUTER_HEADER_STRIP_CHARS).strip()
 
 

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -254,22 +254,22 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
     skill name when surfacing findings.  Do not embed the skill name
     into the messages here.
 
-    Failure modes (all FAIL):
+    Failure modes (all FAIL), in emission order:
 
     * ``capabilities/`` exists but ``SKILL.md`` is missing.
-    * ``SKILL.md`` has a router table but ``capabilities/`` is missing.
     * ``capabilities/`` exists but ``SKILL.md`` has no router-shaped
       table.
+    * ``SKILL.md`` has a router table but ``capabilities/`` is missing.
     * A row inside the router table is structurally malformed (wrong
       number of columns).  Subsequent valid rows are still parsed.
-    * Two rows declare the same capability segment (duplicate router
-      entry).
     * A router row's Path cell is not the literal
       ``capabilities/<name>/capability.md``.
     * A router row's Capability cell does not equal the ``<name>``
       segment of its Path cell.  The path segment is still recorded as
       "declared" so the orphan check does not double-flag the on-disk
       directory.
+    * Two rows declare the same capability segment (duplicate router
+      entry).
     * A router row's Path does not resolve to an existing
       ``capability.md``.
     * A capability subdirectory has a ``capability.md`` but no

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -46,16 +46,28 @@ def _strip_fenced_regions(body: str) -> str:
     Keeps line numbers stable so error messages from upstream tooling
     still line up, while ensuring fenced documentation examples cannot
     shadow the canonical router table (first-table-wins).
+
+    Recognizes both backtick (```` ``` ````) and tilde (``~~~``)
+    CommonMark fences.  A fence is closed by a marker of the same
+    family — opening with ```` ``` ```` and closing with ``~~~`` is
+    not balanced and would leave the rest of the document treated as
+    fenced.
     """
     lines = body.splitlines()
-    in_fence = False
+    fence_marker: str | None = None
     out: list[str] = []
     for line in lines:
-        if line.lstrip().startswith("```"):
-            in_fence = not in_fence
+        stripped = line.lstrip()
+        if fence_marker is None:
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                fence_marker = stripped[:3]
+                out.append("")
+                continue
+            out.append(line)
+        else:
+            if stripped.startswith(fence_marker):
+                fence_marker = None
             out.append("")
-            continue
-        out.append("" if in_fence else line)
     return "\n".join(out)
 
 
@@ -241,9 +253,7 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
             findings.append((
                 LEVEL_FAIL,
                 f"router row '{capability}' has malformed Path '{path}' "
-                f"(expected literal '{DIR_CAPABILITIES}/<name>/{FILE_CAPABILITY_MD}'"
-                " — Path is parsed literally, no backticks, links, fragments,"
-                " or leading './'; header formatting is tolerated, path is not)",
+                f"(expected literal '{DIR_CAPABILITIES}/<name>/{FILE_CAPABILITY_MD}')",
             ))
             continue
         if capability != segment:

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -277,7 +277,7 @@ def _scan_extra_router_tables(
                 if sep_cells is not None and _is_separator_row(sep_cells):
                     findings.append((
                         LEVEL_WARN,
-                        f"second router-shaped table found at line "
+                        f"additional router-shaped table found at line "
                         f"{k + 1}; only the first is audited — "
                         f"consolidate or remove the extra table",
                     ))
@@ -375,10 +375,13 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
     * (FAIL) A row inside the router table is structurally malformed
       (wrong number of columns).  Subsequent valid rows are still
       parsed.
-    * (WARN) A second canonical-headed router table appears in
-      ``SKILL.md``.  Only the first is audited; the warning directs
-      the author to consolidate.  Emitted before per-row checks so it
-      precedes findings that originate from the parsed (first) table.
+    * (WARN) A second (or later) canonical-headed router table appears
+      in ``SKILL.md``.  Only the first is audited; the warning directs
+      the author to consolidate.  Emitted before the per-row audit
+      checks (empty Trigger, malformed Path, duplicate row, missing
+      target, orphan directory) — parse-row malformation FAILs from
+      the first table still appear ahead of the WARN because they are
+      emitted by ``parse_router_table`` itself.
     * (FAIL) A router row's Trigger cell is empty.  Trigger content is
       otherwise opaque, but emptiness is a structural failure (a
       half-edited row).
@@ -415,7 +418,9 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
             f"{DIR_CAPABILITIES}/ exists but {FILE_SKILL_MD} is missing",
         )]
 
-    parsed: tuple[list[tuple[str, str, str]], list[str]] | None = None
+    parsed: tuple[
+        list[tuple[str, str, str]], list[tuple[str, str]]
+    ] | None = None
     if has_skill_md:
         with open(skill_md, "r", encoding="utf-8") as fh:
             content = fh.read()

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -158,10 +158,8 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
         return []
 
     with open(skill_md, "r", encoding="utf-8") as fh:
-        # Read body only — frontmatter cannot contain a router table.
-        # We intentionally pass the full content to ``parse_router_table``
-        # because the frontmatter delimiters ('---') are not pipe rows
-        # and won't be mistaken for a header.
+        # Pass the full content; YAML frontmatter delimiters ('---') are
+        # not pipe rows and cannot be mistaken for a router header.
         content = fh.read()
 
     rows = parse_router_table(content)
@@ -213,7 +211,8 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
     for orphan in sorted(on_disk - declared):
         findings.append((
             LEVEL_FAIL,
-            f"{DIR_CAPABILITIES}/{orphan}/ has no matching router row",
+            f"{DIR_CAPABILITIES}/{orphan}/ has no matching router row "
+            f"(expected Path '{expected_path(orphan)}')",
         ))
 
     return findings

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -32,6 +32,7 @@ from .constants import (
     FILE_CAPABILITY_MD,
     FILE_SKILL_MD,
     LEVEL_FAIL,
+    LEVEL_WARN,
     ROUTER_HEADERS,
     ROUTER_HEADER_STRIP_CHARS,
 )
@@ -171,22 +172,32 @@ def _is_router_header(cells: list[str]) -> bool:
 
 def parse_router_table(
     body: str,
-) -> tuple[list[tuple[str, str, str]], list[str]] | None:
+) -> tuple[list[tuple[str, str, str]], list[tuple[str, str]]] | None:
     """Return rows of the first router-shaped table in *body*.
 
-    Returns ``(rows, parse_errors)`` where ``rows`` is a list of
+    Returns ``(rows, findings)`` where ``rows`` is a list of
     ``(capability, trigger, path)`` tuples with each cell stripped, and
-    ``parse_errors`` is a list of human-readable messages for rows that
-    were structurally malformed (e.g., wrong column count) but appeared
-    inside the table region.  Returns ``None`` if no Markdown table
-    whose header is exactly ``Capability | Trigger | Path`` (after
-    stripping ``*``, backticks, and whitespace) appears in *body*.
+    ``findings`` is a list of ``(level, message)`` tuples — ``LEVEL_FAIL``
+    for structural row malformations inside the matched table, and
+    ``LEVEL_WARN`` when a second canonical-headed table is found later
+    in the body.  Returns ``None`` if no Markdown table whose header is
+    exactly ``Capability | Trigger | Path`` (after stripping ``*``,
+    backticks, and whitespace) appears in *body*.
 
     Mid-table rows whose column count differs from the header are
-    recorded in ``parse_errors`` and skipped, but scanning continues
-    so trailing valid rows still appear in ``rows``.  This prevents a
+    recorded as FAIL findings and skipped, but scanning continues so
+    trailing valid rows still appear in ``rows``.  This prevents a
     single malformed row from masking valid ones (and producing
     misleading orphan errors downstream).
+
+    Only the first router-shaped table is parsed (first-table-wins),
+    but the rest of the body is scanned for additional canonical
+    headers paired with valid separator rows.  Each additional table
+    emits a ``LEVEL_WARN`` finding pointing to its line number — the
+    audit was designed to catch drift, and a silently ignored second
+    table is exactly the failure mode that defeats it.  The parser
+    deliberately does not parse rows from the second table; the warning
+    is enough to direct the author to consolidate.
 
     Fenced code blocks are stripped before scanning so a documentation
     example in a ```` ```markdown ```` block cannot shadow the canonical
@@ -211,27 +222,59 @@ def parse_router_table(
                 i += 1
                 continue
             rows: list[tuple[str, str, str]] = []
-            parse_errors: list[str] = []
+            findings: list[tuple[str, str]] = []
             j = i + 2
             while j < len(lines):
                 row_cells = _split_row(lines[j])
                 if row_cells is None:
                     break
                 if len(row_cells) != len(ROUTER_HEADERS):
-                    parse_errors.append(
+                    findings.append((
+                        LEVEL_FAIL,
                         f"router table row at line {j + 1} has "
                         f"{len(row_cells)} columns (expected "
-                        f"{len(ROUTER_HEADERS)})"
-                    )
+                        f"{len(ROUTER_HEADERS)})",
+                    ))
                     j += 1
                     continue
                 rows.append(
                     (row_cells[0], row_cells[1], row_cells[2])
                 )
                 j += 1
-            return rows, parse_errors
+            findings.extend(_scan_extra_router_tables(lines, j))
+            return rows, findings
         i += 1
     return None
+
+
+def _scan_extra_router_tables(
+    lines: list[str], start: int,
+) -> list[tuple[str, str]]:
+    """Emit a WARN per additional canonical-headed table after *start*.
+
+    Detects a second (third, ...) router-shaped header followed by a
+    valid separator.  Does not parse rows — the warning's purpose is to
+    direct the author back to the canonical first table; row contents
+    are not authoritative once duplicated.
+    """
+    findings: list[tuple[str, str]] = []
+    k = start
+    while k < len(lines):
+        cells = _split_row(lines[k])
+        if cells is not None and _is_router_header(cells):
+            if k + 1 < len(lines):
+                sep_cells = _split_row(lines[k + 1])
+                if sep_cells is not None and _is_separator_row(sep_cells):
+                    findings.append((
+                        LEVEL_WARN,
+                        f"second router-shaped table found at line "
+                        f"{k + 1}; only the first is audited — "
+                        f"consolidate or remove the extra table",
+                    ))
+                    k += 2
+                    continue
+        k += 1
+    return findings
 
 
 def expected_path(capability_name: str) -> str:
@@ -267,29 +310,38 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
     skill name when surfacing findings.  Do not embed the skill name
     into the messages here.
 
-    Failure modes (all FAIL), in emission order:
+    Failure modes, in emission order:
 
-    * ``capabilities/`` exists but ``SKILL.md`` is missing.
-    * ``capabilities/`` exists but ``SKILL.md`` has no router-shaped
-      table.
-    * ``SKILL.md`` has a router table but ``capabilities/`` is missing.
-    * A row inside the router table is structurally malformed (wrong
-      number of columns).  Subsequent valid rows are still parsed.
-    * A router row's Path cell is not the literal
+    * (FAIL) ``capabilities/`` exists but ``SKILL.md`` is missing.
+    * (FAIL) ``capabilities/`` exists but ``SKILL.md`` has no
+      router-shaped table.
+    * (FAIL) ``SKILL.md`` has a router table but ``capabilities/`` is
+      missing.
+    * (FAIL) A row inside the router table is structurally malformed
+      (wrong number of columns).  Subsequent valid rows are still
+      parsed.
+    * (WARN) A second canonical-headed router table appears in
+      ``SKILL.md``.  Only the first is audited; the warning directs
+      the author to consolidate.  Emitted before per-row checks so it
+      precedes findings that originate from the parsed (first) table.
+    * (FAIL) A router row's Trigger cell is empty.  Trigger content is
+      otherwise opaque, but emptiness is a structural failure (a
+      half-edited row).
+    * (FAIL) A router row's Path cell is not the literal
       ``capabilities/<name>/capability.md``.
-    * A router row's Capability cell does not equal the ``<name>``
-      segment of its Path cell.  The path segment is still recorded as
-      "declared" so the orphan check does not double-flag the on-disk
-      directory.
-    * Two rows declare the same capability segment (duplicate router
-      entry).  Detected only when both rows have parseable Path cells —
-      two rows whose Paths both fail ``_parse_path_cell`` already each
-      surface a "malformed Path" FAIL, so the duplicate is not silently
-      lost; it is reported as two independent malformed rows rather
-      than one duplicate.
-    * A router row's Path does not resolve to an existing
+    * (FAIL) A router row's Capability cell does not equal the
+      ``<name>`` segment of its Path cell.  The path segment is still
+      recorded as "declared" so the orphan check does not double-flag
+      the on-disk directory.
+    * (FAIL) Two rows declare the same capability segment (duplicate
+      router entry).  Detected only when both rows have parseable Path
+      cells — two rows whose Paths both fail ``_parse_path_cell``
+      already each surface a "malformed Path" FAIL, so the duplicate is
+      not silently lost; it is reported as two independent malformed
+      rows rather than one duplicate.
+    * (FAIL) A router row's Path does not resolve to an existing
       ``capability.md``.
-    * A capability subdirectory has a ``capability.md`` but no
+    * (FAIL) A capability subdirectory has a ``capability.md`` but no
       matching router row.
     """
     cap_dir = os.path.join(skill_path, DIR_CAPABILITIES)
@@ -332,13 +384,16 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
             f"{DIR_CAPABILITIES}/ is missing",
         )]
 
-    rows, parse_errors = parsed
-    findings: list[tuple[str, str]] = []
-    for parse_error in parse_errors:
-        findings.append((LEVEL_FAIL, parse_error))
+    rows, parse_findings = parsed
+    findings: list[tuple[str, str]] = list(parse_findings)
 
     declared: set[str] = set()
-    for capability, _trigger, path in rows:
+    for capability, trigger, path in rows:
+        if not trigger:
+            findings.append((
+                LEVEL_FAIL,
+                f"router row '{capability}' has an empty Trigger cell",
+            ))
         segment = _parse_path_cell(path)
         if segment is None:
             findings.append((

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -192,7 +192,8 @@ def parse_router_table(
     ``LEVEL_WARN`` when a second canonical-headed table is found later
     in the body.  Returns ``None`` if no Markdown table whose header is
     exactly ``Capability | Trigger | Path`` (after stripping ``*``,
-    backticks, and whitespace) appears in *body*.
+    underscores, backticks, and whitespace — see
+    ``ROUTER_HEADER_STRIP_CHARS``) appears in *body*.
 
     Mid-table rows whose column count differs from the header are
     recorded as FAIL findings and skipped, but scanning continues so

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -144,8 +144,13 @@ def _split_row(line: str) -> list[str] | None:
 
 
 def _is_separator_row(cells: list[str]) -> bool:
-    """A separator row's cells are made of dashes, optional colons, and spaces."""
-    if not cells:
+    """A separator row's cells are made of dashes, optional colons, and spaces.
+
+    Also requires the cell count to match ``ROUTER_HEADERS`` so a
+    malformed separator (e.g., ``|---|---|`` under the canonical
+    3-column header) does not promote a non-table to the router table.
+    """
+    if len(cells) != len(ROUTER_HEADERS):
         return False
     for cell in cells:
         bare = cell.replace(":", "").replace("-", "").replace(" ", "")

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -303,6 +303,39 @@ def _parse_path_cell(path_cell: str) -> str | None:
     return middle
 
 
+def _recover_segment(path_cell: str) -> str | None:
+    """Return a best-effort ``<name>`` segment when the strict parser fails.
+
+    Strips common author decorations — backticks, the ``[text](url)``
+    markdown link wrapper, leading ``./``, and a trailing ``#fragment``
+    — then re-runs the strict parser.  Returns ``None`` if nothing
+    recoverable is left.
+
+    The audit uses the recovered segment to suppress the orphan check
+    so a single author error (e.g., wrapping the path in backticks)
+    surfaces as exactly one FAIL ("malformed Path") instead of also
+    triggering "no matching router row" for a directory the row was
+    clearly trying to reference.
+    """
+    candidate = path_cell.strip()
+    # Backticks: ``` `path` ```
+    if candidate.startswith("`") and candidate.endswith("`"):
+        candidate = candidate[1:-1].strip()
+    # Markdown link: ``[text](path)``
+    if candidate.startswith("[") and candidate.endswith(")"):
+        bracket_end = candidate.find("](")
+        if bracket_end != -1:
+            candidate = candidate[bracket_end + 2:-1].strip()
+    # Leading ``./``
+    if candidate.startswith("./"):
+        candidate = candidate[2:]
+    # Fragment: ``path#anchor``
+    hash_pos = candidate.find("#")
+    if hash_pos != -1:
+        candidate = candidate[:hash_pos]
+    return _parse_path_cell(candidate)
+
+
 def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
     """Audit the router table of the skill at *skill_path*.
 
@@ -406,6 +439,12 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
                 f"router row '{capability}' has malformed Path '{path}' "
                 f"(expected literal '{expected_path('<name>')}')",
             ))
+            # Recover a best-effort segment so the orphan check does not
+            # double-flag a directory the malformed row clearly
+            # references (e.g., "./capabilities/alpha/capability.md").
+            recovered = _recover_segment(path)
+            if recovered is not None:
+                declared.add(recovered)
             continue
         if capability != segment:
             findings.append((
@@ -420,6 +459,9 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
                 LEVEL_FAIL,
                 f"router has duplicate row for '{segment}'",
             ))
+            # The first occurrence already ran the existence check
+            # below; both rows resolve to the same path so a second
+            # ``os.path.isfile`` would just repeat the same answer.
             continue
         declared.add(segment)
         resolved = os.path.normpath(os.path.join(skill_path, path))

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -60,7 +60,10 @@ def _strip_fenced_regions(body: str) -> str:
     document treated as fenced.
 
     CommonMark indented (4-space) code blocks are **not** stripped —
-    only fenced blocks are.  Author router-table examples in fenced
+    only fenced blocks are.  Per CommonMark §4.5, a fence opener may
+    be indented 0–3 spaces; a line indented 4+ spaces is an indented
+    code block and the backticks (or tildes) are literal content, so
+    we leave it untouched.  Author router-table examples in fenced
     blocks so they cannot shadow the canonical router.
     """
     lines = body.splitlines()
@@ -69,7 +72,14 @@ def _strip_fenced_regions(body: str) -> str:
     out: list[str] = []
     for line in lines:
         stripped = line.lstrip()
+        indent = len(line) - len(stripped)
         if fence_char is None:
+            # CommonMark §4.5: fenced code blocks accept 0–3 leading
+            # spaces; 4+ spaces is an indented code block whose
+            # backticks/tildes are literal content.
+            if indent > 3:
+                out.append(line)
+                continue
             opener: str | None = None
             if stripped.startswith("```"):
                 opener = "`"
@@ -82,10 +92,13 @@ def _strip_fenced_regions(body: str) -> str:
             fence_len = _fence_run_length(stripped, fence_char)
             out.append("")
         else:
-            if stripped[:1] == fence_char:
+            # A closer is also constrained to 0–3 spaces of indent
+            # (CommonMark §4.5); a deeper-indented line cannot close
+            # the fence and is treated as content.
+            if indent <= 3 and stripped[:1] == fence_char:
                 run = _fence_run_length(stripped, fence_char)
                 # Closer must match opener length and have only
-                # whitespace after the run (CommonMark §4.5).
+                # whitespace after the run.
                 if run >= fence_len and stripped[run:].strip() == "":
                     fence_char = None
                     fence_len = 0

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -5,22 +5,24 @@ whose header is ``| Capability | Trigger | Path |``.  This module
 parses that table and reports drift between the router rows and the
 ``capabilities/`` directory.
 
-The audit fires only on skills that have a ``capabilities/`` directory.
-Standalone skills (no router, no capabilities) are a no-op.  A skill
-that has a router-shaped table but no ``capabilities/`` directory is
-also a no-op — the rule's contract is "audit drift when both halves
-exist", which matches the standalone-vs-router architecture.
+The audit fires on any router skill — that is, any skill where either
+the ``SKILL.md`` declares a router table **or** a ``capabilities/``
+directory exists on disk.  When only one half is present the rule
+FAILs: a router table without ``capabilities/`` means the on-disk tree
+was deleted; a ``capabilities/`` directory without a router table means
+the router section was removed.  Standalone skills (neither half
+present) are a no-op.
 
 Trigger column content is treated as opaque — its only audit role is to
-identify the canonical 3-column header.  The Path column must be the
+identify the canonical 3-column header.  Cells may include the escape
+sequence ``\\|`` to embed a literal pipe.  The Path column must be the
 literal string ``capabilities/<name>/capability.md`` (no backticks, no
 markdown link, no fragment, no leading ``./``).  The Capability column
 must equal ``<name>`` from the Path column.
 
-The router header tuple lives here, not in ``configuration.yaml``: it
-is a parser-coupled structural constant (analogous to
-``DIR_CAPABILITIES`` and ``FILE_SKILL_MD`` in ``constants.py``), not a
-tunable validation rule like a limit, pattern, or reserved word.
+The router header tuple lives in ``constants.py`` (alongside
+``DIR_CAPABILITIES`` and ``FILE_SKILL_MD``) — it is a structural
+constant, not a tunable validation rule.
 """
 
 import os
@@ -30,23 +32,49 @@ from .constants import (
     FILE_CAPABILITY_MD,
     FILE_SKILL_MD,
     LEVEL_FAIL,
+    ROUTER_HEADERS,
+    ROUTER_HEADER_STRIP_CHARS,
 )
 
 
-ROUTER_HEADERS: tuple[str, str, str] = ("Capability", "Trigger", "Path")
-HEADER_STRIP_CHARS = " *`"
+_PIPE_ESCAPE_PLACEHOLDER = "\x00PIPE\x00"
+
+
+def _strip_fenced_regions(body: str) -> str:
+    """Replace fenced code blocks with blank lines.
+
+    Keeps line numbers stable so error messages from upstream tooling
+    still line up, while ensuring fenced documentation examples cannot
+    shadow the canonical router table (first-table-wins).
+    """
+    lines = body.splitlines()
+    in_fence = False
+    out: list[str] = []
+    for line in lines:
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            out.append("")
+            continue
+        out.append("" if in_fence else line)
+    return "\n".join(out)
 
 
 def _split_row(line: str) -> list[str] | None:
     """Split a Markdown table row into trimmed cells.
 
-    Returns ``None`` if *line* is not a pipe-delimited row.
+    Honors the CommonMark ``\\|`` escape so a Trigger cell containing
+    a literal pipe does not truncate the table.  Returns ``None`` if
+    *line* is not a pipe-delimited row.
     """
     stripped = line.strip()
     if not stripped.startswith("|") or not stripped.endswith("|"):
         return None
     inner = stripped[1:-1]
-    return [cell.strip() for cell in inner.split("|")]
+    inner = inner.replace("\\|", _PIPE_ESCAPE_PLACEHOLDER)
+    return [
+        cell.strip().replace(_PIPE_ESCAPE_PLACEHOLDER, "|")
+        for cell in inner.split("|")
+    ]
 
 
 def _is_separator_row(cells: list[str]) -> bool:
@@ -62,7 +90,7 @@ def _is_separator_row(cells: list[str]) -> bool:
 
 def _normalize_header_cell(cell: str) -> str:
     """Strip ``*``, backticks, and surrounding whitespace from a header cell."""
-    return cell.strip().strip(HEADER_STRIP_CHARS).strip()
+    return cell.strip().strip(ROUTER_HEADER_STRIP_CHARS).strip()
 
 
 def _is_router_header(cells: list[str]) -> bool:
@@ -79,32 +107,25 @@ def parse_router_table(body: str) -> list[tuple[str, str, str]] | None:
     ``Capability | Trigger | Path`` (after stripping ``*``, backticks,
     and whitespace) appears in *body*.
 
-    Code fences are *not* stripped before scanning — a router-shaped
-    table inside a fenced block still counts, because an AI agent
-    consuming the SKILL.md sees that content too.  Combined with the
-    first-table-wins rule above, this means a fenced documentation
-    example placed *before* the canonical router will be picked up
-    instead of it.  Authors who want to document the format in prose
-    should keep the example below the canonical router or use a
-    non-router header shape in the example.
+    Fenced code blocks are stripped before scanning so a documentation
+    example in a ```` ```markdown ```` block cannot shadow the canonical
+    router (first-table-wins).
 
     A header line that matches the tuple but is not followed by a
     Markdown separator row (``|---|---|---|``) does not terminate the
     scan — the parser advances past the pseudo-header and keeps looking
-    for a real table.  This lets a SKILL.md describe the header shape in
-    prose without blocking discovery of the actual router below.
+    for a real table.
     """
-    lines = body.splitlines()
+    cleaned = _strip_fenced_regions(body)
+    lines = cleaned.splitlines()
     i = 0
     while i < len(lines):
         cells = _split_row(lines[i])
         if cells is not None and _is_router_header(cells):
-            # Expect a separator row immediately after the header.
             if i + 1 >= len(lines):
                 return None
             sep_cells = _split_row(lines[i + 1])
             if sep_cells is None or not _is_separator_row(sep_cells):
-                # Not a real table — keep scanning for a later one.
                 i += 1
                 continue
             rows: list[tuple[str, str, str]] = []
@@ -114,7 +135,7 @@ def parse_router_table(body: str) -> list[tuple[str, str, str]] | None:
                 if row_cells is None:
                     break
                 if len(row_cells) != len(ROUTER_HEADERS):
-                    # Malformed row — stop the table here.
+                    # Mid-table malformed row — stop the table here.
                     break
                 rows.append(
                     (row_cells[0], row_cells[1], row_cells[2])
@@ -149,57 +170,71 @@ def _parse_path_cell(path_cell: str) -> str | None:
 def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
     """Audit the router table of the skill at *skill_path*.
 
-    Returns a list of ``(level, message)`` tuples.  Returns ``[]`` when
-    the skill has no ``capabilities/`` directory (standalone skill —
-    rule does not apply) or when all checks pass.
+    Returns a list of ``(level, message)`` tuples.  Returns ``[]`` for
+    standalone skills (no ``SKILL.md`` router table and no
+    ``capabilities/`` directory) and when all checks pass.
 
     Failure modes (all FAIL):
 
     * ``capabilities/`` exists but ``SKILL.md`` is missing.
+    * ``SKILL.md`` has a router table but ``capabilities/`` is missing.
     * ``capabilities/`` exists but ``SKILL.md`` has no router-shaped
       table.
     * A router row's Path cell is not the literal
       ``capabilities/<name>/capability.md``.
     * A router row's Capability cell does not equal the ``<name>``
       segment of its Path cell.  The path segment is still recorded as
-      "declared", so the orphan check below does not double-flag the
-      on-disk directory.
+      "declared" so the orphan check does not double-flag the on-disk
+      directory.
     * A router row's Path does not resolve to an existing
       ``capability.md``.
     * A capability subdirectory has a ``capability.md`` but no
       matching router row.
     """
     cap_dir = os.path.join(skill_path, DIR_CAPABILITIES)
-    if not os.path.isdir(cap_dir):
-        return []
+    has_cap_dir = os.path.isdir(cap_dir)
 
     skill_md = os.path.join(skill_path, FILE_SKILL_MD)
-    if not os.path.isfile(skill_md):
+    has_skill_md = os.path.isfile(skill_md)
+
+    if has_cap_dir and not has_skill_md:
         # find_skill_dirs silently drops directories without SKILL.md,
         # so no other rule reaches this case.  Flag it here; the
         # presence of capabilities/ proves the directory is meant to be
         # a router skill.
         return [(
             LEVEL_FAIL,
-            f"has {DIR_CAPABILITIES}/ but no {FILE_SKILL_MD}",
+            f"{DIR_CAPABILITIES}/ exists but {FILE_SKILL_MD} is missing",
         )]
 
-    with open(skill_md, "r", encoding="utf-8") as fh:
-        # Pass the full content; YAML frontmatter delimiters ('---') are
-        # not pipe rows and cannot be mistaken for a router header.
-        content = fh.read()
+    rows: list[tuple[str, str, str]] | None = None
+    if has_skill_md:
+        with open(skill_md, "r", encoding="utf-8") as fh:
+            content = fh.read()
+        rows = parse_router_table(content)
 
-    rows = parse_router_table(content)
-    if rows is None:
+    if not has_cap_dir and rows is None:
+        # Standalone skill — neither half of the rule is present.
+        return []
+
+    if has_cap_dir and rows is None:
         return [(
             LEVEL_FAIL,
             f"{FILE_SKILL_MD} has {DIR_CAPABILITIES}/ but no router "
             f"table with header 'Capability | Trigger | Path'",
         )]
 
+    if not has_cap_dir and rows is not None:
+        return [(
+            LEVEL_FAIL,
+            f"{FILE_SKILL_MD} declares a router table but "
+            f"{DIR_CAPABILITIES}/ is missing",
+        )]
+
     findings: list[tuple[str, str]] = []
     declared: set[str] = set()
 
+    assert rows is not None  # narrowed above for the type checker
     for capability, _trigger, path in rows:
         segment = _parse_path_cell(path)
         if segment is None:
@@ -220,7 +255,7 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
             # Continue with the path-based name so existence/orphan
             # checks still cover the cell that is on disk.
         declared.add(segment)
-        resolved = os.path.join(skill_path, path)
+        resolved = os.path.normpath(os.path.join(skill_path, path))
         if not os.path.isfile(resolved):
             findings.append((
                 LEVEL_FAIL,

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -160,6 +160,11 @@ def _normalize_header_cell(cell: str) -> str:
     The strip set covers both CommonMark italic forms (``*x*`` and
     ``_x_``), bold (``**x**``), and inline code (``` `x` ```).  See
     ``ROUTER_HEADER_STRIP_CHARS`` in ``constants.py``.
+
+    The trailing ``.strip()`` is not redundant — the strip set includes
+    a literal space, so ``"** Capability **"`` round-trips correctly,
+    but ``"* Capability *"`` exposes inner spaces only after the
+    asterisks are removed; the second strip cleans those up.
     """
     return cell.strip().strip(ROUTER_HEADER_STRIP_CHARS).strip()
 

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -13,12 +13,14 @@ was deleted; a ``capabilities/`` directory without a router table means
 the router section was removed.  Standalone skills (neither half
 present) are a no-op.
 
-Trigger column content is treated as opaque — its only audit role is to
-identify the canonical 3-column header.  Cells may include the escape
-sequence ``\\|`` to embed a literal pipe.  The Path column must be the
-literal string ``capabilities/<name>/capability.md`` (no backticks, no
-markdown link, no fragment, no leading ``./``).  The Capability column
-must equal ``<name>`` from the Path column.
+Trigger column content is otherwise treated as opaque — its text helps
+identify the canonical 3-column header, and each router row must have
+a non-empty Trigger cell (an empty cell is a structural FAIL — see
+``audit_router_table``).  Cells may include the escape sequence ``\\|``
+to embed a literal pipe.  The Path column must be the literal string
+``capabilities/<name>/capability.md`` (no backticks, no markdown link,
+no fragment, no leading ``./``).  The Capability column must equal
+``<name>`` from the Path column.
 
 The router header tuple lives in ``constants.py`` (alongside
 ``DIR_CAPABILITIES`` and ``FILE_SKILL_MD``) — it is a structural

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -282,7 +282,11 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
       "declared" so the orphan check does not double-flag the on-disk
       directory.
     * Two rows declare the same capability segment (duplicate router
-      entry).
+      entry).  Detected only when both rows have parseable Path cells —
+      two rows whose Paths both fail ``_parse_path_cell`` already each
+      surface a "malformed Path" FAIL, so the duplicate is not silently
+      lost; it is reported as two independent malformed rows rather
+      than one duplicate.
     * A router row's Path does not resolve to an existing
       ``capability.md``.
     * A capability subdirectory has a ``capability.md`` but no

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -468,6 +468,21 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
             recovered = _recover_segment(path)
             if recovered is not None:
                 declared.add(recovered)
+                # A malformed Path can ALSO point at a missing target.
+                # Run the existence check against the canonical
+                # ``capabilities/<recovered>/capability.md`` so the
+                # author sees both problems in one audit pass instead
+                # of fixing the decoration only to learn next run that
+                # the target file is missing too.
+                recovered_path = os.path.normpath(
+                    os.path.join(skill_path, expected_path(recovered))
+                )
+                if not os.path.isfile(recovered_path):
+                    findings.append((
+                        LEVEL_FAIL,
+                        f"router row '{recovered}' Path does not resolve "
+                        f"to an existing {FILE_CAPABILITY_MD}",
+                    ))
             continue
         if capability != segment:
             findings.append((

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -37,9 +37,6 @@ from .constants import (
 )
 
 
-_PIPE_ESCAPE_PLACEHOLDER = "\x00PIPE\x00"
-
-
 def _fence_run_length(stripped: str, ch: str) -> int:
     """Count the leading run of *ch* characters at the start of *stripped*."""
     n = 0
@@ -102,16 +99,34 @@ def _split_row(line: str) -> list[str] | None:
     Honors the CommonMark ``\\|`` escape so a Trigger cell containing
     a literal pipe does not truncate the table.  Returns ``None`` if
     *line* is not a pipe-delimited row.
+
+    Uses a single-pass scan rather than a sentinel substitution so no
+    placeholder string is ever embedded in the cell content — this
+    avoids any collision with characters that happen to appear in the
+    input (e.g., NUL bytes from binary-tainted clipboards).
     """
     stripped = line.strip()
     if not stripped.startswith("|") or not stripped.endswith("|"):
         return None
     inner = stripped[1:-1]
-    inner = inner.replace("\\|", _PIPE_ESCAPE_PLACEHOLDER)
-    return [
-        cell.strip().replace(_PIPE_ESCAPE_PLACEHOLDER, "|")
-        for cell in inner.split("|")
-    ]
+    cells: list[str] = []
+    buf: list[str] = []
+    i = 0
+    while i < len(inner):
+        ch = inner[i]
+        if ch == "\\" and i + 1 < len(inner) and inner[i + 1] == "|":
+            buf.append("|")
+            i += 2
+            continue
+        if ch == "|":
+            cells.append("".join(buf).strip())
+            buf = []
+            i += 1
+            continue
+        buf.append(ch)
+        i += 1
+    cells.append("".join(buf).strip())
+    return cells
 
 
 def _is_separator_row(cells: list[str]) -> bool:
@@ -229,6 +244,11 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
     standalone skills (no ``SKILL.md`` router table and no
     ``capabilities/`` directory) and when all checks pass.
 
+    Messages are skill-relative — the caller (e.g.,
+    ``audit_skill_system.py``) is responsible for prefixing the
+    skill name when surfacing findings.  Do not embed the skill name
+    into the messages here.
+
     Failure modes (all FAIL):
 
     * ``capabilities/`` exists but ``SKILL.md`` is missing.
@@ -302,7 +322,7 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
             findings.append((
                 LEVEL_FAIL,
                 f"router row '{capability}' has malformed Path '{path}' "
-                f"(expected literal '{DIR_CAPABILITIES}/<name>/{FILE_CAPABILITY_MD}')",
+                f"(expected literal '{expected_path('<name>')}')",
             ))
             continue
         if capability != segment:

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -81,7 +81,12 @@ def parse_router_table(body: str) -> list[tuple[str, str, str]] | None:
 
     Code fences are *not* stripped before scanning — a router-shaped
     table inside a fenced block still counts, because an AI agent
-    consuming the SKILL.md sees that content too.
+    consuming the SKILL.md sees that content too.  Combined with the
+    first-table-wins rule above, this means a fenced documentation
+    example placed *before* the canonical router will be picked up
+    instead of it.  Authors who want to document the format in prose
+    should keep the example below the canonical router or use a
+    non-router header shape in the example.
 
     A header line that matches the tuple but is not followed by a
     Markdown separator row (``|---|---|---|``) does not terminate the
@@ -201,7 +206,9 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
             findings.append((
                 LEVEL_FAIL,
                 f"router row '{capability}' has malformed Path '{path}' "
-                f"(expected '{DIR_CAPABILITIES}/<name>/{FILE_CAPABILITY_MD}')",
+                f"(expected literal '{DIR_CAPABILITIES}/<name>/{FILE_CAPABILITY_MD}'"
+                " — Path is parsed literally, no backticks, links, fragments,"
+                " or leading './'; header formatting is tolerated, path is not)",
             ))
             continue
         if capability != segment:

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -40,6 +40,14 @@ from .constants import (
 _PIPE_ESCAPE_PLACEHOLDER = "\x00PIPE\x00"
 
 
+def _fence_run_length(stripped: str, ch: str) -> int:
+    """Count the leading run of *ch* characters at the start of *stripped*."""
+    n = 0
+    while n < len(stripped) and stripped[n] == ch:
+        n += 1
+    return n
+
+
 def _strip_fenced_regions(body: str) -> str:
     """Replace fenced code blocks with blank lines.
 
@@ -48,25 +56,42 @@ def _strip_fenced_regions(body: str) -> str:
     shadow the canonical router table (first-table-wins).
 
     Recognizes both backtick (```` ``` ````) and tilde (``~~~``)
-    CommonMark fences.  A fence is closed by a marker of the same
-    family — opening with ```` ``` ```` and closing with ``~~~`` is
-    not balanced and would leave the rest of the document treated as
-    fenced.
+    CommonMark fences with arbitrary run length.  A fence is closed by
+    a marker of the **same family** whose run length is at least the
+    opener's; mixing families (opening with ```` ``` ```` and closing
+    with ``~~~``) is not balanced and would leave the rest of the
+    document treated as fenced.
+
+    CommonMark indented (4-space) code blocks are **not** stripped —
+    only fenced blocks are.  Author router-table examples in fenced
+    blocks so they cannot shadow the canonical router.
     """
     lines = body.splitlines()
-    fence_marker: str | None = None
+    fence_char: str | None = None
+    fence_len = 0
     out: list[str] = []
     for line in lines:
         stripped = line.lstrip()
-        if fence_marker is None:
-            if stripped.startswith("```") or stripped.startswith("~~~"):
-                fence_marker = stripped[:3]
-                out.append("")
+        if fence_char is None:
+            opener: str | None = None
+            if stripped.startswith("```"):
+                opener = "`"
+            elif stripped.startswith("~~~"):
+                opener = "~"
+            if opener is None:
+                out.append(line)
                 continue
-            out.append(line)
+            fence_char = opener
+            fence_len = _fence_run_length(stripped, fence_char)
+            out.append("")
         else:
-            if stripped.startswith(fence_marker):
-                fence_marker = None
+            if stripped[:1] == fence_char:
+                run = _fence_run_length(stripped, fence_char)
+                # Closer must match opener length and have only
+                # whitespace after the run (CommonMark §4.5).
+                if run >= fence_len and stripped[run:].strip() == "":
+                    fence_char = None
+                    fence_len = 0
             out.append("")
     return "\n".join(out)
 
@@ -111,17 +136,29 @@ def _is_router_header(cells: list[str]) -> bool:
     return tuple(_normalize_header_cell(c) for c in cells) == ROUTER_HEADERS
 
 
-def parse_router_table(body: str) -> list[tuple[str, str, str]] | None:
+def parse_router_table(
+    body: str,
+) -> tuple[list[tuple[str, str, str]], list[str]] | None:
     """Return rows of the first router-shaped table in *body*.
 
-    A row is ``(capability, trigger, path)`` with each cell stripped.
-    Returns ``None`` if no Markdown table whose header is exactly
-    ``Capability | Trigger | Path`` (after stripping ``*``, backticks,
-    and whitespace) appears in *body*.
+    Returns ``(rows, parse_errors)`` where ``rows`` is a list of
+    ``(capability, trigger, path)`` tuples with each cell stripped, and
+    ``parse_errors`` is a list of human-readable messages for rows that
+    were structurally malformed (e.g., wrong column count) but appeared
+    inside the table region.  Returns ``None`` if no Markdown table
+    whose header is exactly ``Capability | Trigger | Path`` (after
+    stripping ``*``, backticks, and whitespace) appears in *body*.
+
+    Mid-table rows whose column count differs from the header are
+    recorded in ``parse_errors`` and skipped, but scanning continues
+    so trailing valid rows still appear in ``rows``.  This prevents a
+    single malformed row from masking valid ones (and producing
+    misleading orphan errors downstream).
 
     Fenced code blocks are stripped before scanning so a documentation
     example in a ```` ```markdown ```` block cannot shadow the canonical
-    router (first-table-wins).
+    router (first-table-wins).  Indented (4-space) code blocks are not
+    stripped — see ``_strip_fenced_regions``.
 
     A header line that matches the tuple but is not followed by a
     Markdown separator row (``|---|---|---|``) does not terminate the
@@ -141,19 +178,25 @@ def parse_router_table(body: str) -> list[tuple[str, str, str]] | None:
                 i += 1
                 continue
             rows: list[tuple[str, str, str]] = []
+            parse_errors: list[str] = []
             j = i + 2
             while j < len(lines):
                 row_cells = _split_row(lines[j])
                 if row_cells is None:
                     break
                 if len(row_cells) != len(ROUTER_HEADERS):
-                    # Mid-table malformed row — stop the table here.
-                    break
+                    parse_errors.append(
+                        f"router table row at line {j + 1} has "
+                        f"{len(row_cells)} columns (expected "
+                        f"{len(ROUTER_HEADERS)})"
+                    )
+                    j += 1
+                    continue
                 rows.append(
                     (row_cells[0], row_cells[1], row_cells[2])
                 )
                 j += 1
-            return rows
+            return rows, parse_errors
         i += 1
     return None
 
@@ -192,6 +235,10 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
     * ``SKILL.md`` has a router table but ``capabilities/`` is missing.
     * ``capabilities/`` exists but ``SKILL.md`` has no router-shaped
       table.
+    * A row inside the router table is structurally malformed (wrong
+      number of columns).  Subsequent valid rows are still parsed.
+    * Two rows declare the same capability segment (duplicate router
+      entry).
     * A router row's Path cell is not the literal
       ``capabilities/<name>/capability.md``.
     * A router row's Capability cell does not equal the ``<name>``
@@ -219,34 +266,36 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
             f"{DIR_CAPABILITIES}/ exists but {FILE_SKILL_MD} is missing",
         )]
 
-    rows: list[tuple[str, str, str]] | None = None
+    parsed: tuple[list[tuple[str, str, str]], list[str]] | None = None
     if has_skill_md:
         with open(skill_md, "r", encoding="utf-8") as fh:
             content = fh.read()
-        rows = parse_router_table(content)
+        parsed = parse_router_table(content)
 
-    if not has_cap_dir and rows is None:
+    if not has_cap_dir and parsed is None:
         # Standalone skill — neither half of the rule is present.
         return []
 
-    if has_cap_dir and rows is None:
+    if has_cap_dir and parsed is None:
         return [(
             LEVEL_FAIL,
             f"{FILE_SKILL_MD} has {DIR_CAPABILITIES}/ but no router "
             f"table with header 'Capability | Trigger | Path'",
         )]
 
-    if not has_cap_dir and rows is not None:
+    if not has_cap_dir and parsed is not None:
         return [(
             LEVEL_FAIL,
             f"{FILE_SKILL_MD} declares a router table but "
             f"{DIR_CAPABILITIES}/ is missing",
         )]
 
+    rows, parse_errors = parsed
     findings: list[tuple[str, str]] = []
-    declared: set[str] = set()
+    for parse_error in parse_errors:
+        findings.append((LEVEL_FAIL, parse_error))
 
-    assert rows is not None  # narrowed above for the type checker
+    declared: set[str] = set()
     for capability, _trigger, path in rows:
         segment = _parse_path_cell(path)
         if segment is None:
@@ -264,6 +313,12 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
             ))
             # Continue with the path-based name so existence/orphan
             # checks still cover the cell that is on disk.
+        if segment in declared:
+            findings.append((
+                LEVEL_FAIL,
+                f"router has duplicate row for '{segment}'",
+            ))
+            continue
         declared.add(segment)
         resolved = os.path.normpath(os.path.join(skill_path, path))
         if not os.path.isfile(resolved):

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -6,13 +6,21 @@ parses that table and reports drift between the router rows and the
 ``capabilities/`` directory.
 
 The audit fires only on skills that have a ``capabilities/`` directory.
-Standalone skills (no router, no capabilities) are a no-op.
+Standalone skills (no router, no capabilities) are a no-op.  A skill
+that has a router-shaped table but no ``capabilities/`` directory is
+also a no-op — the rule's contract is "audit drift when both halves
+exist", which matches the standalone-vs-router architecture.
 
 Trigger column content is treated as opaque — its only audit role is to
 identify the canonical 3-column header.  The Path column must be the
 literal string ``capabilities/<name>/capability.md`` (no backticks, no
 markdown link, no fragment, no leading ``./``).  The Capability column
 must equal ``<name>`` from the Path column.
+
+The router header tuple lives here, not in ``configuration.yaml``: it
+is a parser-coupled structural constant (analogous to
+``DIR_CAPABILITIES`` and ``FILE_SKILL_MD`` in ``constants.py``), not a
+tunable validation rule like a limit, pattern, or reserved word.
 """
 
 import os
@@ -74,6 +82,12 @@ def parse_router_table(body: str) -> list[tuple[str, str, str]] | None:
     Code fences are *not* stripped before scanning — a router-shaped
     table inside a fenced block still counts, because an AI agent
     consuming the SKILL.md sees that content too.
+
+    A header line that matches the tuple but is not followed by a
+    Markdown separator row (``|---|---|---|``) does not terminate the
+    scan — the parser advances past the pseudo-header and keeps looking
+    for a real table.  This lets a SKILL.md describe the header shape in
+    prose without blocking discovery of the actual router below.
     """
     lines = body.splitlines()
     i = 0
@@ -142,7 +156,9 @@ def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
     * A router row's Path cell is not the literal
       ``capabilities/<name>/capability.md``.
     * A router row's Capability cell does not equal the ``<name>``
-      segment of its Path cell.
+      segment of its Path cell.  The path segment is still recorded as
+      "declared", so the orphan check below does not double-flag the
+      on-disk directory.
     * A router row's Path does not resolve to an existing
       ``capability.md``.
     * A capability subdirectory has a ``capability.md`` but no

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -311,6 +311,13 @@ def _recover_segment(path_cell: str) -> str | None:
     — then re-runs the strict parser.  Returns ``None`` if nothing
     recoverable is left.
 
+    Shape validation is delegated entirely to ``_parse_path_cell`` (the
+    final ``return``) — this helper only handles decoration stripping.
+    Pathological inputs (e.g., embedded parentheses) are rejected by
+    the strict re-parse rather than by this function, so a future
+    contributor can extend the decoration set without re-deriving the
+    canonical-path semantics.
+
     The audit uses the recovered segment to suppress the orphan check
     so a single author error (e.g., wrapping the path in backticks)
     surfaces as exactly one FAIL ("malformed Path") instead of also

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -303,7 +303,12 @@ def _parse_path_cell(path_cell: str) -> str | None:
     if not path_cell.startswith(prefix) or not path_cell.endswith(suffix):
         return None
     middle = path_cell[len(prefix):-len(suffix)]
-    if not middle or "/" in middle:
+    if (
+        not middle
+        or "/" in middle
+        or "\\" in middle
+        or middle in (".", "..")
+    ):
         return None
     return middle
 

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -1,0 +1,219 @@
+"""Router-table consistency audit.
+
+A router skill's ``SKILL.md`` lists its capabilities in a Markdown table
+whose header is ``| Capability | Trigger | Path |``.  This module
+parses that table and reports drift between the router rows and the
+``capabilities/`` directory.
+
+The audit fires only on skills that have a ``capabilities/`` directory.
+Standalone skills (no router, no capabilities) are a no-op.
+
+Trigger column content is treated as opaque — its only audit role is to
+identify the canonical 3-column header.  The Path column must be the
+literal string ``capabilities/<name>/capability.md`` (no backticks, no
+markdown link, no fragment, no leading ``./``).  The Capability column
+must equal ``<name>`` from the Path column.
+"""
+
+import os
+
+from .constants import (
+    DIR_CAPABILITIES,
+    FILE_CAPABILITY_MD,
+    FILE_SKILL_MD,
+    LEVEL_FAIL,
+)
+
+
+ROUTER_HEADERS: tuple[str, str, str] = ("Capability", "Trigger", "Path")
+HEADER_STRIP_CHARS = " *`"
+
+
+def _split_row(line: str) -> list[str] | None:
+    """Split a Markdown table row into trimmed cells.
+
+    Returns ``None`` if *line* is not a pipe-delimited row.
+    """
+    stripped = line.strip()
+    if not stripped.startswith("|") or not stripped.endswith("|"):
+        return None
+    inner = stripped[1:-1]
+    return [cell.strip() for cell in inner.split("|")]
+
+
+def _is_separator_row(cells: list[str]) -> bool:
+    """A separator row's cells are made of dashes, optional colons, and spaces."""
+    if not cells:
+        return False
+    for cell in cells:
+        bare = cell.replace(":", "").replace("-", "").replace(" ", "")
+        if bare or "-" not in cell:
+            return False
+    return True
+
+
+def _normalize_header_cell(cell: str) -> str:
+    """Strip ``*``, backticks, and surrounding whitespace from a header cell."""
+    return cell.strip().strip(HEADER_STRIP_CHARS).strip()
+
+
+def _is_router_header(cells: list[str]) -> bool:
+    if len(cells) != len(ROUTER_HEADERS):
+        return False
+    return tuple(_normalize_header_cell(c) for c in cells) == ROUTER_HEADERS
+
+
+def parse_router_table(body: str) -> list[tuple[str, str, str]] | None:
+    """Return rows of the first router-shaped table in *body*.
+
+    A row is ``(capability, trigger, path)`` with each cell stripped.
+    Returns ``None`` if no Markdown table whose header is exactly
+    ``Capability | Trigger | Path`` (after stripping ``*``, backticks,
+    and whitespace) appears in *body*.
+
+    Code fences are *not* stripped before scanning — a router-shaped
+    table inside a fenced block still counts, because an AI agent
+    consuming the SKILL.md sees that content too.
+    """
+    lines = body.splitlines()
+    i = 0
+    while i < len(lines):
+        cells = _split_row(lines[i])
+        if cells is not None and _is_router_header(cells):
+            # Expect a separator row immediately after the header.
+            if i + 1 >= len(lines):
+                return None
+            sep_cells = _split_row(lines[i + 1])
+            if sep_cells is None or not _is_separator_row(sep_cells):
+                # Not a real table — keep scanning for a later one.
+                i += 1
+                continue
+            rows: list[tuple[str, str, str]] = []
+            j = i + 2
+            while j < len(lines):
+                row_cells = _split_row(lines[j])
+                if row_cells is None:
+                    break
+                if len(row_cells) != len(ROUTER_HEADERS):
+                    # Malformed row — stop the table here.
+                    break
+                rows.append(
+                    (row_cells[0], row_cells[1], row_cells[2])
+                )
+                j += 1
+            return rows
+        i += 1
+    return None
+
+
+def expected_path(capability_name: str) -> str:
+    """Return the canonical Path-cell value for a capability name."""
+    return f"{DIR_CAPABILITIES}/{capability_name}/{FILE_CAPABILITY_MD}"
+
+
+def _parse_path_cell(path_cell: str) -> str | None:
+    """Return the ``<name>`` segment from ``capabilities/<name>/capability.md``.
+
+    Returns ``None`` if *path_cell* does not match the canonical literal
+    shape.  Strict matching is intentional — see module docstring.
+    """
+    prefix = f"{DIR_CAPABILITIES}/"
+    suffix = f"/{FILE_CAPABILITY_MD}"
+    if not path_cell.startswith(prefix) or not path_cell.endswith(suffix):
+        return None
+    middle = path_cell[len(prefix):-len(suffix)]
+    if not middle or "/" in middle:
+        return None
+    return middle
+
+
+def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
+    """Audit the router table of the skill at *skill_path*.
+
+    Returns a list of ``(level, message)`` tuples.  Returns ``[]`` when
+    the skill has no ``capabilities/`` directory (standalone skill —
+    rule does not apply) or when all checks pass.
+
+    Failure modes (all FAIL):
+
+    * ``capabilities/`` exists but ``SKILL.md`` has no router-shaped
+      table.
+    * A router row's Path cell is not the literal
+      ``capabilities/<name>/capability.md``.
+    * A router row's Capability cell does not equal the ``<name>``
+      segment of its Path cell.
+    * A router row's Path does not resolve to an existing
+      ``capability.md``.
+    * A capability subdirectory has a ``capability.md`` but no
+      matching router row.
+    """
+    cap_dir = os.path.join(skill_path, DIR_CAPABILITIES)
+    if not os.path.isdir(cap_dir):
+        return []
+
+    skill_md = os.path.join(skill_path, FILE_SKILL_MD)
+    if not os.path.isfile(skill_md):
+        # The missing-SKILL.md case is reported by other rules; do not
+        # double-flag here.
+        return []
+
+    with open(skill_md, "r", encoding="utf-8") as fh:
+        # Read body only — frontmatter cannot contain a router table.
+        # We intentionally pass the full content to ``parse_router_table``
+        # because the frontmatter delimiters ('---') are not pipe rows
+        # and won't be mistaken for a header.
+        content = fh.read()
+
+    rows = parse_router_table(content)
+    if rows is None:
+        return [(
+            LEVEL_FAIL,
+            f"{FILE_SKILL_MD} has {DIR_CAPABILITIES}/ but no router "
+            f"table with header 'Capability | Trigger | Path'",
+        )]
+
+    findings: list[tuple[str, str]] = []
+    declared: set[str] = set()
+
+    for capability, _trigger, path in rows:
+        segment = _parse_path_cell(path)
+        if segment is None:
+            findings.append((
+                LEVEL_FAIL,
+                f"router row '{capability}' has malformed Path '{path}' "
+                f"(expected '{DIR_CAPABILITIES}/<name>/{FILE_CAPABILITY_MD}')",
+            ))
+            continue
+        if capability != segment:
+            findings.append((
+                LEVEL_FAIL,
+                f"router row Capability '{capability}' does not match "
+                f"Path segment '{segment}'",
+            ))
+            # Continue with the path-based name so existence/orphan
+            # checks still cover the cell that is on disk.
+        declared.add(segment)
+        resolved = os.path.join(skill_path, path)
+        if not os.path.isfile(resolved):
+            findings.append((
+                LEVEL_FAIL,
+                f"router row '{segment}' Path does not resolve to an "
+                f"existing {FILE_CAPABILITY_MD}",
+            ))
+
+    on_disk: set[str] = set()
+    for entry in os.listdir(cap_dir):
+        entry_path = os.path.join(cap_dir, entry)
+        if not os.path.isdir(entry_path):
+            continue
+        if not os.path.isfile(os.path.join(entry_path, FILE_CAPABILITY_MD)):
+            continue
+        on_disk.add(entry)
+
+    for orphan in sorted(on_disk - declared):
+        findings.append((
+            LEVEL_FAIL,
+            f"{DIR_CAPABILITIES}/{orphan}/ has no matching router row",
+        ))
+
+    return findings

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1009,6 +1009,34 @@ class AuditRouterTableTests(unittest.TestCase):
         ]
         self.assertGreaterEqual(len(skill_md_fails), 1)
 
+    def test_second_router_table_surfaces_warn_through_audit(self) -> None:
+        """A duplicate router table in SKILL.md surfaces a WARN through audit_skill_system."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
+            body = (
+                "# Demo Skill\n\n"
+                "## Capabilities\n\n"
+                "| Capability | Trigger | Path |\n"
+                "|---|---|---|\n"
+                "| my-cap | When my-cap is needed | "
+                "capabilities/my-cap/capability.md |\n"
+                "\n## Stale duplicate\n\n"
+                "| Capability | Trigger | Path |\n"
+                "|---|---|---|\n"
+                "| ignored | x | capabilities/ignored/capability.md |\n"
+            )
+            write_skill_md(skill_dir, body=body)
+            _write_capability_md(
+                os.path.join(skill_dir, "capabilities", "my-cap")
+            )
+            errors = audit_skill_system(tmpdir, verbose=False)
+        warns = [
+            e for e in errors
+            if e.startswith(LEVEL_WARN) and "second router-shaped table" in e
+        ]
+        self.assertEqual(len(warns), 1)
+        self.assertIn("demo-skill", warns[0])
+
 
 class AuditManifestTests(unittest.TestCase):
     """Tests for manifest checks in audit_skill_system."""

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -995,8 +995,8 @@ class AuditRouterTableTests(unittest.TestCase):
     def test_missing_skill_md_with_capabilities_still_surfaces_fail(self) -> None:
         """A directory under skills/ with capabilities/ but no SKILL.md
         is invisible to find_skill_dirs.  The router-table rule must
-        still surface the missing-SKILL.md FAIL via its second-pass
-        discovery, otherwise the gap is silent.
+        still surface the missing-SKILL.md FAIL — find_router_audit_targets
+        catches the directory via its capabilities/ half.
         """
         with tempfile.TemporaryDirectory() as tmpdir:
             skill_dir = os.path.join(tmpdir, "skills", "demo-skill")

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1032,7 +1032,7 @@ class AuditRouterTableTests(unittest.TestCase):
             errors = audit_skill_system(tmpdir, verbose=False)
         warns = [
             e for e in errors
-            if e.startswith(LEVEL_WARN) and "second router-shaped table" in e
+            if e.startswith(LEVEL_WARN) and "additional router-shaped table" in e
         ]
         self.assertEqual(len(warns), 1)
         self.assertIn("demo-skill", warns[0])

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -992,6 +992,23 @@ class AuditRouterTableTests(unittest.TestCase):
         ]
         self.assertEqual(router_errors, [])
 
+    def test_missing_skill_md_with_capabilities_still_surfaces_fail(self) -> None:
+        """A directory under skills/ with capabilities/ but no SKILL.md
+        is invisible to find_skill_dirs.  The router-table rule must
+        still surface the missing-SKILL.md FAIL via its second-pass
+        discovery, otherwise the gap is silent.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
+            os.makedirs(skill_dir)
+            _write_capability_md(os.path.join(skill_dir, "capabilities", "alpha"))
+            errors = audit_skill_system(tmpdir, verbose=False)
+        skill_md_fails = [
+            e for e in errors
+            if e.startswith(LEVEL_FAIL) and "SKILL.md" in e
+        ]
+        self.assertGreaterEqual(len(skill_md_fails), 1)
+
 
 class AuditManifestTests(unittest.TestCase):
     """Tests for manifest checks in audit_skill_system."""

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -118,9 +118,16 @@ def _create_full_valid_system(system_root: str) -> None:
     Includes a skill with a capability, a role composing 2+ skills,
     and a manifest — all checks pass with zero errors.
     """
-    # Skill with capability
+    # Skill with capability — router table required by the router-table rule
     skill_dir = os.path.join(system_root, "skills", "demo-skill")
-    write_skill_md(skill_dir)
+    router_body = (
+        "# Demo Skill\n\n"
+        "## Capabilities\n\n"
+        "| Capability | Trigger | Path |\n"
+        "|---|---|---|\n"
+        "| my-cap | When my-cap is needed | capabilities/my-cap/capability.md |\n"
+    )
+    write_skill_md(skill_dir, body=router_body)
     cap_dir = os.path.join(skill_dir, "capabilities", "my-cap")
     _write_capability_md(cap_dir, body="# My Capability\n")
 
@@ -856,14 +863,20 @@ class AuditCapabilityEntryNamingTests(unittest.TestCase):
         """A capability with capability.md passes the naming check."""
         with tempfile.TemporaryDirectory() as tmpdir:
             skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
-            write_skill_md(skill_dir)
+            router_body = (
+                "# Demo Skill\n\n"
+                "| Capability | Trigger | Path |\n"
+                "|---|---|---|\n"
+                "| my-cap | When my-cap | capabilities/my-cap/capability.md |\n"
+            )
+            write_skill_md(skill_dir, body=router_body)
             cap_dir = os.path.join(skill_dir, "capabilities", "my-cap")
             _write_capability_md(cap_dir, body="# My Capability\n")
             errors = audit_skill_system(tmpdir, verbose=False)
         fail_errors = [e for e in errors if e.startswith(LEVEL_FAIL)]
         naming_fails = [
             e for e in fail_errors
-            if "capability.md" in e or "SKILL.md" in e
+            if "must use" in e or "entry file" in e
         ]
         self.assertEqual(naming_fails, [])
 
@@ -882,6 +895,102 @@ class AuditCapabilityEntryNamingTests(unittest.TestCase):
         fail_errors = [e for e in errors if e.startswith(LEVEL_FAIL)]
         parse_fails = [e for e in fail_errors if "parse error" in e.lower()]
         self.assertGreaterEqual(len(parse_fails), 1)
+
+
+class AuditRouterTableTests(unittest.TestCase):
+    """Integration tests for the Router Table section.
+
+    The unit tests for parsing and per-skill auditing live in
+    ``test_router_table.py``.  These tests verify that
+    ``audit_skill_system`` discovers the right skills and prefixes
+    findings correctly.
+    """
+
+    _CANONICAL_TABLE = (
+        "## Capabilities\n\n"
+        "| Capability | Trigger | Path |\n"
+        "|---|---|---|\n"
+        "| my-cap | When my-cap is needed | capabilities/my-cap/capability.md |\n"
+    )
+
+    def test_clean_router_via_skills_dir_has_no_findings(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
+            write_skill_md(skill_dir, body="# Skill\n\n" + self._CANONICAL_TABLE)
+            cap_dir = os.path.join(skill_dir, "capabilities", "my-cap")
+            _write_capability_md(cap_dir)
+            errors = audit_skill_system(tmpdir, verbose=False)
+        router_errors = [
+            e for e in errors
+            if "router" in e.lower() or "no matching router row" in e
+        ]
+        self.assertEqual(router_errors, [])
+
+    def test_missing_table_in_skill_root_mode_fails(self) -> None:
+        """A meta-skill at top level with capabilities/ but no router table fails."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "my-meta-skill")
+            write_skill_md(skill_dir, name="my-meta-skill")
+            cap_dir = os.path.join(skill_dir, "capabilities", "alpha")
+            _write_capability_md(cap_dir)
+            errors = audit_skill_system(skill_dir, verbose=False)
+        fail_errors = [e for e in errors if e.startswith(LEVEL_FAIL)]
+        router_fails = [
+            e for e in fail_errors if "no router table" in e
+        ]
+        self.assertEqual(len(router_fails), 1)
+        self.assertIn("my-meta-skill", router_fails[0])
+
+    def test_orphan_directory_fails(self) -> None:
+        """A capability directory with no router row produces a FAIL."""
+        table = (
+            "## Capabilities\n\n"
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | t | capabilities/alpha/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
+            write_skill_md(skill_dir, body="# Skill\n\n" + table)
+            _write_capability_md(os.path.join(skill_dir, "capabilities", "alpha"))
+            _write_capability_md(os.path.join(skill_dir, "capabilities", "extra"))
+            errors = audit_skill_system(tmpdir, verbose=False)
+        orphan_fails = [
+            e for e in errors
+            if e.startswith(LEVEL_FAIL) and "no matching router row" in e
+        ]
+        self.assertEqual(len(orphan_fails), 1)
+        self.assertIn("demo-skill", orphan_fails[0])
+
+    def test_row_without_directory_fails(self) -> None:
+        table = (
+            "## Capabilities\n\n"
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| ghost | t | capabilities/ghost/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
+            write_skill_md(skill_dir, body="# Skill\n\n" + table)
+            os.makedirs(os.path.join(skill_dir, "capabilities"))
+            errors = audit_skill_system(tmpdir, verbose=False)
+        resolution_fails = [
+            e for e in errors
+            if e.startswith(LEVEL_FAIL) and "does not resolve" in e
+        ]
+        self.assertEqual(len(resolution_fails), 1)
+        self.assertIn("demo-skill", resolution_fails[0])
+
+    def test_standalone_skill_is_no_op(self) -> None:
+        """A skill without capabilities/ produces no router-table findings."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
+            write_skill_md(skill_dir)
+            errors = audit_skill_system(tmpdir, verbose=False)
+        router_errors = [
+            e for e in errors if "router" in e.lower() or "matching router" in e
+        ]
+        self.assertEqual(router_errors, [])
 
 
 class AuditManifestTests(unittest.TestCase):

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -237,6 +237,15 @@ class AuditSkillSystemEmptyTests(unittest.TestCase):
         partial_warns = [e for e in warn_errors if "partial audit" in e]
         self.assertGreaterEqual(len(partial_warns), 1)
 
+    def test_skill_root_mode_suppresses_partial_audit_warn(self) -> None:
+        """A top-level SKILL.md makes the audit a single-skill audit, not partial."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "my-meta-skill")
+            write_skill_md(skill_dir, name="my-meta-skill")
+            errors = audit_skill_system(skill_dir, verbose=False)
+        partial_warns = [e for e in errors if "partial audit" in e]
+        self.assertEqual(partial_warns, [])
+
     def test_empty_skills_directory_passes(self) -> None:
         """A system root with an empty skills/ directory passes."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -1356,6 +1356,28 @@ class AuditVerboseBranchTests(unittest.TestCase):
                 audit_skill_system(tmpdir, verbose=True)
         self.assertIn("skipped", stdout.getvalue())
 
+    def test_verbose_skill_root_mode_announces_synthetic_audit_target(self) -> None:
+        """Skill-root mode prints a header line naming the synthetic target.
+
+        find_skill_dirs only walks <root>/skills/, so the existing
+        "Found: 0 skills, 0 capabilities, 0 roles" line would otherwise
+        contradict the per-skill findings the router-table rule emits
+        for the top-level SKILL.md.  The extra line keeps the verbose
+        header honest.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "my-meta-skill")
+            write_skill_md(skill_dir, name="my-meta-skill")
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                audit_skill_system(skill_dir, verbose=True)
+        output = stdout.getvalue()
+        self.assertIn("Skill-root mode: also auditing skill at", output)
+        # Resolved path appears (audit_skill_system abspaths system_root
+        # before printing, so the operator sees a real directory rather
+        # than a relative ".").
+        self.assertIn(os.path.abspath(skill_dir), output)
+
     def test_verbose_manifest_no_skills_section(self) -> None:
         """A manifest without a skills key prints 'no skills section'."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -82,7 +82,41 @@ class FindSkillRootTests(unittest.TestCase):
         assert entry is not None  # for the type checker
         self.assertEqual(entry["name"], "my-meta-skill")
         self.assertEqual(entry["type"], "registered")
-        self.assertEqual(entry["path"], os.path.abspath(skill_dir))
+        # Path shape mirrors the caller's ``system_root`` (matches
+        # ``find_skill_dirs``); the basename is computed from the
+        # absolute path so callers passing "." still get a real name.
+        self.assertEqual(entry["path"], skill_dir)
+
+    def test_relative_path_is_preserved(self) -> None:
+        """find_skill_root must not abspath-promote the caller's path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-meta-skill")
+            write_skill_md(skill_dir, name="my-meta-skill")
+            saved_cwd = os.getcwd()
+            try:
+                os.chdir(tmp)
+                entry = find_skill_root("my-meta-skill")
+            finally:
+                os.chdir(saved_cwd)
+        assert entry is not None
+        self.assertEqual(entry["path"], "my-meta-skill")
+        # name still resolves correctly even with a relative path.
+        self.assertEqual(entry["name"], "my-meta-skill")
+
+    def test_dot_path_resolves_name_from_abspath(self) -> None:
+        """When called with ``"."`` the name comes from the resolved abspath."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-meta-skill")
+            write_skill_md(skill_dir, name="my-meta-skill")
+            saved_cwd = os.getcwd()
+            try:
+                os.chdir(skill_dir)
+                entry = find_skill_root(".")
+            finally:
+                os.chdir(saved_cwd)
+        assert entry is not None
+        self.assertEqual(entry["name"], "my-meta-skill")
+        self.assertEqual(entry["path"], ".")
 
     def test_no_skill_md_returns_none(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,8 +1,9 @@
 """Tests for lib/discovery.py.
 
 Covers ``find_skill_dirs`` (system-root, deployed-system layout),
-``find_skill_root`` (skill-root mode for meta-skill audits), and
-``find_roles``.
+``find_skill_root`` (skill-root mode for meta-skill audits),
+``find_router_audit_targets`` (union of the above plus capability-only
+directories), and ``find_roles``.
 """
 
 import os
@@ -18,7 +19,12 @@ SCRIPTS_DIR = os.path.abspath(
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
-from lib.discovery import find_skill_dirs, find_skill_root, find_roles
+from lib.discovery import (
+    find_roles,
+    find_router_audit_targets,
+    find_skill_dirs,
+    find_skill_root,
+)
 
 
 def _write_capability(cap_dir: str, body: str = "# Capability\n") -> None:
@@ -88,6 +94,56 @@ class FindSkillRootTests(unittest.TestCase):
             inner = os.path.join(tmp, "skills", "inner-skill")
             write_skill_md(inner, name="inner-skill")
             self.assertIsNone(find_skill_root(tmp))
+
+
+# ===================================================================
+# find_router_audit_targets — union of registered, skill-root, and
+# capability-only directories
+# ===================================================================
+
+
+class FindRouterAuditTargetsTests(unittest.TestCase):
+    def test_empty_root_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(find_router_audit_targets(tmp), [])
+
+    def test_includes_registered_skills(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            write_skill_md(os.path.join(tmp, "skills", "alpha"), name="alpha")
+            write_skill_md(os.path.join(tmp, "skills", "beta"), name="beta")
+            names = sorted(t["name"] for t in find_router_audit_targets(tmp))
+        self.assertEqual(names, ["alpha", "beta"])
+
+    def test_includes_skill_root_when_top_level_skill_md_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-meta-skill")
+            write_skill_md(skill_dir, name="my-meta-skill")
+            names = [t["name"] for t in find_router_audit_targets(skill_dir)]
+        self.assertEqual(names, ["my-meta-skill"])
+
+    def test_includes_capability_only_directory_without_skill_md(self) -> None:
+        """A skills/<name>/ with capabilities/ but no SKILL.md must surface."""
+        with tempfile.TemporaryDirectory() as tmp:
+            ghost_dir = os.path.join(tmp, "skills", "ghost")
+            _write_capability(os.path.join(ghost_dir, "capabilities", "alpha"))
+            names = [t["name"] for t in find_router_audit_targets(tmp)]
+        self.assertEqual(names, ["ghost"])
+
+    def test_does_not_double_count_registered_with_capabilities(self) -> None:
+        """A skill that has both SKILL.md and capabilities/ appears once."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "skills", "alpha")
+            write_skill_md(skill_dir, name="alpha")
+            _write_capability(os.path.join(skill_dir, "capabilities", "cap"))
+            targets = find_router_audit_targets(tmp)
+        names = [t["name"] for t in targets]
+        self.assertEqual(names, ["alpha"])
+
+    def test_skips_files_that_are_not_directories_under_skills(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "skills"))
+            write_text(os.path.join(tmp, "skills", "stray.md"), "# stray\n")
+            self.assertEqual(find_router_audit_targets(tmp), [])
 
 
 # ===================================================================

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,9 +1,10 @@
 """Tests for lib/discovery.py.
 
 Covers ``find_skill_dirs`` (system-root, deployed-system layout),
-``_top_level_skill_entry`` (skill-root mode for meta-skill audits — private helper, exercised here as the only non-trivial discovery branch),
-``find_router_audit_targets`` (union of the above plus capability-only
-directories), and ``find_roles``.
+``find_router_audit_targets`` (union of registered skills, capability-only
+directories, and the skill-root entry), and ``find_roles``.  The skill-root
+branch is exercised exclusively through ``find_router_audit_targets`` —
+the underlying helper is private and intentionally not imported here.
 """
 
 import os
@@ -20,7 +21,6 @@ if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
 from lib.discovery import (
-    _top_level_skill_entry,
     find_roles,
     find_router_audit_targets,
     find_skill_dirs,
@@ -66,68 +66,80 @@ class FindSkillDirsSystemRootTests(unittest.TestCase):
 
 
 # ===================================================================
-# _top_level_skill_entry — skill-root mode
+# find_router_audit_targets — skill-root mode (top-level SKILL.md)
 # ===================================================================
 
 
-class TopLevelSkillEntryTests(unittest.TestCase):
-    """``SKILL.md`` at system_root yields a synthetic registered entry."""
+class FindRouterAuditTargetsSkillRootTests(unittest.TestCase):
+    """The skill-root branch is exercised through the public API.
 
-    def test_top_level_skill_md_returns_entry(self) -> None:
+    Each test names the directory shape it builds (top-level SKILL.md,
+    relative call, ``"."`` call, no SKILL.md, nested-only) and asserts
+    the resulting target list.  The internal helper that produces the
+    synthetic registered entry is private; covering it through
+    ``find_router_audit_targets`` upholds the privacy boundary while
+    exercising every branch.
+    """
+
+    def test_top_level_skill_md_yields_registered_entry(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             skill_dir = os.path.join(tmp, "my-meta-skill")
             write_skill_md(skill_dir, name="my-meta-skill")
-            entry = _top_level_skill_entry(skill_dir)
-        self.assertIsNotNone(entry)
-        assert entry is not None  # for the type checker
-        self.assertEqual(entry["name"], "my-meta-skill")
-        self.assertEqual(entry["type"], "registered")
+            targets = find_router_audit_targets(skill_dir)
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["name"], "my-meta-skill")
+        self.assertEqual(targets[0]["type"], "registered")
         # Path shape mirrors the caller's ``system_root`` (matches
-        # ``find_skill_dirs``); the basename is computed from the
-        # absolute path so callers passing "." still get a real name.
-        self.assertEqual(entry["path"], skill_dir)
+        # ``find_skill_dirs``).
+        self.assertEqual(targets[0]["path"], skill_dir)
 
     def test_relative_path_is_preserved(self) -> None:
-        """_top_level_skill_entry must not abspath-promote the caller's path."""
+        """A relative ``system_root`` is not abspath-promoted on the target's path."""
         with tempfile.TemporaryDirectory() as tmp:
             skill_dir = os.path.join(tmp, "my-meta-skill")
             write_skill_md(skill_dir, name="my-meta-skill")
             saved_cwd = os.getcwd()
             try:
                 os.chdir(tmp)
-                entry = _top_level_skill_entry("my-meta-skill")
+                targets = find_router_audit_targets("my-meta-skill")
             finally:
                 os.chdir(saved_cwd)
-        assert entry is not None
-        self.assertEqual(entry["path"], "my-meta-skill")
-        # name still resolves correctly even with a relative path.
-        self.assertEqual(entry["name"], "my-meta-skill")
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["path"], "my-meta-skill")
+        # The name resolves from the absolute path, so callers passing
+        # a relative path still get a real directory name.
+        self.assertEqual(targets[0]["name"], "my-meta-skill")
 
     def test_dot_path_resolves_name_from_abspath(self) -> None:
-        """When called with ``"."`` the name comes from the resolved abspath."""
+        """``find_router_audit_targets(".")`` uses the resolved basename for *name*."""
         with tempfile.TemporaryDirectory() as tmp:
             skill_dir = os.path.join(tmp, "my-meta-skill")
             write_skill_md(skill_dir, name="my-meta-skill")
             saved_cwd = os.getcwd()
             try:
                 os.chdir(skill_dir)
-                entry = _top_level_skill_entry(".")
+                targets = find_router_audit_targets(".")
             finally:
                 os.chdir(saved_cwd)
-        assert entry is not None
-        self.assertEqual(entry["name"], "my-meta-skill")
-        self.assertEqual(entry["path"], ".")
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["name"], "my-meta-skill")
+        self.assertEqual(targets[0]["path"], ".")
 
-    def test_no_skill_md_returns_none(self) -> None:
+    def test_no_skill_md_at_root_yields_no_skill_root_entry(self) -> None:
+        """Without a top-level SKILL.md the skill-root branch contributes nothing."""
         with tempfile.TemporaryDirectory() as tmp:
-            self.assertIsNone(_top_level_skill_entry(tmp))
+            self.assertEqual(find_router_audit_targets(tmp), [])
 
-    def test_only_returns_top_level_not_subdirectory_skill(self) -> None:
-        """_top_level_skill_entry checks only system_root itself, not nested skills."""
+    def test_nested_skill_md_alone_does_not_synthesize_skill_root_entry(self) -> None:
+        """A nested ``skills/<name>/SKILL.md`` must not be promoted to a skill-root entry."""
         with tempfile.TemporaryDirectory() as tmp:
             inner = os.path.join(tmp, "skills", "inner-skill")
             write_skill_md(inner, name="inner-skill")
-            self.assertIsNone(_top_level_skill_entry(tmp))
+            targets = find_router_audit_targets(tmp)
+        # Only the nested skill should appear; no synthetic skill-root entry
+        # for *tmp* itself, because *tmp* has no SKILL.md.
+        names = [t["name"] for t in targets]
+        self.assertEqual(names, ["inner-skill"])
 
 
 # ===================================================================

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,7 +1,7 @@
 """Tests for lib/discovery.py.
 
 Covers ``find_skill_dirs`` (system-root, deployed-system layout),
-``find_skill_root`` (skill-root mode for meta-skill audits),
+``_top_level_skill_entry`` (skill-root mode for meta-skill audits — private helper, exercised here as the only non-trivial discovery branch),
 ``find_router_audit_targets`` (union of the above plus capability-only
 directories), and ``find_roles``.
 """
@@ -20,10 +20,10 @@ if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
 from lib.discovery import (
+    _top_level_skill_entry,
     find_roles,
     find_router_audit_targets,
     find_skill_dirs,
-    find_skill_root,
 )
 
 
@@ -66,18 +66,18 @@ class FindSkillDirsSystemRootTests(unittest.TestCase):
 
 
 # ===================================================================
-# find_skill_root — skill-root mode
+# _top_level_skill_entry — skill-root mode
 # ===================================================================
 
 
-class FindSkillRootTests(unittest.TestCase):
+class TopLevelSkillEntryTests(unittest.TestCase):
     """``SKILL.md`` at system_root yields a synthetic registered entry."""
 
     def test_top_level_skill_md_returns_entry(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             skill_dir = os.path.join(tmp, "my-meta-skill")
             write_skill_md(skill_dir, name="my-meta-skill")
-            entry = find_skill_root(skill_dir)
+            entry = _top_level_skill_entry(skill_dir)
         self.assertIsNotNone(entry)
         assert entry is not None  # for the type checker
         self.assertEqual(entry["name"], "my-meta-skill")
@@ -88,14 +88,14 @@ class FindSkillRootTests(unittest.TestCase):
         self.assertEqual(entry["path"], skill_dir)
 
     def test_relative_path_is_preserved(self) -> None:
-        """find_skill_root must not abspath-promote the caller's path."""
+        """_top_level_skill_entry must not abspath-promote the caller's path."""
         with tempfile.TemporaryDirectory() as tmp:
             skill_dir = os.path.join(tmp, "my-meta-skill")
             write_skill_md(skill_dir, name="my-meta-skill")
             saved_cwd = os.getcwd()
             try:
                 os.chdir(tmp)
-                entry = find_skill_root("my-meta-skill")
+                entry = _top_level_skill_entry("my-meta-skill")
             finally:
                 os.chdir(saved_cwd)
         assert entry is not None
@@ -111,7 +111,7 @@ class FindSkillRootTests(unittest.TestCase):
             saved_cwd = os.getcwd()
             try:
                 os.chdir(skill_dir)
-                entry = find_skill_root(".")
+                entry = _top_level_skill_entry(".")
             finally:
                 os.chdir(saved_cwd)
         assert entry is not None
@@ -120,14 +120,14 @@ class FindSkillRootTests(unittest.TestCase):
 
     def test_no_skill_md_returns_none(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            self.assertIsNone(find_skill_root(tmp))
+            self.assertIsNone(_top_level_skill_entry(tmp))
 
     def test_only_returns_top_level_not_subdirectory_skill(self) -> None:
-        """find_skill_root checks only system_root itself, not nested skills."""
+        """_top_level_skill_entry checks only system_root itself, not nested skills."""
         with tempfile.TemporaryDirectory() as tmp:
             inner = os.path.join(tmp, "skills", "inner-skill")
             write_skill_md(inner, name="inner-skill")
-            self.assertIsNone(find_skill_root(tmp))
+            self.assertIsNone(_top_level_skill_entry(tmp))
 
 
 # ===================================================================

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -213,6 +213,22 @@ class FindRouterAuditTargetsTests(unittest.TestCase):
             names = [t["name"] for t in find_router_audit_targets(tmp)]
         self.assertEqual(names, ["ghost"])
 
+    def test_includes_top_level_capabilities_without_skill_md(self) -> None:
+        """A skill-root with capabilities/ but no SKILL.md must still be audited.
+
+        Without this branch ``find_router_audit_targets`` would skip the
+        broken root entirely, downgrading the
+        ``capabilities/ exists but SKILL.md is missing`` FAIL to the
+        generic partial-audit WARN.  The synthetic entry uses the
+        directory basename because no frontmatter is available.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "broken-meta-skill")
+            _write_capability(os.path.join(skill_dir, "capabilities", "alpha"))
+            targets = find_router_audit_targets(skill_dir)
+        names = [t["name"] for t in targets]
+        self.assertEqual(names, ["broken-meta-skill"])
+
     def test_does_not_double_count_registered_with_capabilities(self) -> None:
         """A skill that has both SKILL.md and capabilities/ appears once."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -110,8 +110,8 @@ class FindRouterAuditTargetsSkillRootTests(unittest.TestCase):
         # a relative path still get a real directory name.
         self.assertEqual(targets[0]["name"], "my-meta-skill")
 
-    def test_dot_path_resolves_name_from_abspath(self) -> None:
-        """``find_router_audit_targets(".")`` uses the resolved basename for *name*."""
+    def test_dot_path_resolves_name_from_frontmatter(self) -> None:
+        """``find_router_audit_targets(".")`` uses the SKILL.md frontmatter name."""
         with tempfile.TemporaryDirectory() as tmp:
             skill_dir = os.path.join(tmp, "my-meta-skill")
             write_skill_md(skill_dir, name="my-meta-skill")
@@ -124,6 +124,44 @@ class FindRouterAuditTargetsSkillRootTests(unittest.TestCase):
         self.assertEqual(len(targets), 1)
         self.assertEqual(targets[0]["name"], "my-meta-skill")
         self.assertEqual(targets[0]["path"], ".")
+
+    def test_skill_root_name_prefers_frontmatter_over_directory(self) -> None:
+        """A renamed worktree directory must not change the finding prefix.
+
+        Mirrors the worktree case (e.g., ``worktrees/feature-foo/`` holding
+        the foundry meta-skill) where the on-disk basename diverges from
+        the canonical SKILL.md ``name``.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "renamed-worktree-dir")
+            write_skill_md(skill_dir, name="canonical-skill-name")
+            targets = find_router_audit_targets(skill_dir)
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["name"], "canonical-skill-name")
+
+    def test_skill_root_falls_back_to_basename_when_frontmatter_missing(self) -> None:
+        """A SKILL.md without frontmatter degrades to the directory basename."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "no-frontmatter-skill")
+            write_text(
+                os.path.join(skill_dir, "SKILL.md"),
+                "# A SKILL.md with no frontmatter at all\n",
+            )
+            targets = find_router_audit_targets(skill_dir)
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["name"], "no-frontmatter-skill")
+
+    def test_skill_root_falls_back_to_basename_when_frontmatter_unparseable(self) -> None:
+        """A SKILL.md with malformed YAML degrades to the directory basename."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "broken-frontmatter-skill")
+            write_text(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: missing closing delimiter\n",
+            )
+            targets = find_router_audit_targets(skill_dir)
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0]["name"], "broken-frontmatter-skill")
 
     def test_no_skill_md_at_root_yields_no_skill_root_entry(self) -> None:
         """Without a top-level SKILL.md the skill-root branch contributes nothing."""
@@ -208,9 +246,10 @@ class FindRouterAuditTargetsTests(unittest.TestCase):
             write_skill_md(os.path.join(tmp, "skills", "beta"), name="beta")
             targets = find_router_audit_targets(tmp)
         names = sorted(t["name"] for t in targets)
-        self.assertEqual(
-            names, ["alpha", "beta", os.path.basename(os.path.abspath(tmp))]
-        )
+        # The skill-root entry uses the SKILL.md frontmatter name
+        # ("integrator-meta-skill"), not the temp-directory basename,
+        # so findings stay stable across worktrees and renames.
+        self.assertEqual(names, ["alpha", "beta", "integrator-meta-skill"])
 
 
 # ===================================================================

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,149 @@
+"""Tests for lib/discovery.py.
+
+Covers ``find_skill_dirs`` discovery in both system-root mode (with
+``skills/`` directory) and skill-root mode (top-level ``SKILL.md``).
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+from helpers import write_text, write_skill_md
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "skill-system-foundry", "scripts")
+)
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.discovery import find_skill_dirs, find_roles
+
+
+def _write_capability(cap_dir: str, body: str = "# Capability\n") -> None:
+    write_text(os.path.join(cap_dir, "capability.md"), body)
+
+
+# ===================================================================
+# find_skill_dirs — system-root mode
+# ===================================================================
+
+
+class FindSkillDirsSystemRootTests(unittest.TestCase):
+    """``skills/<name>/SKILL.md`` discovery (deployed-system layout)."""
+
+    def test_empty_root_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(find_skill_dirs(tmp), [])
+
+    def test_skills_dir_with_one_registered(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "skills", "demo-skill")
+            write_skill_md(skill_dir)
+            entries = find_skill_dirs(tmp)
+        names = [(e["name"], e["type"]) for e in entries]
+        self.assertEqual(names, [("demo-skill", "registered")])
+
+    def test_skills_dir_with_capability(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "skills", "demo-skill")
+            write_skill_md(skill_dir)
+            _write_capability(os.path.join(skill_dir, "capabilities", "my-cap"))
+            entries = find_skill_dirs(tmp)
+        types = sorted((e["name"], e["type"]) for e in entries)
+        self.assertEqual(
+            types, [("demo-skill", "registered"), ("my-cap", "capability")]
+        )
+        cap_entry = [e for e in entries if e["type"] == "capability"][0]
+        self.assertEqual(cap_entry["parent"], "demo-skill")
+
+
+# ===================================================================
+# find_skill_dirs — skill-root mode
+# ===================================================================
+
+
+class FindSkillDirsSkillRootTests(unittest.TestCase):
+    """Top-level ``SKILL.md`` discovery (single-skill layout)."""
+
+    def test_top_level_skill_md_registers_root(self) -> None:
+        """A SKILL.md at system_root registers system_root as a skill."""
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-meta-skill")
+            write_skill_md(skill_dir, name="my-meta-skill")
+            entries = find_skill_dirs(skill_dir)
+        registered = [e for e in entries if e["type"] == "registered"]
+        self.assertEqual(len(registered), 1)
+        self.assertEqual(registered[0]["name"], "my-meta-skill")
+        self.assertEqual(registered[0]["path"], os.path.abspath(skill_dir))
+
+    def test_top_level_skill_with_capabilities(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-meta-skill")
+            write_skill_md(skill_dir, name="my-meta-skill")
+            _write_capability(os.path.join(skill_dir, "capabilities", "alpha"))
+            _write_capability(os.path.join(skill_dir, "capabilities", "beta"))
+            entries = find_skill_dirs(skill_dir)
+        names = sorted((e["name"], e["type"]) for e in entries)
+        self.assertEqual(
+            names,
+            [
+                ("alpha", "capability"),
+                ("beta", "capability"),
+                ("my-meta-skill", "registered"),
+            ],
+        )
+        # Capability entries record the meta-skill as parent.
+        for e in entries:
+            if e["type"] == "capability":
+                self.assertEqual(e["parent"], "my-meta-skill")
+
+    def test_skill_root_and_skills_dir_coexist(self) -> None:
+        """Both modes can apply at once; results are concatenated."""
+        with tempfile.TemporaryDirectory() as tmp:
+            outer = os.path.join(tmp, "outer-skill")
+            write_skill_md(outer, name="outer-skill")
+            inner = os.path.join(outer, "skills", "inner-skill")
+            write_skill_md(inner, name="inner-skill")
+            entries = find_skill_dirs(outer)
+        names = sorted(e["name"] for e in entries if e["type"] == "registered")
+        self.assertEqual(names, ["inner-skill", "outer-skill"])
+
+    def test_no_skill_md_no_skills_dir_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(find_skill_dirs(tmp), [])
+
+
+# ===================================================================
+# find_roles
+# ===================================================================
+
+
+class FindRolesTests(unittest.TestCase):
+    """``find_roles`` discovers role markdown files under ``roles/<group>/``."""
+
+    def test_no_roles_dir_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(find_roles(tmp), [])
+
+    def test_finds_role_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            role_path = os.path.join(tmp, "roles", "ops", "reviewer.md")
+            write_text(role_path, "# Reviewer\n")
+            entries = find_roles(tmp)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["name"], "reviewer")
+        self.assertEqual(entries[0]["group"], "ops")
+
+    def test_skips_readme(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "roles", "ops")
+            write_text(os.path.join(base, "README.md"), "# README\n")
+            write_text(os.path.join(base, "reviewer.md"), "# Reviewer\n")
+            entries = find_roles(tmp)
+        names = [e["name"] for e in entries]
+        self.assertEqual(names, ["reviewer"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -64,6 +64,23 @@ class FindSkillDirsSystemRootTests(unittest.TestCase):
         cap_entry = [e for e in entries if e["type"] == "capability"][0]
         self.assertEqual(cap_entry["parent"], "demo-skill")
 
+    def test_capabilities_are_returned_in_sorted_order(self) -> None:
+        """Capability entries are sorted so output is deterministic across filesystems.
+
+        ``os.listdir`` order is filesystem-defined; sorting in
+        ``find_skill_dirs`` keeps audit output stable on APFS, ext4,
+        and NTFS alike.  The capabilities are created here in a
+        non-alphabetical order to make the sort meaningful.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "skills", "demo-skill")
+            write_skill_md(skill_dir)
+            for cap in ("zeta", "alpha", "mu"):
+                _write_capability(os.path.join(skill_dir, "capabilities", cap))
+            entries = find_skill_dirs(tmp)
+        cap_names = [e["name"] for e in entries if e["type"] == "capability"]
+        self.assertEqual(cap_names, ["alpha", "mu", "zeta"])
+
 
 # ===================================================================
 # find_router_audit_targets — skill-root mode (top-level SKILL.md)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -179,6 +179,27 @@ class FindRouterAuditTargetsTests(unittest.TestCase):
             write_text(os.path.join(tmp, "skills", "stray.md"), "# stray\n")
             self.assertEqual(find_router_audit_targets(tmp), [])
 
+    def test_returns_union_when_top_level_skill_and_skills_tree_coexist(self) -> None:
+        """A directory that is itself a skill *and* hosts a skills/ tree
+        (e.g., an integrator's meta-skill kept alongside deployed skills)
+        must surface every audit target — the meta-skill at the top
+        level and each subdirectory under skills/.  Names must not
+        collide because the candidate iterator never walks the system
+        root itself.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            write_skill_md(tmp, name="integrator-meta-skill")
+            write_skill_md(os.path.join(tmp, "skills", "alpha"), name="alpha")
+            _write_capability(
+                os.path.join(tmp, "skills", "alpha", "capabilities", "cap")
+            )
+            write_skill_md(os.path.join(tmp, "skills", "beta"), name="beta")
+            targets = find_router_audit_targets(tmp)
+        names = sorted(t["name"] for t in targets)
+        self.assertEqual(
+            names, ["alpha", "beta", os.path.basename(os.path.abspath(tmp))]
+        )
+
 
 # ===================================================================
 # find_roles

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,7 +1,8 @@
 """Tests for lib/discovery.py.
 
-Covers ``find_skill_dirs`` discovery in both system-root mode (with
-``skills/`` directory) and skill-root mode (top-level ``SKILL.md``).
+Covers ``find_skill_dirs`` (system-root, deployed-system layout),
+``find_skill_root`` (skill-root mode for meta-skill audits), and
+``find_roles``.
 """
 
 import os
@@ -17,7 +18,7 @@ SCRIPTS_DIR = os.path.abspath(
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
-from lib.discovery import find_skill_dirs, find_roles
+from lib.discovery import find_skill_dirs, find_skill_root, find_roles
 
 
 def _write_capability(cap_dir: str, body: str = "# Capability\n") -> None:
@@ -59,59 +60,34 @@ class FindSkillDirsSystemRootTests(unittest.TestCase):
 
 
 # ===================================================================
-# find_skill_dirs — skill-root mode
+# find_skill_root — skill-root mode
 # ===================================================================
 
 
-class FindSkillDirsSkillRootTests(unittest.TestCase):
-    """Top-level ``SKILL.md`` discovery (single-skill layout)."""
+class FindSkillRootTests(unittest.TestCase):
+    """``SKILL.md`` at system_root yields a synthetic registered entry."""
 
-    def test_top_level_skill_md_registers_root(self) -> None:
-        """A SKILL.md at system_root registers system_root as a skill."""
+    def test_top_level_skill_md_returns_entry(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             skill_dir = os.path.join(tmp, "my-meta-skill")
             write_skill_md(skill_dir, name="my-meta-skill")
-            entries = find_skill_dirs(skill_dir)
-        registered = [e for e in entries if e["type"] == "registered"]
-        self.assertEqual(len(registered), 1)
-        self.assertEqual(registered[0]["name"], "my-meta-skill")
-        self.assertEqual(registered[0]["path"], os.path.abspath(skill_dir))
+            entry = find_skill_root(skill_dir)
+        self.assertIsNotNone(entry)
+        assert entry is not None  # for the type checker
+        self.assertEqual(entry["name"], "my-meta-skill")
+        self.assertEqual(entry["type"], "registered")
+        self.assertEqual(entry["path"], os.path.abspath(skill_dir))
 
-    def test_top_level_skill_with_capabilities(self) -> None:
+    def test_no_skill_md_returns_none(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            skill_dir = os.path.join(tmp, "my-meta-skill")
-            write_skill_md(skill_dir, name="my-meta-skill")
-            _write_capability(os.path.join(skill_dir, "capabilities", "alpha"))
-            _write_capability(os.path.join(skill_dir, "capabilities", "beta"))
-            entries = find_skill_dirs(skill_dir)
-        names = sorted((e["name"], e["type"]) for e in entries)
-        self.assertEqual(
-            names,
-            [
-                ("alpha", "capability"),
-                ("beta", "capability"),
-                ("my-meta-skill", "registered"),
-            ],
-        )
-        # Capability entries record the meta-skill as parent.
-        for e in entries:
-            if e["type"] == "capability":
-                self.assertEqual(e["parent"], "my-meta-skill")
+            self.assertIsNone(find_skill_root(tmp))
 
-    def test_skill_root_and_skills_dir_coexist(self) -> None:
-        """Both modes can apply at once; results are concatenated."""
+    def test_only_returns_top_level_not_subdirectory_skill(self) -> None:
+        """find_skill_root checks only system_root itself, not nested skills."""
         with tempfile.TemporaryDirectory() as tmp:
-            outer = os.path.join(tmp, "outer-skill")
-            write_skill_md(outer, name="outer-skill")
-            inner = os.path.join(outer, "skills", "inner-skill")
+            inner = os.path.join(tmp, "skills", "inner-skill")
             write_skill_md(inner, name="inner-skill")
-            entries = find_skill_dirs(outer)
-        names = sorted(e["name"] for e in entries if e["type"] == "registered")
-        self.assertEqual(names, ["inner-skill", "outer-skill"])
-
-    def test_no_skill_md_no_skills_dir_returns_empty(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            self.assertEqual(find_skill_dirs(tmp), [])
+            self.assertIsNone(find_skill_root(tmp))
 
 
 # ===================================================================

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -129,6 +129,34 @@ class ParseRouterTableTests(unittest.TestCase):
         names = [r[0] for r in rows or []]
         self.assertEqual(names, ["alpha", "beta"])
 
+    def test_tilde_fenced_table_is_ignored(self) -> None:
+        """Tilde fences (``~~~``) are stripped on par with backticks."""
+        body = (
+            "# Skill\n\n"
+            "~~~markdown\n"
+            + CANONICAL_TABLE
+            + "~~~\n"
+        )
+        self.assertIsNone(parse_router_table(body))
+
+    def test_tilde_fenced_decoy_does_not_shadow_real_router(self) -> None:
+        decoy = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| decoy | x | capabilities/decoy/capability.md |\n"
+        )
+        body = (
+            "# Skill\n\n"
+            "~~~markdown\n"
+            + decoy
+            + "~~~\n\n"
+            "## Capabilities\n\n"
+            + CANONICAL_TABLE
+        )
+        rows = parse_router_table(body)
+        names = [r[0] for r in rows or []]
+        self.assertEqual(names, ["alpha", "beta"])
+
     def test_trigger_cell_with_escaped_pipe_is_preserved(self) -> None:
         """A Trigger cell containing ``\\|`` must not truncate the table."""
         body = (

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -507,6 +507,45 @@ class AuditRouterTableFailureTests(unittest.TestCase):
             f"unrecoverable path leaves the on-disk dir genuinely orphan, got: {msgs}",
         )
 
+    def test_traversal_segment_in_path_is_malformed(self) -> None:
+        """A Path segment of ``.`` or ``..`` must be flagged as malformed.
+
+        ``os.path.normpath`` would otherwise collapse such a path so it
+        could resolve to an unrelated ``capability.md`` and silently
+        escape the ``capabilities/<name>/`` shape the audit enforces.
+        """
+        for traversal in (".", ".."):
+            with self.subTest(segment=traversal):
+                table = (
+                    "| Capability | Trigger | Path |\n"
+                    "|---|---|---|\n"
+                    f"| alpha | t | capabilities/{traversal}/capability.md |\n"
+                )
+                with tempfile.TemporaryDirectory() as tmp:
+                    _build_skill(tmp, table, capability_dirs=["alpha"])
+                    findings = audit_router_table(tmp)
+                msgs = [m for _, m in findings]
+                self.assertTrue(
+                    any("malformed Path" in m for m in msgs),
+                    f"expected malformed-Path FAIL for '{traversal}', got: {msgs}",
+                )
+
+    def test_backslash_segment_in_path_is_malformed(self) -> None:
+        """A Path segment containing a backslash is not a single capability name."""
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | t | capabilities/al\\pha/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["alpha"])
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        self.assertTrue(
+            any("malformed Path" in m for m in msgs),
+            f"expected malformed-Path FAIL for backslash segment, got: {msgs}",
+        )
+
     def test_capability_path_mismatch_fails(self) -> None:
         """Capability column != path segment is a FAIL."""
         table = (

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -485,6 +485,58 @@ class AuditRouterTableFailureTests(unittest.TestCase):
                     f"expected exactly one FAIL for {decorated!r}, got: {msgs}",
                 )
 
+    def test_recoverable_malformed_path_also_flags_missing_target(self) -> None:
+        """Recovery suppresses the orphan check, but a missing target
+        still surfaces.
+
+        When ``_recover_segment`` succeeds we add the segment to
+        ``declared`` so the on-disk orphan finding does not double-flag
+        a directory the row clearly intended to reference.  Without an
+        explicit existence check on the recovered path that suppression
+        would also hide a genuinely missing ``capability.md`` — the
+        author would fix the decoration, push, and only then learn the
+        target is absent.  Reporting both in one pass keeps the audit
+        complete.
+        """
+        decorations = (
+            "`capabilities/alpha/capability.md`",
+            "[link](capabilities/alpha/capability.md)",
+            "./capabilities/alpha/capability.md",
+            "capabilities/alpha/capability.md#anchor",
+        )
+        for decorated in decorations:
+            with self.subTest(path=decorated):
+                table = (
+                    "| Capability | Trigger | Path |\n"
+                    "|---|---|---|\n"
+                    f"| alpha | t | {decorated} |\n"
+                )
+                with tempfile.TemporaryDirectory() as tmp:
+                    # capabilities/ exists but the recovered ``alpha``
+                    # subdirectory does not — recovery can resolve the
+                    # name from the decorated cell, yet there is no
+                    # capability.md to point at.
+                    _build_skill(tmp, table, capability_dirs=["beta"])
+                    os.remove(
+                        os.path.join(
+                            tmp, "capabilities", "beta", "capability.md"
+                        )
+                    )
+                    os.rmdir(os.path.join(tmp, "capabilities", "beta"))
+                    findings = audit_router_table(tmp)
+                msgs = [m for _, m in findings]
+                self.assertTrue(
+                    any("malformed Path" in m for m in msgs),
+                    f"expected malformed-Path FAIL for {decorated!r}, got: {msgs}",
+                )
+                self.assertTrue(
+                    any(
+                        "alpha" in m and "does not resolve" in m
+                        for m in msgs
+                    ),
+                    f"expected missing-target FAIL for recovered 'alpha', got: {msgs}",
+                )
+
     def test_unrecoverable_malformed_path_still_flags_orphan(self) -> None:
         """A malformed Path with no recoverable segment still surfaces the
         on-disk directory as orphan — there is no alternative signal that

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -154,11 +154,17 @@ class AuditRouterTableNoOpTests(unittest.TestCase):
             write_skill_md(tmp)
             self.assertEqual(audit_router_table(tmp), [])
 
-    def test_missing_skill_md_returns_empty(self) -> None:
-        """Missing SKILL.md is flagged elsewhere; this rule does not double-flag."""
+    def test_missing_skill_md_with_capabilities_fails(self) -> None:
+        """capabilities/ without SKILL.md is a router skill that lost its
+        entry point — find_skill_dirs would otherwise drop it silently,
+        so this rule owns the FAIL."""
         with tempfile.TemporaryDirectory() as tmp:
             _write_capability(os.path.join(tmp, "capabilities", "alpha"))
-            self.assertEqual(audit_router_table(tmp), [])
+            findings = audit_router_table(tmp)
+        self.assertEqual(len(findings), 1)
+        level, msg = findings[0]
+        self.assertEqual(level, LEVEL_FAIL)
+        self.assertIn("no SKILL.md", msg)
 
 
 # ===================================================================

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -48,6 +48,22 @@ CANONICAL_TABLE = (
 )
 
 
+def _parse_rows(body: str) -> list[tuple[str, str, str]]:
+    """Unwrap ``parse_router_table`` for tests that expect a clean parse.
+
+    Asserts that the parser found a router table and reported no parse
+    errors, then returns the row list.  Tests for the None case continue
+    to call ``parse_router_table`` directly.
+    """
+    result = parse_router_table(body)
+    if result is None:
+        raise AssertionError("expected a router table in body, got None")
+    rows, errors = result
+    if errors:
+        raise AssertionError(f"unexpected parse errors: {errors}")
+    return rows
+
+
 # ===================================================================
 # parse_router_table
 # ===================================================================
@@ -55,7 +71,7 @@ CANONICAL_TABLE = (
 
 class ParseRouterTableTests(unittest.TestCase):
     def test_canonical_table_returns_rows(self) -> None:
-        rows = parse_router_table(CANONICAL_TABLE)
+        rows = _parse_rows(CANONICAL_TABLE)
         self.assertEqual(
             rows,
             [
@@ -86,8 +102,8 @@ class ParseRouterTableTests(unittest.TestCase):
             "|---|---|---|\n"
             "| ignored | x | capabilities/ignored/capability.md |\n"
         )
-        rows = parse_router_table(body)
-        names = [r[0] for r in rows or []]
+        rows = _parse_rows(body)
+        names = [r[0] for r in rows]
         self.assertEqual(names, ["alpha", "beta"])
 
     def test_header_with_bold_and_backticks(self) -> None:
@@ -96,7 +112,7 @@ class ParseRouterTableTests(unittest.TestCase):
             "|---|---|---|\n"
             "| alpha | t | capabilities/alpha/capability.md |\n"
         )
-        rows = parse_router_table(body)
+        rows = _parse_rows(body)
         self.assertEqual(rows, [("alpha", "t", "capabilities/alpha/capability.md")])
 
     def test_table_inside_code_fence_is_ignored(self) -> None:
@@ -125,8 +141,8 @@ class ParseRouterTableTests(unittest.TestCase):
             "## Capabilities\n\n"
             + CANONICAL_TABLE
         )
-        rows = parse_router_table(body)
-        names = [r[0] for r in rows or []]
+        rows = _parse_rows(body)
+        names = [r[0] for r in rows]
         self.assertEqual(names, ["alpha", "beta"])
 
     def test_tilde_fenced_table_is_ignored(self) -> None:
@@ -153,8 +169,8 @@ class ParseRouterTableTests(unittest.TestCase):
             "## Capabilities\n\n"
             + CANONICAL_TABLE
         )
-        rows = parse_router_table(body)
-        names = [r[0] for r in rows or []]
+        rows = _parse_rows(body)
+        names = [r[0] for r in rows]
         self.assertEqual(names, ["alpha", "beta"])
 
     def test_trigger_cell_with_escaped_pipe_is_preserved(self) -> None:
@@ -165,7 +181,7 @@ class ParseRouterTableTests(unittest.TestCase):
             "| alpha | when alpha \\| beta is needed | capabilities/alpha/capability.md |\n"
             "| gamma | t | capabilities/gamma/capability.md |\n"
         )
-        rows = parse_router_table(body)
+        rows = _parse_rows(body)
         self.assertEqual(
             rows,
             [
@@ -363,6 +379,77 @@ class AuditRouterTableFailureTests(unittest.TestCase):
         # Path-based existence check should still pass; only the
         # mismatch finding should appear.
         self.assertEqual(len(findings), 1)
+
+    def test_mid_table_malformed_row_does_not_truncate(self) -> None:
+        """A malformed mid-row must surface a FAIL and not drop trailing rows.
+
+        Regression: parser previously broke at the first wrong-cell-count
+        row, dropping later valid rows and surfacing them as misleading
+        orphan errors.
+        """
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | t | capabilities/alpha/capability.md |\n"
+            "| broken |\n"
+            "| beta | t | capabilities/beta/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["alpha", "beta"])
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        # Parse error surfaces.
+        self.assertTrue(
+            any("has 1 columns" in m or "has 1 column" in m for m in msgs),
+            f"expected wrong-column-count FAIL, got: {msgs}",
+        )
+        # Trailing valid row was still parsed — beta is not flagged orphan.
+        self.assertFalse(
+            any("capabilities/beta/" in m and "no matching router row" in m for m in msgs),
+            f"trailing valid row should not be reported as orphan: {msgs}",
+        )
+
+    def test_duplicate_router_rows_fail(self) -> None:
+        """Two rows declaring the same capability segment must produce a FAIL."""
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | first  | capabilities/alpha/capability.md |\n"
+            "| alpha | second | capabilities/alpha/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["alpha"])
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        self.assertTrue(
+            any("duplicate row for 'alpha'" in m for m in msgs),
+            f"expected duplicate-row FAIL, got: {msgs}",
+        )
+
+
+# ===================================================================
+# _strip_fenced_regions — fence run length
+# ===================================================================
+
+
+class StripFencedRegionsTests(unittest.TestCase):
+    """Long-fence behavior: a 4-tick fence is not closed by a 3-tick line."""
+
+    def test_long_backtick_fence_survives_short_inner_close(self) -> None:
+        """````-fenced block must not be closed by ``` inside it."""
+        body = (
+            "# Skill\n\n"
+            "````\n"
+            "```\n"  # inner short fence — must NOT close the outer
+            + CANONICAL_TABLE
+            + "```\n"  # still inside the outer fence
+            "````\n"  # this is the real closer
+            "## Capabilities\n\n"
+            + CANONICAL_TABLE
+        )
+        rows = _parse_rows(body)
+        names = [r[0] for r in rows]
+        self.assertEqual(names, ["alpha", "beta"])
 
 
 if __name__ == "__main__":

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -53,7 +53,7 @@ def _parse_rows(body: str) -> list[tuple[str, str, str]]:
 
     Asserts that the parser found a router table and reported no FAIL
     findings, then returns the row list.  WARN findings (e.g., the
-    "second router-shaped table" warning) are tolerated here; tests
+    "additional router-shaped table" warning) are tolerated here; tests
     that need to assert on warnings call ``parse_router_table``
     directly.  Tests for the ``None`` case also call the parser
     directly.
@@ -113,7 +113,7 @@ class ParseRouterTableTests(unittest.TestCase):
         self.assertEqual(names, ["alpha", "beta"])
         warns = [f for f in findings if f[0] == LEVEL_WARN]
         self.assertEqual(len(warns), 1)
-        self.assertIn("second router-shaped table", warns[0][1])
+        self.assertIn("additional router-shaped table", warns[0][1])
 
     def test_third_router_table_emits_second_warning(self) -> None:
         """Three canonical-headed tables → two WARN findings (one per extra)."""
@@ -650,7 +650,7 @@ class AuditRouterTableFailureTests(unittest.TestCase):
         warns = [f for f in findings if f[0] == LEVEL_WARN]
         fails = [f for f in findings if f[0] == LEVEL_FAIL]
         self.assertEqual(len(warns), 1)
-        self.assertIn("second router-shaped table", warns[0][1])
+        self.assertIn("additional router-shaped table", warns[0][1])
         self.assertEqual(fails, [])
 
 

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -16,7 +16,7 @@ SCRIPTS_DIR = os.path.abspath(
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
-from lib.constants import LEVEL_FAIL
+from lib.constants import LEVEL_FAIL, LEVEL_WARN
 from lib.router_table import (
     audit_router_table,
     expected_path,
@@ -51,16 +51,20 @@ CANONICAL_TABLE = (
 def _parse_rows(body: str) -> list[tuple[str, str, str]]:
     """Unwrap ``parse_router_table`` for tests that expect a clean parse.
 
-    Asserts that the parser found a router table and reported no parse
-    errors, then returns the row list.  Tests for the None case continue
-    to call ``parse_router_table`` directly.
+    Asserts that the parser found a router table and reported no FAIL
+    findings, then returns the row list.  WARN findings (e.g., the
+    "second router-shaped table" warning) are tolerated here; tests
+    that need to assert on warnings call ``parse_router_table``
+    directly.  Tests for the ``None`` case also call the parser
+    directly.
     """
     result = parse_router_table(body)
     if result is None:
         raise AssertionError("expected a router table in body, got None")
-    rows, errors = result
-    if errors:
-        raise AssertionError(f"unexpected parse errors: {errors}")
+    rows, findings = result
+    fails = [f for f in findings if f[0] == LEVEL_FAIL]
+    if fails:
+        raise AssertionError(f"unexpected parse failures: {fails}")
     return rows
 
 
@@ -102,9 +106,60 @@ class ParseRouterTableTests(unittest.TestCase):
             "|---|---|---|\n"
             "| ignored | x | capabilities/ignored/capability.md |\n"
         )
-        rows = _parse_rows(body)
+        result = parse_router_table(body)
+        assert result is not None
+        rows, findings = result
         names = [r[0] for r in rows]
         self.assertEqual(names, ["alpha", "beta"])
+        warns = [f for f in findings if f[0] == LEVEL_WARN]
+        self.assertEqual(len(warns), 1)
+        self.assertIn("second router-shaped table", warns[0][1])
+
+    def test_third_router_table_emits_second_warning(self) -> None:
+        """Three canonical-headed tables → two WARN findings (one per extra)."""
+        extra = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| z | x | capabilities/z/capability.md |\n"
+        )
+        body = "# Skill\n\n" + CANONICAL_TABLE + "\n" + extra + "\n" + extra
+        result = parse_router_table(body)
+        assert result is not None
+        _, findings = result
+        warns = [f for f in findings if f[0] == LEVEL_WARN]
+        self.assertEqual(len(warns), 2)
+
+    def test_second_table_without_separator_does_not_warn(self) -> None:
+        """A pseudo-header without a real separator is not a second table."""
+        body = (
+            "# Skill\n\n"
+            + CANONICAL_TABLE
+            + "\nA pseudo header below:\n\n"
+            "| Capability | Trigger | Path |\n"
+            "Just text after the header, no separator.\n"
+        )
+        result = parse_router_table(body)
+        assert result is not None
+        _, findings = result
+        warns = [f for f in findings if f[0] == LEVEL_WARN]
+        self.assertEqual(warns, [])
+
+    def test_fenced_second_table_does_not_warn(self) -> None:
+        """A second table inside a code fence is stripped — no WARN."""
+        body = (
+            "# Skill\n\n"
+            + CANONICAL_TABLE
+            + "\n```markdown\n"
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| example | x | capabilities/example/capability.md |\n"
+            "```\n"
+        )
+        result = parse_router_table(body)
+        assert result is not None
+        _, findings = result
+        warns = [f for f in findings if f[0] == LEVEL_WARN]
+        self.assertEqual(warns, [])
 
     def test_header_with_bold_and_backticks(self) -> None:
         body = (
@@ -440,6 +495,49 @@ class AuditRouterTableFailureTests(unittest.TestCase):
             any("duplicate row for 'alpha'" in m for m in msgs),
             f"expected duplicate-row FAIL, got: {msgs}",
         )
+
+    def test_empty_trigger_cell_fails(self) -> None:
+        """A row with an empty Trigger cell is a structural failure.
+
+        Trigger content is otherwise opaque, but emptiness is almost
+        certainly a half-edited row, so the audit flags it.  The
+        capability is still wired up correctly otherwise — only the
+        empty-trigger FAIL should surface.
+        """
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha |  | capabilities/alpha/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["alpha"])
+            findings = audit_router_table(tmp)
+        self.assertEqual(len(findings), 1)
+        level, msg = findings[0]
+        self.assertEqual(level, LEVEL_FAIL)
+        self.assertIn("empty Trigger", msg)
+        self.assertIn("'alpha'", msg)
+
+    def test_second_router_table_emits_warn(self) -> None:
+        """A second canonical-headed table in SKILL.md surfaces a WARN.
+
+        The first table is still audited normally; the WARN directs
+        the author to consolidate.  The skill is otherwise clean, so
+        only the WARN should appear.
+        """
+        body = CANONICAL_TABLE + "\n## Stale\n\n" + (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| ignored | x | capabilities/ignored/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, body, capability_dirs=["alpha", "beta"])
+            findings = audit_router_table(tmp)
+        warns = [f for f in findings if f[0] == LEVEL_WARN]
+        fails = [f for f in findings if f[0] == LEVEL_FAIL]
+        self.assertEqual(len(warns), 1)
+        self.assertIn("second router-shaped table", warns[0][1])
+        self.assertEqual(fails, [])
 
 
 # ===================================================================

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -115,6 +115,21 @@ class ParseRouterTableTests(unittest.TestCase):
         rows = _parse_rows(body)
         self.assertEqual(rows, [("alpha", "t", "capabilities/alpha/capability.md")])
 
+    def test_header_with_underscore_italics(self) -> None:
+        """``_Capability_`` (CommonMark italic with underscores) is recognized.
+
+        CommonMark italic emphasis can be expressed with either ``*`` or
+        ``_``; the strip set must accept both so authors do not see an
+        opaque "no router table" failure for underscore decoration.
+        """
+        body = (
+            "| _Capability_ | _Trigger_ | _Path_ |\n"
+            "|---|---|---|\n"
+            "| alpha | t | capabilities/alpha/capability.md |\n"
+        )
+        rows = _parse_rows(body)
+        self.assertEqual(rows, [("alpha", "t", "capabilities/alpha/capability.md")])
+
     def test_table_inside_code_fence_is_ignored(self) -> None:
         """Fenced tables are stripped so doc examples cannot shadow the canonical router."""
         body = (

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -1,0 +1,290 @@
+"""Tests for lib/router_table.py.
+
+Covers ``parse_router_table`` and ``audit_router_table``.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+from helpers import write_text, write_skill_md
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "skill-system-foundry", "scripts")
+)
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.constants import LEVEL_FAIL
+from lib.router_table import (
+    audit_router_table,
+    expected_path,
+    parse_router_table,
+)
+
+
+def _write_capability(cap_dir: str) -> None:
+    write_text(os.path.join(cap_dir, "capability.md"), "# Capability\n")
+
+
+def _build_skill(
+    skill_dir: str, table: str | None, capability_dirs: list[str],
+) -> None:
+    """Create a skill on disk with optional router table and capability dirs."""
+    body = "# Skill\n"
+    if table is not None:
+        body += "\n## Capabilities\n\n" + table + "\n"
+    write_skill_md(skill_dir, body=body)
+    for cap in capability_dirs:
+        _write_capability(os.path.join(skill_dir, "capabilities", cap))
+
+
+CANONICAL_TABLE = (
+    "| Capability | Trigger | Path |\n"
+    "|---|---|---|\n"
+    "| alpha | When alpha is needed | capabilities/alpha/capability.md |\n"
+    "| beta | When beta is needed | capabilities/beta/capability.md |\n"
+)
+
+
+# ===================================================================
+# parse_router_table
+# ===================================================================
+
+
+class ParseRouterTableTests(unittest.TestCase):
+    def test_canonical_table_returns_rows(self) -> None:
+        rows = parse_router_table(CANONICAL_TABLE)
+        self.assertEqual(
+            rows,
+            [
+                ("alpha", "When alpha is needed", "capabilities/alpha/capability.md"),
+                ("beta", "When beta is needed", "capabilities/beta/capability.md"),
+            ],
+        )
+
+    def test_no_table_returns_none(self) -> None:
+        body = "# Skill\n\nNo tables here.\n"
+        self.assertIsNone(parse_router_table(body))
+
+    def test_only_non_router_table_returns_none(self) -> None:
+        body = (
+            "# Skill\n\n"
+            "| Foo | Bar |\n"
+            "|---|---|\n"
+            "| a | b |\n"
+        )
+        self.assertIsNone(parse_router_table(body))
+
+    def test_first_router_table_wins(self) -> None:
+        body = (
+            "# Skill\n\n"
+            + CANONICAL_TABLE
+            + "\n## Other\n\n"
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| ignored | x | capabilities/ignored/capability.md |\n"
+        )
+        rows = parse_router_table(body)
+        names = [r[0] for r in rows or []]
+        self.assertEqual(names, ["alpha", "beta"])
+
+    def test_header_with_bold_and_backticks(self) -> None:
+        body = (
+            "| **Capability** | `Trigger` | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | t | capabilities/alpha/capability.md |\n"
+        )
+        rows = parse_router_table(body)
+        self.assertEqual(rows, [("alpha", "t", "capabilities/alpha/capability.md")])
+
+    def test_table_inside_code_fence_is_recognized(self) -> None:
+        """Decision: don't strip fences — fenced tables count."""
+        body = (
+            "# Skill\n\n"
+            "```markdown\n"
+            + CANONICAL_TABLE
+            + "```\n"
+        )
+        rows = parse_router_table(body)
+        self.assertIsNotNone(rows)
+        self.assertEqual(len(rows or []), 2)
+
+    def test_header_without_separator_is_skipped(self) -> None:
+        """A header row without a following separator is not a real table."""
+        body = (
+            "| Capability | Trigger | Path |\n"
+            "Just text, not a separator.\n"
+        )
+        self.assertIsNone(parse_router_table(body))
+
+    def test_wrong_column_order_returns_none(self) -> None:
+        body = (
+            "| Trigger | Capability | Path |\n"
+            "|---|---|---|\n"
+            "| t | alpha | capabilities/alpha/capability.md |\n"
+        )
+        self.assertIsNone(parse_router_table(body))
+
+    def test_empty_body_returns_none(self) -> None:
+        self.assertIsNone(parse_router_table(""))
+
+
+# ===================================================================
+# expected_path
+# ===================================================================
+
+
+class ExpectedPathTests(unittest.TestCase):
+    def test_returns_canonical_path(self) -> None:
+        self.assertEqual(
+            expected_path("alpha"), "capabilities/alpha/capability.md"
+        )
+
+
+# ===================================================================
+# audit_router_table — no-op cases
+# ===================================================================
+
+
+class AuditRouterTableNoOpTests(unittest.TestCase):
+    def test_standalone_skill_no_capabilities_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            write_skill_md(tmp)
+            self.assertEqual(audit_router_table(tmp), [])
+
+    def test_missing_skill_md_returns_empty(self) -> None:
+        """Missing SKILL.md is flagged elsewhere; this rule does not double-flag."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _write_capability(os.path.join(tmp, "capabilities", "alpha"))
+            self.assertEqual(audit_router_table(tmp), [])
+
+
+# ===================================================================
+# audit_router_table — clean
+# ===================================================================
+
+
+class AuditRouterTableCleanTests(unittest.TestCase):
+    def test_clean_router_table_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, CANONICAL_TABLE, ["alpha", "beta"])
+            self.assertEqual(audit_router_table(tmp), [])
+
+
+# ===================================================================
+# audit_router_table — failure modes
+# ===================================================================
+
+
+class AuditRouterTableFailureTests(unittest.TestCase):
+    def test_missing_table_when_capabilities_exist_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table=None, capability_dirs=["alpha"])
+            findings = audit_router_table(tmp)
+        self.assertEqual(len(findings), 1)
+        level, msg = findings[0]
+        self.assertEqual(level, LEVEL_FAIL)
+        self.assertIn("no router table", msg)
+
+    def test_row_without_directory_fails(self) -> None:
+        """A router row whose capability dir is missing fails."""
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| ghost | t | capabilities/ghost/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            # No capability dir on disk.
+            _build_skill(tmp, table, capability_dirs=[])
+            # Also need a capabilities/ directory so the rule applies.
+            os.makedirs(os.path.join(tmp, "capabilities"))
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        self.assertTrue(any("does not resolve" in m for m in msgs))
+
+    def test_directory_without_row_fails(self) -> None:
+        """A capability directory without a router row fails (orphan)."""
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | t | capabilities/alpha/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["alpha", "extra"])
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        self.assertTrue(
+            any("capabilities/extra/" in m and "no matching router row" in m for m in msgs)
+        )
+
+    def test_malformed_path_with_backticks_fails(self) -> None:
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | t | `capabilities/alpha/capability.md` |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["alpha"])
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        self.assertTrue(any("malformed Path" in m for m in msgs))
+
+    def test_malformed_path_with_markdown_link_fails(self) -> None:
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | t | [link](capabilities/alpha/capability.md) |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["alpha"])
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        self.assertTrue(any("malformed Path" in m for m in msgs))
+
+    def test_malformed_path_with_leading_dot_slash_fails(self) -> None:
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | t | ./capabilities/alpha/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["alpha"])
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        self.assertTrue(any("malformed Path" in m for m in msgs))
+
+    def test_malformed_path_with_fragment_fails(self) -> None:
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | t | capabilities/alpha/capability.md#anchor |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["alpha"])
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        self.assertTrue(any("malformed Path" in m for m in msgs))
+
+    def test_capability_path_mismatch_fails(self) -> None:
+        """Capability column != path segment is a FAIL."""
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| labeled | t | capabilities/actual/capability.md |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["actual"])
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        self.assertTrue(
+            any("does not match Path segment" in m for m in msgs)
+        )
+        # Path-based existence check should still pass; only the
+        # mismatch finding should appear.
+        self.assertEqual(len(findings), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -432,6 +432,67 @@ class AuditRouterTableFailureTests(unittest.TestCase):
         msgs = [m for _, m in findings]
         self.assertTrue(any("malformed Path" in m for m in msgs))
 
+    def test_malformed_path_with_existing_dir_does_not_double_flag(self) -> None:
+        """A recoverable malformed Path (backticks, link wrapper, ./, #fragment)
+        whose target directory exists must surface exactly one FAIL —
+        the malformed Path — and not also the orphan finding.
+
+        Otherwise a single author error produces two findings and sends
+        the reader on a wrong-cause hunt.
+        """
+        decorations = (
+            "`capabilities/alpha/capability.md`",
+            "[link](capabilities/alpha/capability.md)",
+            "./capabilities/alpha/capability.md",
+            "capabilities/alpha/capability.md#anchor",
+        )
+        for decorated in decorations:
+            with self.subTest(path=decorated):
+                table = (
+                    "| Capability | Trigger | Path |\n"
+                    "|---|---|---|\n"
+                    f"| alpha | t | {decorated} |\n"
+                )
+                with tempfile.TemporaryDirectory() as tmp:
+                    _build_skill(tmp, table, capability_dirs=["alpha"])
+                    findings = audit_router_table(tmp)
+                msgs = [m for _, m in findings]
+                self.assertTrue(
+                    any("malformed Path" in m for m in msgs),
+                    f"expected malformed-Path FAIL for {decorated!r}, got: {msgs}",
+                )
+                self.assertFalse(
+                    any("no matching router row" in m for m in msgs),
+                    f"orphan finding must be suppressed when the malformed "
+                    f"Path is recoverable, got: {msgs}",
+                )
+                self.assertEqual(
+                    len(findings), 1,
+                    f"expected exactly one FAIL for {decorated!r}, got: {msgs}",
+                )
+
+    def test_unrecoverable_malformed_path_still_flags_orphan(self) -> None:
+        """A malformed Path with no recoverable segment still surfaces the
+        on-disk directory as orphan — there is no alternative signal that
+        the row was meant to reference it."""
+        table = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | t | totally-wrong-shape |\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, table, capability_dirs=["alpha"])
+            findings = audit_router_table(tmp)
+        msgs = [m for _, m in findings]
+        self.assertTrue(
+            any("malformed Path" in m for m in msgs),
+            f"expected malformed-Path FAIL, got: {msgs}",
+        )
+        self.assertTrue(
+            any("capabilities/alpha/" in m and "no matching router row" in m for m in msgs),
+            f"unrecoverable path leaves the on-disk dir genuinely orphan, got: {msgs}",
+        )
+
     def test_capability_path_mismatch_fails(self) -> None:
         """Capability column != path segment is a FAIL."""
         table = (

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -466,6 +466,36 @@ class StripFencedRegionsTests(unittest.TestCase):
         names = [r[0] for r in rows]
         self.assertEqual(names, ["alpha", "beta"])
 
+    def test_indented_4_space_backticks_are_not_a_fence(self) -> None:
+        """A line indented 4+ spaces is an indented code block, not a fence.
+
+        CommonMark §4.5 caps a fence opener at 0–3 leading spaces.
+        A 4-space-indented run of backticks is literal content and
+        must not strip the surrounding lines, so a real router table
+        following such a line stays visible.
+        """
+        body = (
+            "# Skill\n\n"
+            "    ```\n"  # 4-space indent — indented code block, NOT a fence
+            "    decoy line still inside the same indented block\n"
+            "\n"
+            "## Capabilities\n\n"
+            + CANONICAL_TABLE
+        )
+        rows = _parse_rows(body)
+        names = [r[0] for r in rows]
+        self.assertEqual(names, ["alpha", "beta"])
+
+    def test_3_space_indented_fence_is_recognized(self) -> None:
+        """0–3 leading spaces on a fence opener still counts as a fence."""
+        body = (
+            "# Skill\n\n"
+            "   ```markdown\n"  # 3-space indent — still a valid fence
+            + CANONICAL_TABLE
+            + "   ```\n"
+        )
+        self.assertIsNone(parse_router_table(body))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -99,17 +99,52 @@ class ParseRouterTableTests(unittest.TestCase):
         rows = parse_router_table(body)
         self.assertEqual(rows, [("alpha", "t", "capabilities/alpha/capability.md")])
 
-    def test_table_inside_code_fence_is_recognized(self) -> None:
-        """Decision: don't strip fences — fenced tables count."""
+    def test_table_inside_code_fence_is_ignored(self) -> None:
+        """Fenced tables are stripped so doc examples cannot shadow the canonical router."""
         body = (
             "# Skill\n\n"
             "```markdown\n"
             + CANONICAL_TABLE
             + "```\n"
         )
+        self.assertIsNone(parse_router_table(body))
+
+    def test_fenced_doc_table_does_not_shadow_real_router(self) -> None:
+        """A fenced example placed before the real router must not win."""
+        decoy = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| decoy | x | capabilities/decoy/capability.md |\n"
+        )
+        body = (
+            "# Skill\n\n"
+            "Example format:\n\n"
+            "```markdown\n"
+            + decoy
+            + "```\n\n"
+            "## Capabilities\n\n"
+            + CANONICAL_TABLE
+        )
         rows = parse_router_table(body)
-        self.assertIsNotNone(rows)
-        self.assertEqual(len(rows or []), 2)
+        names = [r[0] for r in rows or []]
+        self.assertEqual(names, ["alpha", "beta"])
+
+    def test_trigger_cell_with_escaped_pipe_is_preserved(self) -> None:
+        """A Trigger cell containing ``\\|`` must not truncate the table."""
+        body = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| alpha | when alpha \\| beta is needed | capabilities/alpha/capability.md |\n"
+            "| gamma | t | capabilities/gamma/capability.md |\n"
+        )
+        rows = parse_router_table(body)
+        self.assertEqual(
+            rows,
+            [
+                ("alpha", "when alpha | beta is needed", "capabilities/alpha/capability.md"),
+                ("gamma", "t", "capabilities/gamma/capability.md"),
+            ],
+        )
 
     def test_header_without_separator_is_skipped(self) -> None:
         """A header row without a following separator is not a real table."""
@@ -164,7 +199,17 @@ class AuditRouterTableNoOpTests(unittest.TestCase):
         self.assertEqual(len(findings), 1)
         level, msg = findings[0]
         self.assertEqual(level, LEVEL_FAIL)
-        self.assertIn("no SKILL.md", msg)
+        self.assertIn("SKILL.md is missing", msg)
+
+    def test_router_table_without_capabilities_dir_fails(self) -> None:
+        """SKILL.md declares a router but capabilities/ tree was deleted."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _build_skill(tmp, CANONICAL_TABLE, capability_dirs=[])
+            findings = audit_router_table(tmp)
+        self.assertEqual(len(findings), 1)
+        level, msg = findings[0]
+        self.assertEqual(level, LEVEL_FAIL)
+        self.assertIn("capabilities/ is missing", msg)
 
 
 # ===================================================================

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -276,6 +276,20 @@ class ParseRouterTableTests(unittest.TestCase):
         )
         self.assertIsNone(parse_router_table(body))
 
+    def test_canonical_header_with_two_cell_separator_returns_none(self) -> None:
+        """A canonical 3-cell header followed by a 2-cell separator is not a router table.
+
+        Without this guard a malformed table (e.g., authoring mistake or
+        prose example) would be promoted to the canonical router and
+        cause spurious failures elsewhere in the audit.
+        """
+        body = (
+            "| Capability | Trigger | Path |\n"
+            "|---|---|\n"
+            "| alpha | t | capabilities/alpha/capability.md |\n"
+        )
+        self.assertIsNone(parse_router_table(body))
+
     def test_empty_body_returns_none(self) -> None:
         self.assertIsNone(parse_router_table(""))
 


### PR DESCRIPTION
Closes #101.

## Summary

- Adds a router-table consistency audit that detects drift between a router skill's `SKILL.md` table and its on-disk `capabilities/` tree. The rule fires per-skill and lives behind a new module, `lib/router_table.py`.
- Introduces *skill-root mode* in `audit_skill_system.py` so the foundry meta-skill (and any integrator-built meta-skill) can self-audit without first being deployed under a `skills/` tree.
- Documents both audit modes, the canonical foundry self-check invocation, and the expected partial-audit warning when run from the distribution-repo root.

## Two audit modes

The audit now runs in one of two modes:

- **System-root mode** — `<system-root>/skills/<name>/` exists. All per-skill rules iterate registered skills; the router-table rule fires on every skill that has either a router table or a `capabilities/` directory.
- **Skill-root mode** — `<system-root>/SKILL.md` exists at the top. The audit treats the directory as a single-skill audit; the router-table rule still fires on it. A new helper, `find_router_audit_targets`, returns the union of `skills/<name>/` candidates and the synthetic skill-root entry.

Findings emitted in skill-root mode are prefixed with the SKILL.md frontmatter `name`, falling back to the directory basename only when the frontmatter is unreadable. This keeps the prefix canonical even when the audit runs from a worktree or renamed directory.

## What the rule detects

`audit_router_table` emits findings, in this order:

- (FAIL) `capabilities/` exists but `SKILL.md` is missing.
- (FAIL) `capabilities/` exists but `SKILL.md` has no router-shaped table.
- (FAIL) `SKILL.md` declares a router table but `capabilities/` is missing.
- (FAIL) A row inside the router table is structurally malformed (wrong number of columns); subsequent valid rows are still parsed.
- (WARN) A second canonical-headed router table appears in `SKILL.md`. Only the first is audited; the warning directs the author to consolidate.
- (FAIL) A row's `Trigger` cell is empty.
- (FAIL) A row's `Path` cell is not the literal `capabilities/<name>/capability.md`. Common decorations (backticks, `[text](url)` wrapper, leading `./`, trailing `#fragment`) are recovered through `_recover_segment` so the orphan check does not also fire.
- (FAIL) A row's `Capability` cell does not equal the `<name>` segment of its `Path` cell.
- (FAIL) Two rows declare the same capability segment (duplicate router entry).
- (FAIL) A row's `Path` does not resolve to an existing `capability.md`.
- (FAIL) A capability subdirectory has a `capability.md` but no matching router row.

## Parser correctness notes

`parse_router_table` is first-table-wins. Fenced regions (backtick and tilde, with arbitrary run length and 0–3 leading spaces per CommonMark §4.5) are stripped before scanning so a fenced documentation example cannot shadow the canonical router. Indented (4-space) code blocks are not stripped — the backticks/tildes inside them are literal content. The Trigger cell honors the CommonMark `\|` escape so it can embed a literal pipe without truncating the table. Header decorations (`**`, `*`, `_`, backticks) are accepted on the header row.

## What's not covered

- The rule does not validate `Trigger` content beyond emptiness — it is treated as opaque so the audit does not race with prose evolution.
- Standalone skills (no `SKILL.md` router table and no `capabilities/`) return `[]` from `audit_router_table` — the rule is a no-op for them.

## Documentation

`AGENTS.md` documents both modes, the canonical `cd skill-system-foundry && python scripts/audit_skill_system.py .` self-check invocation, and notes that running from the repo root produces one expected `WARN: No skills/ directory under system root — ran partial audit` (per-skill rules including the router-table rule are skipped under that invocation). `AGENTS.md` also clarifies which invocation is the canonical foundry self-check vs which one runs the repo-level version-consistency rule.

## Test plan

- [x] `python -m coverage run -m unittest discover -s tests -p "test_*.py"` — 1850 tests, 0 failures
- [x] `python -m coverage report` — 96% total branch coverage; `router_table.py` 95%, `discovery.py` 92%, `audit_skill_system.py` 91%
- [x] `cd skill-system-foundry && python scripts/validate_skill.py . --allow-nested-references --foundry-self --json` — clean (17 passes)
- [x] `cd skill-system-foundry && python scripts/audit_skill_system.py . --json` — clean (skill-root mode, 0 fails)
- [x] `python skill-system-foundry/scripts/audit_skill_system.py . --json` — clean apart from the documented `partial-audit` WARN (distribution-repo mode)
- [x] Review cycle (`/critique`, `/local-ci-code-review`, `/local-code-review`, `/review`, `/validate-skill-spec`) converged with zero findings
