### PR TITLE
Add examples/ directory with three reference skills

### DIFF
--- a/.github/scripts/validate-examples.py
+++ b/.github/scripts/validate-examples.py
@@ -178,18 +178,17 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    skill_dirs = discover_skill_dirs(skills_root)
-    if not skill_dirs:
+    results, all_success = run_validation(skills_root, validator_path)
+    if not results:
         print(
             f"Error: no example skills found under {skills_root}",
             file=sys.stderr,
         )
         return 1
 
-    print(f"Validating {len(skill_dirs)} example skill(s) under {skills_root}")
+    print(f"Validating {len(results)} example skill(s) under {skills_root}")
     print("-" * SEPARATOR_WIDTH)
 
-    results, all_success = run_validation(skills_root, validator_path)
     for skill_path, success, parsed, raw, stderr in results:
         print(format_verdict(skill_path, parsed, success))
         if not success:

--- a/.github/scripts/validate-examples.py
+++ b/.github/scripts/validate-examples.py
@@ -96,11 +96,16 @@ def format_verdict(
 
     *success* is the authoritative pass/fail flag computed by
     :func:`validate_one`. The mark is derived from it so the line never
-    contradicts the aggregate exit code.
+    contradicts the aggregate exit code. When the validator early-exits
+    with a top-level ``error`` field (no ``summary``), the verdict
+    surfaces the message instead of misleading zero counts.
     """
     label = os.path.basename(skill_path.rstrip(os.sep))
     if parsed is None:
         return f"  ✗ {label}: validator emitted no valid JSON output"
+    top_level_error = parsed.get("error")
+    if top_level_error:
+        return f"  ✗ {label}: validator error: {top_level_error}"
     summary = parsed.get("summary") or {}
     failures = summary.get("failures", 0)
     warnings = summary.get("warnings", 0)
@@ -195,11 +200,13 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"      WARN: {warning}")
             for info in errors.get("info", []):
                 print(f"      INFO: {info}")
-            if parsed is None:
-                if raw.strip():
-                    print(f"      raw stdout: {raw.strip()}")
-                if stderr.strip():
-                    print(f"      raw stderr: {stderr.strip()}")
+            top_level_error = (parsed or {}).get("error")
+            if top_level_error:
+                print(f"      FAIL: {top_level_error}")
+            if parsed is None and raw.strip():
+                print(f"      raw stdout: {raw.strip()}")
+            if stderr.strip():
+                print(f"      raw stderr: {stderr.strip()}")
 
     print("-" * SEPARATOR_WIDTH)
     if all_success:

--- a/.github/scripts/validate-examples.py
+++ b/.github/scripts/validate-examples.py
@@ -26,9 +26,15 @@ import subprocess
 import sys
 
 
-REPO_RELATIVE_EXAMPLES_ROOT = os.path.join("examples", "skills")
+# Anchor default paths to the repository root derived from this file's
+# location (mirroring .github/scripts/verify-action-pins.py) so local
+# runs are robust regardless of the current working directory.
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+REPO_RELATIVE_EXAMPLES_ROOT = os.path.join(_REPO_ROOT, "examples", "skills")
 REPO_RELATIVE_VALIDATOR = os.path.join(
-    "skill-system-foundry", "scripts", "validate_skill.py",
+    _REPO_ROOT, "skill-system-foundry", "scripts", "validate_skill.py",
 )
 SEPARATOR_WIDTH = 60
 

--- a/.github/scripts/validate-examples.py
+++ b/.github/scripts/validate-examples.py
@@ -32,8 +32,8 @@ import sys
 _REPO_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..")
 )
-REPO_RELATIVE_EXAMPLES_ROOT = os.path.join(_REPO_ROOT, "examples", "skills")
-REPO_RELATIVE_VALIDATOR = os.path.join(
+DEFAULT_EXAMPLES_ROOT = os.path.join(_REPO_ROOT, "examples", "skills")
+DEFAULT_VALIDATOR = os.path.join(
     _REPO_ROOT, "skill-system-foundry", "scripts", "validate_skill.py",
 )
 SEPARATOR_WIDTH = 60
@@ -260,18 +260,22 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--skills-root",
-        default=REPO_RELATIVE_EXAMPLES_ROOT,
+        default=DEFAULT_EXAMPLES_ROOT,
         help=(
             "Path to the directory holding example skills. "
-            "Defaults to %(default)s relative to the working directory."
+            "Defaults to the repository's examples/skills/ directory "
+            "(%(default)s), resolved from this script's location so the "
+            "default works regardless of the current working directory."
         ),
     )
     parser.add_argument(
         "--validator",
-        default=REPO_RELATIVE_VALIDATOR,
+        default=DEFAULT_VALIDATOR,
         help=(
             "Path to the validate_skill.py entry point. "
-            "Defaults to %(default)s relative to the working directory."
+            "Defaults to skill-system-foundry/scripts/validate_skill.py "
+            "(%(default)s), resolved from this script's location so the "
+            "default works regardless of the current working directory."
         ),
     )
     return parser

--- a/.github/scripts/validate-examples.py
+++ b/.github/scripts/validate-examples.py
@@ -79,6 +79,31 @@ def discover_capability_dirs(skill_dir: str) -> list[str]:
     return found
 
 
+def find_malformed_capability_dirs(skill_dir: str) -> list[str]:
+    """Return non-hidden ``capabilities/<name>/`` dirs missing ``capability.md``.
+
+    Mirrors :func:`find_malformed_skill_dirs` one level deeper. Each
+    non-hidden child of a skill's ``capabilities/`` subtree is expected
+    to be a capability root containing ``capability.md``. Silently
+    skipping such directories would let a broken or newly added
+    capability slip past CI as long as the parent skill still validates,
+    so callers should fail fast with a clear diagnostic instead.
+    """
+    capabilities_root = os.path.join(skill_dir, "capabilities")
+    if not os.path.isdir(capabilities_root):
+        return []
+    malformed: list[str] = []
+    for name in sorted(os.listdir(capabilities_root)):
+        if name.startswith("."):
+            continue
+        candidate = os.path.join(capabilities_root, name)
+        if not os.path.isdir(candidate):
+            continue
+        if not os.path.isfile(os.path.join(candidate, "capability.md")):
+            malformed.append(os.path.abspath(candidate))
+    return malformed
+
+
 def find_malformed_skill_dirs(skills_root: str) -> list[str]:
     """Return absolute paths of non-hidden child directories without ``SKILL.md``.
 
@@ -277,6 +302,18 @@ def main(argv: list[str] | None = None) -> int:
         )
         for path in malformed:
             print(f"  - {path} is missing SKILL.md", file=sys.stderr)
+        return 1
+
+    malformed_caps: list[str] = []
+    for skill_path in discover_skill_dirs(skills_root):
+        malformed_caps.extend(find_malformed_capability_dirs(skill_path))
+    if malformed_caps:
+        print(
+            f"Error: malformed example capability directories under {skills_root}",
+            file=sys.stderr,
+        )
+        for path in malformed_caps:
+            print(f"  - {path} is missing capability.md", file=sys.stderr)
         return 1
 
     results, all_success = run_validation(skills_root, validator_path)

--- a/.github/scripts/validate-examples.py
+++ b/.github/scripts/validate-examples.py
@@ -3,7 +3,7 @@
 Walks the immediate children of ``examples/skills/`` and runs
 ``skill-system-foundry/scripts/validate_skill.py --json`` against each.
 Aggregates per-skill verdicts and exits non-zero when any example reports
-``failures > 0`` (FAIL findings).
+any FAIL, WARN, or INFO finding — examples must validate fully clean.
 
 Roles under ``examples/roles/`` are intentionally skipped — the foundry
 validator does not currently target role files. A dedicated role
@@ -53,13 +53,15 @@ def discover_skill_dirs(skills_root: str) -> list[str]:
 
 def validate_one(
     skill_path: str, validator_path: str,
-) -> tuple[bool, dict | None, str]:
+) -> tuple[bool, dict | None, str, str]:
     """Run ``validate_skill.py --json`` against *skill_path*.
 
-    Returns a tuple of ``(success, parsed_json, raw_stdout)``. *success*
-    is True only when the subprocess returned exit 0 and the parsed
-    payload reports ``success: true``. *parsed_json* is None when stdout
-    could not be parsed as JSON.
+    Returns a tuple of ``(success, parsed_json, raw_stdout, raw_stderr)``.
+    *success* is True only when the subprocess returned exit 0, the
+    parsed payload reports ``success: true``, and the summary reports
+    zero failures, warnings, and info findings — examples must validate
+    fully clean. *parsed_json* is None when stdout could not be parsed
+    as JSON.
     """
     completed = subprocess.run(
         [sys.executable, validator_path, skill_path, "--json"],
@@ -68,27 +70,42 @@ def validate_one(
         encoding="utf-8",
     )
     raw = completed.stdout
+    stderr = completed.stderr
     parsed: dict | None
     try:
         parsed = json.loads(raw) if raw.strip() else None
     except json.JSONDecodeError:
         parsed = None
     if parsed is None:
-        return False, None, raw
-    success = bool(parsed.get("success")) and completed.returncode == 0
-    return success, parsed, raw
+        return False, None, raw, stderr
+    summary = parsed.get("summary") or {}
+    success = (
+        bool(parsed.get("success"))
+        and completed.returncode == 0
+        and summary.get("failures", 0) == 0
+        and summary.get("warnings", 0) == 0
+        and summary.get("info", 0) == 0
+    )
+    return success, parsed, raw, stderr
 
 
-def format_verdict(skill_path: str, parsed: dict | None) -> str:
-    """Render a single one-line verdict for *skill_path*."""
+def format_verdict(
+    skill_path: str, parsed: dict | None, success: bool,
+) -> str:
+    """Render a single one-line verdict for *skill_path*.
+
+    *success* is the authoritative pass/fail flag computed by
+    :func:`validate_one`. The mark is derived from it so the line never
+    contradicts the aggregate exit code.
+    """
     label = os.path.basename(skill_path.rstrip(os.sep))
     if parsed is None:
-        return f"  ✗ {label}: validator emitted no JSON output"
+        return f"  ✗ {label}: validator emitted no valid JSON output"
     summary = parsed.get("summary") or {}
     failures = summary.get("failures", 0)
     warnings = summary.get("warnings", 0)
     info = summary.get("info", 0)
-    mark = "✓" if parsed.get("success") and failures == 0 else "✗"
+    mark = "✓" if success else "✗"
     return (
         f"  {mark} {label}: "
         f"{failures} fail / {warnings} warn / {info} info"
@@ -97,17 +114,20 @@ def format_verdict(skill_path: str, parsed: dict | None) -> str:
 
 def run_validation(
     skills_root: str, validator_path: str,
-) -> tuple[list[tuple[str, bool, dict | None, str]], bool]:
+) -> tuple[list[tuple[str, bool, dict | None, str, str]], bool]:
     """Validate every skill under *skills_root*.
 
     Returns ``(results, all_success)`` where *results* is a list of
-    ``(skill_path, success, parsed, raw_stdout)`` tuples in walk order.
+    ``(skill_path, success, parsed, raw_stdout, raw_stderr)`` tuples in
+    walk order.
     """
-    results: list[tuple[str, bool, dict | None, str]] = []
+    results: list[tuple[str, bool, dict | None, str, str]] = []
     all_success = True
     for skill_path in discover_skill_dirs(skills_root):
-        success, parsed, raw = validate_one(skill_path, validator_path)
-        results.append((skill_path, success, parsed, raw))
+        success, parsed, raw, stderr = validate_one(
+            skill_path, validator_path,
+        )
+        results.append((skill_path, success, parsed, raw, stderr))
         if not success:
             all_success = False
     return results, all_success
@@ -165,19 +185,27 @@ def main(argv: list[str] | None = None) -> int:
     print("-" * SEPARATOR_WIDTH)
 
     results, all_success = run_validation(skills_root, validator_path)
-    for skill_path, success, parsed, raw in results:
-        print(format_verdict(skill_path, parsed))
+    for skill_path, success, parsed, raw, stderr in results:
+        print(format_verdict(skill_path, parsed, success))
         if not success:
-            for error in (parsed or {}).get("errors", {}).get("failures", []):
+            errors = (parsed or {}).get("errors", {}) or {}
+            for error in errors.get("failures", []):
                 print(f"      FAIL: {error}")
-            if parsed is None and raw.strip():
-                print(f"      raw stdout: {raw.strip()}")
+            for warning in errors.get("warnings", []):
+                print(f"      WARN: {warning}")
+            for info in errors.get("info", []):
+                print(f"      INFO: {info}")
+            if parsed is None:
+                if raw.strip():
+                    print(f"      raw stdout: {raw.strip()}")
+                if stderr.strip():
+                    print(f"      raw stderr: {stderr.strip()}")
 
     print("-" * SEPARATOR_WIDTH)
     if all_success:
         print(f"✓ All {len(results)} example(s) validated cleanly")
         return 0
-    failed = sum(1 for _, success, _, _ in results if not success)
+    failed = sum(1 for _, success, _, _, _ in results if not success)
     print(f"✗ {failed} of {len(results)} example(s) failed validation")
     return 1
 

--- a/.github/scripts/validate-examples.py
+++ b/.github/scripts/validate-examples.py
@@ -1,9 +1,13 @@
 """Validate every reference skill under ``examples/skills/``.
 
 Walks the immediate children of ``examples/skills/`` and runs
-``skill-system-foundry/scripts/validate_skill.py --json`` against each.
-Aggregates per-skill verdicts and exits non-zero when any example reports
-any FAIL, WARN, or INFO finding — examples must validate fully clean.
+``skill-system-foundry/scripts/validate_skill.py --json`` against each
+skill root. For router examples, every ``capabilities/<name>/`` subdir
+is also validated with ``--capability --json`` so a broken capability
+(frontmatter parse error, body line cap, etc.) cannot slip past CI when
+the parent skill still passes. Aggregates verdicts and exits non-zero
+when any example reports any FAIL, WARN, or INFO finding — examples
+must validate fully clean.
 
 Roles under ``examples/roles/`` are intentionally skipped — the foundry
 validator does not currently target role files. A dedicated role
@@ -51,6 +55,30 @@ def discover_skill_dirs(skills_root: str) -> list[str]:
     return found
 
 
+def discover_capability_dirs(skill_dir: str) -> list[str]:
+    """Return absolute paths of capability dirs nested under *skill_dir*.
+
+    A capability qualifies when ``<skill_dir>/capabilities/<name>/`` is a
+    directory containing a ``capability.md`` file. Skills without a
+    ``capabilities/`` subtree (standalone pattern) yield an empty list.
+    Other entries (loose files, hidden directories, non-conforming
+    subdirectories) are silently skipped.
+    """
+    capabilities_root = os.path.join(skill_dir, "capabilities")
+    if not os.path.isdir(capabilities_root):
+        return []
+    found: list[str] = []
+    for name in sorted(os.listdir(capabilities_root)):
+        if name.startswith("."):
+            continue
+        candidate = os.path.join(capabilities_root, name)
+        if not os.path.isdir(candidate):
+            continue
+        if os.path.isfile(os.path.join(candidate, "capability.md")):
+            found.append(os.path.abspath(candidate))
+    return found
+
+
 def find_malformed_skill_dirs(skills_root: str) -> list[str]:
     """Return absolute paths of non-hidden child directories without ``SKILL.md``.
 
@@ -76,9 +104,15 @@ def find_malformed_skill_dirs(skills_root: str) -> list[str]:
 
 
 def validate_one(
-    skill_path: str, validator_path: str,
+    skill_path: str,
+    validator_path: str,
+    *,
+    capability: bool = False,
 ) -> tuple[bool, dict | None, str, str]:
     """Run ``validate_skill.py --json`` against *skill_path*.
+
+    When *capability* is True, the ``--capability`` flag is added so the
+    validator looks for ``capability.md`` instead of ``SKILL.md``.
 
     Returns a tuple of ``(success, parsed_json, raw_stdout, raw_stderr)``.
     *success* is True only when the subprocess returned exit 0, the
@@ -87,8 +121,11 @@ def validate_one(
     fully clean. *parsed_json* is None when stdout could not be parsed
     as JSON.
     """
+    cmd = [sys.executable, validator_path, skill_path, "--json"]
+    if capability:
+        cmd.append("--capability")
     completed = subprocess.run(
-        [sys.executable, validator_path, skill_path, "--json"],
+        cmd,
         capture_output=True,
         text=True,
         encoding="utf-8",
@@ -114,9 +151,17 @@ def validate_one(
 
 
 def format_verdict(
-    skill_path: str, parsed: dict | None, success: bool,
+    target_path: str,
+    parsed: dict | None,
+    success: bool,
+    *,
+    kind: str = "skill",
 ) -> str:
-    """Render a single one-line verdict for *skill_path*.
+    """Render a single one-line verdict for *target_path*.
+
+    *kind* is ``"skill"`` for skill-root verdicts and ``"capability"`` for
+    capability verdicts; capability lines are indented one level deeper
+    than the parent skill so the relationship reads at a glance.
 
     *success* is the authoritative pass/fail flag computed by
     :func:`validate_one`. The mark is derived from it so the line never
@@ -124,41 +169,54 @@ def format_verdict(
     with a top-level ``error`` field (no ``summary``), the verdict
     surfaces the message instead of misleading zero counts.
     """
-    label = os.path.basename(skill_path.rstrip(os.sep))
+    indent = "    └─ " if kind == "capability" else "  "
+    label = os.path.basename(target_path.rstrip(os.sep))
+    if kind == "capability":
+        label = f"capabilities/{label}"
     if parsed is None:
-        return f"  ✗ {label}: validator emitted no valid JSON output"
+        return f"{indent}✗ {label}: validator emitted no valid JSON output"
     top_level_error = parsed.get("error")
     if top_level_error:
-        return f"  ✗ {label}: validator error: {top_level_error}"
+        return f"{indent}✗ {label}: validator error: {top_level_error}"
     summary = parsed.get("summary") or {}
     failures = summary.get("failures", 0)
     warnings = summary.get("warnings", 0)
     info = summary.get("info", 0)
     mark = "✓" if success else "✗"
     return (
-        f"  {mark} {label}: "
+        f"{indent}{mark} {label}: "
         f"{failures} fail / {warnings} warn / {info} info"
     )
 
 
 def run_validation(
     skills_root: str, validator_path: str,
-) -> tuple[list[tuple[str, bool, dict | None, str, str]], bool]:
-    """Validate every skill under *skills_root*.
+) -> tuple[list[tuple[str, str, bool, dict | None, str, str]], bool]:
+    """Validate every skill (and its capabilities) under *skills_root*.
 
     Returns ``(results, all_success)`` where *results* is a list of
-    ``(skill_path, success, parsed, raw_stdout, raw_stderr)`` tuples in
-    walk order.
+    ``(target_path, kind, success, parsed, raw_stdout, raw_stderr)``
+    tuples in walk order. *kind* is ``"skill"`` or ``"capability"``;
+    capability rows always immediately follow their parent skill row.
     """
-    results: list[tuple[str, bool, dict | None, str, str]] = []
+    results: list[tuple[str, str, bool, dict | None, str, str]] = []
     all_success = True
     for skill_path in discover_skill_dirs(skills_root):
         success, parsed, raw, stderr = validate_one(
             skill_path, validator_path,
         )
-        results.append((skill_path, success, parsed, raw, stderr))
+        results.append((skill_path, "skill", success, parsed, raw, stderr))
         if not success:
             all_success = False
+        for cap_path in discover_capability_dirs(skill_path):
+            cap_success, cap_parsed, cap_raw, cap_stderr = validate_one(
+                cap_path, validator_path, capability=True,
+            )
+            results.append(
+                (cap_path, "capability", cap_success, cap_parsed, cap_raw, cap_stderr),
+            )
+            if not cap_success:
+                all_success = False
     return results, all_success
 
 
@@ -229,11 +287,20 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    print(f"Validating {len(results)} example skill(s) under {skills_root}")
+    skill_count = sum(1 for _, kind, _, _, _, _ in results if kind == "skill")
+    cap_count = sum(
+        1 for _, kind, _, _, _, _ in results if kind == "capability"
+    )
+    summary_root = (
+        f"Validating {skill_count} example skill(s) "
+        f"and {cap_count} capabilit{'y' if cap_count == 1 else 'ies'} "
+        f"under {skills_root}"
+    )
+    print(summary_root)
     print("-" * SEPARATOR_WIDTH)
 
-    for skill_path, success, parsed, raw, stderr in results:
-        print(format_verdict(skill_path, parsed, success))
+    for target_path, kind, success, parsed, raw, stderr in results:
+        print(format_verdict(target_path, parsed, success, kind=kind))
         if not success:
             errors = (parsed or {}).get("errors", {}) or {}
             for error in errors.get("failures", []):
@@ -252,10 +319,15 @@ def main(argv: list[str] | None = None) -> int:
 
     print("-" * SEPARATOR_WIDTH)
     if all_success:
-        print(f"✓ All {len(results)} example(s) validated cleanly")
+        print(
+            f"✓ All {len(results)} example target(s) validated cleanly "
+            f"({skill_count} skill / {cap_count} capability)"
+        )
         return 0
-    failed = sum(1 for _, success, _, _, _ in results if not success)
-    print(f"✗ {failed} of {len(results)} example(s) failed validation")
+    failed = sum(1 for _, _, success, _, _, _ in results if not success)
+    print(
+        f"✗ {failed} of {len(results)} example target(s) failed validation"
+    )
     return 1
 
 

--- a/.github/scripts/validate-examples.py
+++ b/.github/scripts/validate-examples.py
@@ -33,9 +33,9 @@ def discover_skill_dirs(skills_root: str) -> list[str]:
     """Return absolute paths of immediate subdirectories that look like skills.
 
     A directory qualifies when it contains a ``SKILL.md`` file at its top
-    level. Other entries (loose files, hidden directories, directories
-    without ``SKILL.md``) are silently skipped — they may exist for
-    documentation or future expansion.
+    level. Hidden entries and loose files are silently skipped. Non-hidden
+    directories without ``SKILL.md`` are *not* treated as skills here —
+    use :func:`find_malformed_skill_dirs` to surface them as failures.
     """
     if not os.path.isdir(skills_root):
         return []
@@ -49,6 +49,30 @@ def discover_skill_dirs(skills_root: str) -> list[str]:
         if os.path.isfile(os.path.join(candidate, "SKILL.md")):
             found.append(os.path.abspath(candidate))
     return found
+
+
+def find_malformed_skill_dirs(skills_root: str) -> list[str]:
+    """Return absolute paths of non-hidden child directories without ``SKILL.md``.
+
+    Each immediate non-hidden child directory under *skills_root* is
+    expected to be a skill root (matching a deployed-style ``skills/``
+    tree). Missing ``SKILL.md`` indicates an accidental rename, deletion,
+    or scaffolding mistake — silently skipping such directories would let
+    a broken example slip past CI as long as another example remains, so
+    callers should fail with a clear diagnostic instead.
+    """
+    if not os.path.isdir(skills_root):
+        return []
+    malformed: list[str] = []
+    for name in sorted(os.listdir(skills_root)):
+        if name.startswith("."):
+            continue
+        candidate = os.path.join(skills_root, name)
+        if not os.path.isdir(candidate):
+            continue
+        if not os.path.isfile(os.path.join(candidate, "SKILL.md")):
+            malformed.append(os.path.abspath(candidate))
+    return malformed
 
 
 def validate_one(
@@ -185,6 +209,16 @@ def main(argv: list[str] | None = None) -> int:
             f"Error: validator not found at {validator_path}",
             file=sys.stderr,
         )
+        return 1
+
+    malformed = find_malformed_skill_dirs(skills_root)
+    if malformed:
+        print(
+            f"Error: malformed example skill directories under {skills_root}",
+            file=sys.stderr,
+        )
+        for path in malformed:
+            print(f"  - {path} is missing SKILL.md", file=sys.stderr)
         return 1
 
     results, all_success = run_validation(skills_root, validator_path)

--- a/.github/scripts/validate-examples.py
+++ b/.github/scripts/validate-examples.py
@@ -1,0 +1,186 @@
+"""Validate every reference skill under ``examples/skills/``.
+
+Walks the immediate children of ``examples/skills/`` and runs
+``skill-system-foundry/scripts/validate_skill.py --json`` against each.
+Aggregates per-skill verdicts and exits non-zero when any example reports
+``failures > 0`` (FAIL findings).
+
+Roles under ``examples/roles/`` are intentionally skipped — the foundry
+validator does not currently target role files. A dedicated role
+validator is tracked as a follow-up issue.
+
+Designed for CI: stdlib-only, runs identically on Linux and Windows, no
+third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+REPO_RELATIVE_EXAMPLES_ROOT = os.path.join("examples", "skills")
+REPO_RELATIVE_VALIDATOR = os.path.join(
+    "skill-system-foundry", "scripts", "validate_skill.py",
+)
+SEPARATOR_WIDTH = 60
+
+
+def discover_skill_dirs(skills_root: str) -> list[str]:
+    """Return absolute paths of immediate subdirectories that look like skills.
+
+    A directory qualifies when it contains a ``SKILL.md`` file at its top
+    level. Other entries (loose files, hidden directories, directories
+    without ``SKILL.md``) are silently skipped — they may exist for
+    documentation or future expansion.
+    """
+    if not os.path.isdir(skills_root):
+        return []
+    found: list[str] = []
+    for name in sorted(os.listdir(skills_root)):
+        if name.startswith("."):
+            continue
+        candidate = os.path.join(skills_root, name)
+        if not os.path.isdir(candidate):
+            continue
+        if os.path.isfile(os.path.join(candidate, "SKILL.md")):
+            found.append(os.path.abspath(candidate))
+    return found
+
+
+def validate_one(
+    skill_path: str, validator_path: str,
+) -> tuple[bool, dict | None, str]:
+    """Run ``validate_skill.py --json`` against *skill_path*.
+
+    Returns a tuple of ``(success, parsed_json, raw_stdout)``. *success*
+    is True only when the subprocess returned exit 0 and the parsed
+    payload reports ``success: true``. *parsed_json* is None when stdout
+    could not be parsed as JSON.
+    """
+    completed = subprocess.run(
+        [sys.executable, validator_path, skill_path, "--json"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    raw = completed.stdout
+    parsed: dict | None
+    try:
+        parsed = json.loads(raw) if raw.strip() else None
+    except json.JSONDecodeError:
+        parsed = None
+    if parsed is None:
+        return False, None, raw
+    success = bool(parsed.get("success")) and completed.returncode == 0
+    return success, parsed, raw
+
+
+def format_verdict(skill_path: str, parsed: dict | None) -> str:
+    """Render a single one-line verdict for *skill_path*."""
+    label = os.path.basename(skill_path.rstrip(os.sep))
+    if parsed is None:
+        return f"  ✗ {label}: validator emitted no JSON output"
+    summary = parsed.get("summary") or {}
+    failures = summary.get("failures", 0)
+    warnings = summary.get("warnings", 0)
+    info = summary.get("info", 0)
+    mark = "✓" if parsed.get("success") and failures == 0 else "✗"
+    return (
+        f"  {mark} {label}: "
+        f"{failures} fail / {warnings} warn / {info} info"
+    )
+
+
+def run_validation(
+    skills_root: str, validator_path: str,
+) -> tuple[list[tuple[str, bool, dict | None, str]], bool]:
+    """Validate every skill under *skills_root*.
+
+    Returns ``(results, all_success)`` where *results* is a list of
+    ``(skill_path, success, parsed, raw_stdout)`` tuples in walk order.
+    """
+    results: list[tuple[str, bool, dict | None, str]] = []
+    all_success = True
+    for skill_path in discover_skill_dirs(skills_root):
+        success, parsed, raw = validate_one(skill_path, validator_path)
+        results.append((skill_path, success, parsed, raw))
+        if not success:
+            all_success = False
+    return results, all_success
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate every reference skill under examples/skills/."
+        ),
+    )
+    parser.add_argument(
+        "--skills-root",
+        default=REPO_RELATIVE_EXAMPLES_ROOT,
+        help=(
+            "Path to the directory holding example skills. "
+            "Defaults to %(default)s relative to the working directory."
+        ),
+    )
+    parser.add_argument(
+        "--validator",
+        default=REPO_RELATIVE_VALIDATOR,
+        help=(
+            "Path to the validate_skill.py entry point. "
+            "Defaults to %(default)s relative to the working directory."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns the exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    skills_root = os.path.abspath(args.skills_root)
+    validator_path = os.path.abspath(args.validator)
+
+    if not os.path.isfile(validator_path):
+        print(
+            f"Error: validator not found at {validator_path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    skill_dirs = discover_skill_dirs(skills_root)
+    if not skill_dirs:
+        print(
+            f"Error: no example skills found under {skills_root}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Validating {len(skill_dirs)} example skill(s) under {skills_root}")
+    print("-" * SEPARATOR_WIDTH)
+
+    results, all_success = run_validation(skills_root, validator_path)
+    for skill_path, success, parsed, raw in results:
+        print(format_verdict(skill_path, parsed))
+        if not success:
+            for error in (parsed or {}).get("errors", {}).get("failures", []):
+                print(f"      FAIL: {error}")
+            if parsed is None and raw.strip():
+                print(f"      raw stdout: {raw.strip()}")
+
+    print("-" * SEPARATOR_WIDTH)
+    if all_success:
+        print(f"✓ All {len(results)} example(s) validated cleanly")
+        return 0
+    failed = sum(1 for _, success, _, _ in results if not success)
+    print(f"✗ {failed} of {len(results)} example(s) failed validation")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/validate-examples.py
+++ b/.github/scripts/validate-examples.py
@@ -166,6 +166,15 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point. Returns the exit code."""
+    # On Windows the default console encoding (cp1252) cannot represent
+    # the ✓/✗ Unicode marks the verdict lines use. Reconfigure
+    # stdout/stderr to replace unencodable characters rather than
+    # raising UnicodeEncodeError on local runs outside CI.
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(errors="replace")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(errors="replace")
+
     parser = _build_parser()
     args = parser.parse_args(argv)
     skills_root = os.path.abspath(args.skills_root)

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -105,6 +105,8 @@ jobs:
 
   validate-examples:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -103,6 +103,30 @@ jobs:
       - name: Check coverage threshold
         run: python -m coverage report
 
+  validate-examples:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v5 as 5.6.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Validate reference examples
+        run: python .github/scripts/validate-examples.py
+        env:
+          PYTHONUTF8: "1"
+
   update-badge:
     needs: test
     # Restrict to genuine pushes to main; this skips reusable

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -130,7 +130,9 @@ jobs:
           PYTHONUTF8: "1"
 
   update-badge:
-    needs: test
+    needs:
+      - test
+      - validate-examples
     # Restrict to genuine pushes to main; this skips reusable
     # workflow_call invocations (e.g. release-prep.yml) where
     # github.event_name is the caller's event (workflow_dispatch) and

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ On Linux and macOS the expected output is `skill-system-foundry-vX.Y.Z.zip: OK`.
      --system-root /path/to/project/.agents --output my-skill.zip
    ```
 
+## Reference examples
+
+The [`examples/`](examples/) directory ships three reference skills laid out as a self-contained mini system root. They demonstrate the patterns the foundry supports — standalone, router, and role — using the same paths real deployments use:
+
+- **[`examples/skills/hello-greeter/`](examples/skills/hello-greeter/SKILL.md)** — the smallest valid standalone skill: a single `SKILL.md`, minimal frontmatter, no `allowed-tools`.
+- **[`examples/skills/hello-router/`](examples/skills/hello-router/SKILL.md)** — a router skill dispatching to two capabilities, with `allowed-tools: Bash` declared so a fenced bash example in one capability stays coherent.
+- **[`examples/roles/hello-orchestrator.md`](examples/roles/hello-orchestrator.md)** — a role contract composing the standalone and router skills above, with the canonical responsibility / allowed / forbidden / handoff / "Skills Used" structure.
+
+CI validates each skill example on every push and pull request. The examples ship in the repository for onboarding only — `release.yml` zips just `skill-system-foundry/`, so the directory adds no weight to the distributed bundle.
+
 ## Releases
 
 Shipped versions and what changed between them are tracked in [CHANGELOG.md](CHANGELOG.md). Each release is also published as a versioned zip on the [Releases](https://github.com/milanhorvatovic/skill-system-foundry/releases) page (with a SHA256 checksum file alongside it; see the [GitHub Releases](#github-releases) installation section for verification commands).

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ On Linux and macOS the expected output is `skill-system-foundry-vX.Y.Z.zip: OK`.
 
 ## Reference examples
 
-The [`examples/`](examples/) directory ships three reference skills laid out as a self-contained mini system root. They demonstrate the patterns the foundry supports — standalone, router, and role — using the same paths real deployments use:
+The [`examples/`](examples/) directory ships three reference examples — two skills and one role — laid out as a self-contained mini system root. They demonstrate the patterns the foundry supports — standalone, router, and role — using the same paths real deployments use:
 
 - **[`examples/skills/hello-greeter/`](examples/skills/hello-greeter/SKILL.md)** — the smallest valid standalone skill: a single `SKILL.md`, minimal frontmatter, no `allowed-tools`.
 - **[`examples/skills/hello-router/`](examples/skills/hello-router/SKILL.md)** — a router skill dispatching to two capabilities, with `allowed-tools: Bash` declared so a fenced bash example in one capability stays coherent.

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,7 @@ examples/
 
 ### Standalone skill — [`skills/hello-greeter/`](skills/hello-greeter/SKILL.md)
 
-The smallest valid skill: a single `SKILL.md` with the minimum required frontmatter (`name`, `description`), no `allowed-tools`, no shell fences, no subdirectories. Read this first to see the floor of what counts as a skill in the Skill System Foundry.
+The smallest valid skill: a single `SKILL.md` with the required `name` and `description` frontmatter plus an optional `metadata` block, no `allowed-tools`, no shell fences, and no subdirectories. Read this first to see the floor of what counts as a skill in the Skill System Foundry.
 
 ### Router skill — [`skills/hello-router/`](skills/hello-router/SKILL.md)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,46 @@
+# Reference Examples
+
+This directory is a self-contained mini skill-system that demonstrates the three patterns the foundry supports: a standalone skill, a router skill with capabilities, and a role that composes both. The layout mirrors a deployed skill-system root (a top-level `skills/` and `roles/` directory), so the examples teach the same paths bundling and orchestration use in real projects.
+
+The examples ship in the repository for onboarding only. The release zip published by `release.yml` packages just `skill-system-foundry/`, so nothing in `examples/` adds weight to the distributed bundle.
+
+## Layout
+
+```
+examples/
+├── skills/
+│   ├── hello-greeter/                                    ← standalone
+│   │   └── SKILL.md
+│   └── hello-router/                                     ← router
+│       ├── SKILL.md
+│       └── capabilities/
+│           ├── greet-formal/capability.md
+│           └── greet-casual/capability.md
+└── roles/
+    └── hello-orchestrator.md                             ← role composing the two skills
+```
+
+## Examples
+
+### Standalone skill — [`skills/hello-greeter/`](skills/hello-greeter/SKILL.md)
+
+The smallest valid skill: a single `SKILL.md` with the minimum required frontmatter (`name`, `description`), no `allowed-tools`, no shell fences, no subdirectories. Read this first to see the floor of what counts as a skill in the Skill System Foundry.
+
+### Router skill — [`skills/hello-router/`](skills/hello-router/SKILL.md)
+
+A thin router entry point dispatching to two capabilities. Declares `allowed-tools: Bash` so a fenced `bash` example inside `capabilities/greet-formal/capability.md` stays coherent with the foundry's tool-coherence rule. Read this to see how a router table, capability layout, and `allowed-tools` declaration fit together.
+
+### Role — [`roles/hello-orchestrator.md`](roles/hello-orchestrator.md)
+
+A role contract composing the standalone and router skills above. Demonstrates the responsibility, allowed, forbidden, handoff, workflow, and "Skills Used" sections. Paths in the role's "Skills Used" table use the canonical `skills/<domain>/SKILL.md` form — the same form the audit and bundle tools recognise.
+
+## Validation
+
+Each skill example validates clean under the foundry's own validator:
+
+```bash
+python skill-system-foundry/scripts/validate_skill.py examples/skills/hello-greeter
+python skill-system-foundry/scripts/validate_skill.py examples/skills/hello-router
+```
+
+CI runs these automatically. The role file is intentionally outside `validate_skill.py`'s scope today — a dedicated role validator is tracked as a separate follow-up.

--- a/examples/roles/hello-orchestrator.md
+++ b/examples/roles/hello-orchestrator.md
@@ -22,7 +22,7 @@ This role is a reference example. It shows the orchestration contract a real rol
 ## Forbidden
 
 - Loading more than one greeting skill in a single turn.
-- Loading capability files (`capabilities/**/capability.md`) directly. Roles compose skills, not capabilities — capability dispatch stays inside the parent skill.
+- Loading capability files (`capabilities/**/capability.md`) directly. This role composes the parent skills only; in this example, capability dispatch stays inside `hello-router`. (The foundry's self-contained-skill pattern lets roles reference a skill's capabilities by system-root-relative path; this role just opts out.)
 - Inventing tone variants beyond `formal` and `casual`. Unknown tones trigger the handoff rule below.
 - Holding state between turns. Each request is treated independently.
 - Loading other roles. Roles never compose roles in this skill system.

--- a/examples/roles/hello-orchestrator.md
+++ b/examples/roles/hello-orchestrator.md
@@ -1,0 +1,78 @@
+# Hello Orchestrator
+
+## Purpose
+
+Coordinates a tone-aware welcome workflow that combines the standalone
+`hello-greeter` skill (default greeting) with the `hello-router` skill
+(tone-specific dispatch). Activates when a multi-step welcome is requested
+and the caller wants the role to decide which skill to invoke based on the
+tone signal in the request.
+
+This role is a reference example. It shows the orchestration contract a
+real role would publish — responsibility, allowed actions, forbidden
+actions, handoff rules, and a Skills Used table — without owning any
+domain logic of its own.
+
+## Responsibilities
+
+- Detect the tone signal in the request and decide between the standalone
+  greeter and the tone-specific router.
+- Emit exactly one greeting per request — never two greetings, never zero.
+- Preserve recipient names verbatim, including honorifics, when passing
+  them to the underlying skills.
+- Surface a clear handoff message when the request falls outside the
+  greeting domain.
+
+## Allowed
+
+- Loading the `hello-greeter` skill for the default casual greeting.
+- Loading the `hello-router` skill and selecting one of its two registered
+  capabilities (`greet-formal`, `greet-casual`).
+- Reading the recipient name and tone fields from the incoming request.
+
+## Forbidden
+
+- Loading more than one greeting skill in a single turn.
+- Inventing tone variants beyond `formal` and `casual`. Unknown tones
+  trigger the handoff rule below.
+- Holding state between turns. Each request is treated independently.
+- Loading other roles. Roles never compose roles in this skill system.
+
+## Handoff
+
+- Tone is missing or unrecognized → fall back to `hello-greeter` with the
+  default casual tone, and note the fallback in the response prefix.
+- Request asks for multi-recipient or templated bulk greetings → return a
+  short refusal pointing the caller at a future bulk-greeting skill.
+- Request asks for anything other than a greeting → return control to the
+  caller with an explicit "out of scope" message.
+
+## Workflow
+
+Task Progress:
+- [ ] Step 1: Parse the recipient name and tone from the request.
+- [ ] Step 2: If tone is `formal` or `casual`, load `hello-router` and
+      dispatch to the matching capability.
+- [ ] Step 3: Otherwise, load `hello-greeter` and emit the default
+      casual greeting.
+- [ ] Step 4: Return the single greeting line and stop.
+
+## Skills Used
+
+| Skill / Capability | Purpose in Workflow |
+|---|---|
+| skills/hello-greeter/SKILL.md | Default casual greeting when no tone is specified |
+| skills/hello-router/SKILL.md | Tone-aware dispatch entry point |
+| skills/hello-router/capabilities/greet-formal/capability.md | Formal tone rendering loaded by the router |
+
+<!-- Paths in this table are relative to the example mini system root
+     (the examples/ directory containing skills/ and roles/), not relative
+     to this role file's location. -->
+
+## Interaction Pattern
+
+The role decides autonomously between the standalone and router paths
+based on the tone signal. It asks no clarifying questions for missing
+tone — it falls back to the default greeting and notes the fallback in
+the prefix. It escalates to the caller only when the request is outside
+the greeting domain.

--- a/examples/roles/hello-orchestrator.md
+++ b/examples/roles/hello-orchestrator.md
@@ -23,7 +23,7 @@ This role is a reference example. It shows the orchestration contract a real rol
 
 - Loading more than one greeting skill in a single turn.
 - Loading capability files (`capabilities/**/capability.md`) directly. This role composes the parent skills only; in this example, capability dispatch stays inside `hello-router`. (The foundry's self-contained-skill pattern lets roles reference a skill's capabilities by system-root-relative path; this role just opts out.)
-- Inventing tone variants beyond `formal` and `casual`. Unknown tones trigger the handoff rule below.
+- Inventing tone variants beyond `formal` and `casual`. Unknown tones route to the silent casual fallback described in Handoff — they never surface as a new tone branch or an escalation to the caller.
 - Holding state between turns. Each request is treated independently.
 - Loading other roles. Roles never compose roles in this skill system.
 

--- a/examples/roles/hello-orchestrator.md
+++ b/examples/roles/hello-orchestrator.md
@@ -2,71 +2,51 @@
 
 ## Purpose
 
-Coordinates a tone-aware welcome workflow that combines the standalone
-`hello-greeter` skill (default greeting) with the `hello-router` skill
-(tone-specific dispatch). Activates when a multi-step welcome is requested
-and the caller wants the role to decide which skill to invoke based on the
-tone signal in the request.
+Coordinates a tone-aware welcome workflow that combines the standalone `hello-greeter` skill (default greeting) with the `hello-router` skill (tone-specific dispatch). Activates when a multi-step welcome is requested and the caller wants the role to decide which skill to invoke based on the tone signal in the request.
 
-This role is a reference example. It shows the orchestration contract a
-real role would publish — responsibility, allowed actions, forbidden
-actions, handoff rules, and a Skills Used table — without owning any
-domain logic of its own.
+This role is a reference example. It shows the orchestration contract a real role would publish — responsibility, allowed actions, forbidden actions, handoff rules, and a Skills Used table — without owning any domain logic of its own.
 
 ## Responsibilities
 
-- Detect the tone signal in the request and decide between the standalone
-  greeter and the tone-specific router.
-- Emit exactly one greeting per request — never two greetings, never zero.
-- Preserve recipient names verbatim, including honorifics, when passing
-  them to the underlying skills.
-- Surface a clear handoff message when the request falls outside the
-  greeting domain.
+- Detect the tone signal in the request and decide between the standalone greeter and the tone-specific router.
+- Emit exactly one greeting for each in-scope greeting request — never two greetings, never zero. Out-of-scope requests return a handoff message instead of a greeting (see Handoff below).
+- Preserve recipient names verbatim, including honorifics, when passing them to the underlying skills.
+- Surface a clear handoff message when the request falls outside the greeting domain.
 
 ## Allowed
 
 - Loading the `hello-greeter` skill for the default casual greeting.
-- Loading the `hello-router` skill and selecting one of its two registered
-  capabilities (`greet-formal`, `greet-casual`).
+- Loading the `hello-router` skill, which then dispatches internally to its formal or casual capability. The role does not load capability files directly — capability dispatch is the router's responsibility.
 - Reading the recipient name and tone fields from the incoming request.
 
 ## Forbidden
 
 - Loading more than one greeting skill in a single turn.
-- Inventing tone variants beyond `formal` and `casual`. Unknown tones
-  trigger the handoff rule below.
+- Loading capability files (`capabilities/**/capability.md`) directly. Roles compose skills, not capabilities — capability dispatch stays inside the parent skill.
+- Inventing tone variants beyond `formal` and `casual`. Unknown tones trigger the handoff rule below.
 - Holding state between turns. Each request is treated independently.
 - Loading other roles. Roles never compose roles in this skill system.
 
 ## Handoff
 
-- Tone is missing or unrecognized → fall back silently to `hello-greeter`
-  with the default casual tone. The fallback is not announced in the
-  output — the role still emits exactly one greeting line and nothing
-  else.
-- Request asks for multi-recipient or templated bulk greetings → return a
-  short refusal pointing the caller at a future bulk-greeting skill.
-- Request asks for anything other than a greeting → return control to the
-  caller with an explicit "out of scope" message.
+- Tone is missing or unrecognized → fall back silently to `hello-greeter` with the default casual tone. The fallback is not announced in the output — the role still emits exactly one greeting line and nothing else.
+- Request asks for multi-recipient or templated bulk greetings → return a short refusal pointing the caller at a future bulk-greeting skill.
+- Request asks for anything other than a greeting → return control to the caller with an explicit "out of scope" message.
 
 ## Workflow
 
 Task Progress:
 - [ ] Step 1: Parse the recipient name and tone from the request.
-- [ ] Step 2: If tone is `formal` or `casual`, load `hello-router` and
-      dispatch to the matching capability.
-- [ ] Step 3: Otherwise, load `hello-greeter` and emit the default
-      casual greeting.
+- [ ] Step 2: If tone is `formal` or `casual`, load `hello-router` and pass the tone signal — the router dispatches to the matching capability internally.
+- [ ] Step 3: Otherwise, load `hello-greeter` and emit the default casual greeting.
 - [ ] Step 4: Return the single greeting line and stop.
 
 ## Skills Used
 
-| Skill / Capability | Purpose in Workflow |
+| Skill | Purpose in Workflow |
 |---|---|
 | skills/hello-greeter/SKILL.md | Default casual greeting when no tone is specified |
-| skills/hello-router/SKILL.md | Tone-aware dispatch entry point |
-| skills/hello-router/capabilities/greet-formal/capability.md | Formal tone rendering loaded by the router |
-| skills/hello-router/capabilities/greet-casual/capability.md | Casual tone rendering loaded by the router |
+| skills/hello-router/SKILL.md | Tone-aware dispatch entry point — loads its own `greet-formal` or `greet-casual` capability based on the tone signal the role hands it |
 
 <!-- Paths in this table are relative to the example mini system root
      (the examples/ directory containing skills/ and roles/), not relative
@@ -74,8 +54,4 @@ Task Progress:
 
 ## Interaction Pattern
 
-The role decides autonomously between the standalone and router paths
-based on the tone signal. It asks no clarifying questions for missing
-tone — it falls back silently to the default greeting and emits exactly
-one line. It escalates to the caller only when the request is outside
-the greeting domain.
+The role decides autonomously between the standalone and router paths based on the tone signal. It asks no clarifying questions for missing tone — it falls back silently to the default greeting and emits exactly one line. It escalates to the caller only when the request is outside the greeting domain.

--- a/examples/roles/hello-orchestrator.md
+++ b/examples/roles/hello-orchestrator.md
@@ -40,8 +40,10 @@ domain logic of its own.
 
 ## Handoff
 
-- Tone is missing or unrecognized → fall back to `hello-greeter` with the
-  default casual tone, and note the fallback in the response prefix.
+- Tone is missing or unrecognized → fall back silently to `hello-greeter`
+  with the default casual tone. The fallback is not announced in the
+  output — the role still emits exactly one greeting line and nothing
+  else.
 - Request asks for multi-recipient or templated bulk greetings → return a
   short refusal pointing the caller at a future bulk-greeting skill.
 - Request asks for anything other than a greeting → return control to the
@@ -64,6 +66,7 @@ Task Progress:
 | skills/hello-greeter/SKILL.md | Default casual greeting when no tone is specified |
 | skills/hello-router/SKILL.md | Tone-aware dispatch entry point |
 | skills/hello-router/capabilities/greet-formal/capability.md | Formal tone rendering loaded by the router |
+| skills/hello-router/capabilities/greet-casual/capability.md | Casual tone rendering loaded by the router |
 
 <!-- Paths in this table are relative to the example mini system root
      (the examples/ directory containing skills/ and roles/), not relative
@@ -73,6 +76,6 @@ Task Progress:
 
 The role decides autonomously between the standalone and router paths
 based on the tone signal. It asks no clarifying questions for missing
-tone — it falls back to the default greeting and notes the fallback in
-the prefix. It escalates to the caller only when the request is outside
+tone — it falls back silently to the default greeting and emits exactly
+one line. It escalates to the caller only when the request is outside
 the greeting domain.

--- a/examples/skills/hello-greeter/SKILL.md
+++ b/examples/skills/hello-greeter/SKILL.md
@@ -5,8 +5,9 @@ description: >
   formal or casual tone. Activates whenever the conversation asks to say
   hello, welcome someone, or produce an opening greeting. Single-purpose,
   no branching, no shell access. Demonstrates the smallest valid standalone
-  skill in the Skill System Foundry — minimal frontmatter, third-person
-  description, body well under the recommended line cap.
+  skill in the Skill System Foundry — required `name` and `description`
+  fields plus an optional `metadata` block, third-person description, body
+  well under the recommended line cap.
 metadata:
   version: "1.0.0"
 ---

--- a/examples/skills/hello-greeter/SKILL.md
+++ b/examples/skills/hello-greeter/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: hello-greeter
+description: >
+  Greets a single recipient with a friendly, language-aware welcome message.
+  Activates whenever the conversation asks to say hello, welcome someone, or
+  produce an opening greeting. Single-purpose, no branching, no shell access.
+  Demonstrates the smallest valid standalone skill in the Skill System
+  Foundry — minimal frontmatter, third-person description, body well under
+  the recommended line cap.
+metadata:
+  version: "1.0.0"
+---
+
+# Hello Greeter
+
+## Purpose
+
+Produces a one-line welcome message addressed to a named recipient. The skill
+exists as a reference example only — it shows the smallest valid shape a
+standalone skill can take while still satisfying the Agent Skills
+specification and foundry conventions.
+
+## Instructions
+
+1. Identify the recipient name from the request. Fall back to the literal
+   word "friend" when no name is supplied.
+2. Choose a tone token from the request: "formal" or "casual". Default to
+   "casual" when nothing is specified.
+3. Emit exactly one greeting line. For "casual" tone, the format is
+   `Hello, <name>!`. For "formal" tone, the format is
+   `Good day, <name>.`.
+4. Stop after the single line. The skill performs no follow-up question and
+   no continuation prompt.
+
+## Examples
+
+Input: `say hello to Sam`. Output: `Hello, Sam!`
+
+Input: `formal greeting for Dr. Lee`. Output: `Good day, Dr. Lee.`
+
+## Output Format
+
+A single plain-text line containing the greeting. No markdown, no fences,
+no trailing whitespace.

--- a/examples/skills/hello-greeter/SKILL.md
+++ b/examples/skills/hello-greeter/SKILL.md
@@ -15,22 +15,14 @@ metadata:
 
 ## Purpose
 
-Produces a one-line welcome message addressed to a named recipient. The skill
-exists as a reference example only — it shows the smallest valid shape a
-standalone skill can take while still satisfying the Agent Skills
-specification and foundry conventions.
+Produces a one-line welcome message addressed to a named recipient. The skill exists as a reference example only — it shows the smallest valid shape a standalone skill can take while still satisfying the Agent Skills specification and foundry conventions.
 
 ## Instructions
 
-1. Identify the recipient name from the request. Fall back to the literal
-   word "friend" when no name is supplied.
-2. Choose a tone token from the request: "formal" or "casual". Default to
-   "casual" when nothing is specified.
-3. Emit exactly one greeting line. For "casual" tone, the format is
-   `Hello, <name>!`. For "formal" tone, the format is
-   `Good day, <name>.`.
-4. Stop after the single line. The skill performs no follow-up question and
-   no continuation prompt.
+1. Identify the recipient name from the request. Fall back to the literal word "friend" when no name is supplied.
+2. Choose a tone token from the request: "formal" or "casual". Default to "casual" when nothing is specified.
+3. Emit exactly one greeting line. For "casual" tone, the format is `Hello, <name>!`. For "formal" tone, the format is `Good day, <name>.`.
+4. Stop after the single line. The skill performs no follow-up question and no continuation prompt.
 
 ## Examples
 
@@ -40,5 +32,4 @@ Input: `formal greeting for Dr. Lee`. Output: `Good day, Dr. Lee.`
 
 ## Output Format
 
-A single plain-text line containing the greeting. No markdown, no fences,
-no trailing whitespace.
+A single plain-text line containing the greeting. No markdown, no fences, no trailing whitespace.

--- a/examples/skills/hello-greeter/SKILL.md
+++ b/examples/skills/hello-greeter/SKILL.md
@@ -20,7 +20,7 @@ Produces a one-line welcome message addressed to a named recipient. The skill ex
 ## Instructions
 
 1. Identify the recipient name from the request. Fall back to the literal word "friend" when no name is supplied.
-2. Choose a tone token from the request: "formal" or "casual". Default to "casual" when nothing is specified.
+2. Choose a tone token from the request: use "formal" only when the request explicitly specifies "formal". Use "casual" for every other case — when no tone is specified, when the request says "casual", or when the request uses any unrecognized tone term (e.g., "informal", "friendly").
 3. Emit exactly one greeting line. For "casual" tone, the format is `Hello, <name>!`. For "formal" tone, the format is `Good day, <name>.`.
 4. Stop after the single line. The skill performs no follow-up question and no continuation prompt.
 

--- a/examples/skills/hello-greeter/SKILL.md
+++ b/examples/skills/hello-greeter/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: hello-greeter
 description: >
-  Greets a single recipient with a friendly, language-aware welcome message.
-  Activates whenever the conversation asks to say hello, welcome someone, or
-  produce an opening greeting. Single-purpose, no branching, no shell access.
-  Demonstrates the smallest valid standalone skill in the Skill System
-  Foundry — minimal frontmatter, third-person description, body well under
-  the recommended line cap.
+  Greets a single recipient with a friendly welcome message rendered in a
+  formal or casual tone. Activates whenever the conversation asks to say
+  hello, welcome someone, or produce an opening greeting. Single-purpose,
+  no branching, no shell access. Demonstrates the smallest valid standalone
+  skill in the Skill System Foundry — minimal frontmatter, third-person
+  description, body well under the recommended line cap.
 metadata:
   version: "1.0.0"
 ---

--- a/examples/skills/hello-router/SKILL.md
+++ b/examples/skills/hello-router/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: hello-router
+description: >
+  Greets a recipient through one of two registered tones — formal or casual —
+  by dispatching to a dedicated capability. Activates whenever the
+  conversation asks for a tone-specific welcome, a switch between formal and
+  casual greetings, or a comparison of the two styles. Demonstrates the
+  router pattern in the Skill System Foundry — a thin SKILL.md entry point
+  routing to capability files that hold the actual instructions, with
+  allowed-tools declared so capability-level shell fences stay coherent.
+allowed-tools: Bash
+metadata:
+  version: "1.0.0"
+---
+
+# Hello Router
+
+## Capabilities
+
+Route to the matching capability based on the requested tone:
+
+| Capability | Trigger | Path |
+|---|---|---|
+| greet-formal | When the request asks for a formal, business-appropriate, or honorific greeting | capabilities/greet-formal/capability.md |
+| greet-casual | When the request asks for a casual, friendly, or first-name greeting | capabilities/greet-casual/capability.md |
+
+Load only the capability that matches the request. Do not load both unless
+the conversation explicitly compares the two tones side by side.
+
+## Shared Behaviour
+
+Both capabilities emit a single greeting line and stop. Neither capability
+loops, prompts, or escalates back to this entry point. The router itself
+holds no business logic — it only dispatches.

--- a/examples/skills/hello-router/SKILL.md
+++ b/examples/skills/hello-router/SKILL.md
@@ -24,11 +24,8 @@ Route to the matching capability based on the requested tone:
 | greet-formal | When the request asks for a formal, business-appropriate, or honorific greeting | capabilities/greet-formal/capability.md |
 | greet-casual | When the request asks for a casual, friendly, or first-name greeting | capabilities/greet-casual/capability.md |
 
-Load only the capability that matches the request. Do not load both unless
-the conversation explicitly compares the two tones side by side.
+Load only the capability that matches the request. Do not load both unless the conversation explicitly compares the two tones side by side.
 
 ## Shared Behaviour
 
-Both capabilities emit a single greeting line and stop. Neither capability
-loops, prompts, or escalates back to this entry point. The router itself
-holds no business logic — it only dispatches.
+Both capabilities emit a single greeting line and stop. Neither capability loops, prompts, or escalates back to this entry point. The router itself holds no business logic — it only dispatches.

--- a/examples/skills/hello-router/SKILL.md
+++ b/examples/skills/hello-router/SKILL.md
@@ -26,6 +26,6 @@ Route to the matching capability based on the requested tone:
 
 Load only the capability that matches the request. Do not load both unless the conversation explicitly compares the two tones side by side.
 
-## Shared Behaviour
+## Shared Behavior
 
 Both capabilities emit a single greeting line and stop. Neither capability loops, prompts, or escalates back to this entry point. The router itself holds no business logic — it only dispatches.

--- a/examples/skills/hello-router/capabilities/greet-casual/capability.md
+++ b/examples/skills/hello-router/capabilities/greet-casual/capability.md
@@ -9,16 +9,12 @@ metadata:
 
 ## Purpose
 
-Renders one casual greeting line for a single recipient. Loaded on demand
-from `hello-router` when the request asks for a casual, friendly, or
-first-name tone.
+Renders one casual greeting line for a single recipient. Loaded on demand from `hello-router` when the request asks for a casual, friendly, or first-name tone.
 
 ## Instructions
 
-1. Read the recipient name from the request. Strip honorifics if present —
-   casual greetings drop titles by convention.
-2. Render the greeting using the format `Hello, <name>!` followed by no
-   trailing characters.
+1. Read the recipient name from the request. Strip honorifics if present — casual greetings drop titles by convention.
+2. Render the greeting using the format `Hello, <name>!` followed by no trailing characters.
 3. Stop after a single line. The capability never loops or chains.
 
 ## Output Format

--- a/examples/skills/hello-router/capabilities/greet-casual/capability.md
+++ b/examples/skills/hello-router/capabilities/greet-casual/capability.md
@@ -1,7 +1,8 @@
 ---
 description: >
   Produces a casual, friendly greeting line for a named recipient.
-  Activates when the parent router selects the casual tone.
+  Activates when the request asks for a casual, friendly, or first-name
+  greeting.
 metadata:
   version: "1.0.0"
 ---

--- a/examples/skills/hello-router/capabilities/greet-casual/capability.md
+++ b/examples/skills/hello-router/capabilities/greet-casual/capability.md
@@ -1,0 +1,26 @@
+---
+description: >
+  Produces a casual, friendly greeting line for a named recipient.
+  Activates when the parent router selects the casual tone.
+metadata:
+  version: "1.0.0"
+---
+# Greet Casual
+
+## Purpose
+
+Renders one casual greeting line for a single recipient. Loaded on demand
+from `hello-router` when the request asks for a casual, friendly, or
+first-name tone.
+
+## Instructions
+
+1. Read the recipient name from the request. Strip honorifics if present —
+   casual greetings drop titles by convention.
+2. Render the greeting using the format `Hello, <name>!` followed by no
+   trailing characters.
+3. Stop after a single line. The capability never loops or chains.
+
+## Output Format
+
+One plain-text line. No markdown, no fences, no trailing whitespace.

--- a/examples/skills/hello-router/capabilities/greet-casual/capability.md
+++ b/examples/skills/hello-router/capabilities/greet-casual/capability.md
@@ -10,7 +10,7 @@ metadata:
 
 ## Purpose
 
-Renders one casual greeting line for a single recipient. Loaded on demand from `hello-router` when the request asks for a casual, friendly, or first-name tone.
+Renders one casual greeting line for a single recipient. Use when the request asks for a casual, friendly, or first-name greeting.
 
 ## Instructions
 

--- a/examples/skills/hello-router/capabilities/greet-formal/capability.md
+++ b/examples/skills/hello-router/capabilities/greet-formal/capability.md
@@ -16,13 +16,16 @@ Renders one formal greeting line for a single recipient. Use when the request as
 
 1. Read the recipient name from the request. Preserve any honorific provided ("Dr.", "Prof.", "Ms.") verbatim.
 2. Render the greeting using the format `Good day, <name>.`. Nothing follows the period on the same line.
-3. Optionally print the rendered line through the harness Bash tool when the request asks for an interactive demonstration. The fence below illustrates the canonical invocation — `printf` terminates the line with a single newline, which is the line terminator the shell needs and is not part of the greeting itself:
-
-   ```bash
-   printf 'Good day, %s.\n' "$RECIPIENT"
-   ```
-
+3. Optionally print the rendered line through the harness Bash tool when the request asks for an interactive demonstration — see [Optional Shell Demonstration](#optional-shell-demonstration) below for the canonical invocation.
 4. Stop after a single line. The capability never loops or chains.
+
+## Optional Shell Demonstration
+
+The fence below shows the canonical Bash invocation. `printf` terminates the line with a single newline, which is the line terminator the shell needs and is not part of the greeting itself. This fence is at column 0 so the foundry's tool-coherence rule recognises it and matches it against the parent skill's `allowed-tools: Bash` declaration:
+
+```bash
+printf 'Good day, %s.\n' "$RECIPIENT"
+```
 
 ## Output Format
 

--- a/examples/skills/hello-router/capabilities/greet-formal/capability.md
+++ b/examples/skills/hello-router/capabilities/greet-formal/capability.md
@@ -17,11 +17,13 @@ honorific tone.
 
 1. Read the recipient name from the request. Preserve any honorific
    provided ("Dr.", "Prof.", "Ms.") verbatim.
-2. Render the greeting using the format `Good day, <name>.` followed by no
-   trailing characters.
+2. Render the greeting using the format `Good day, <name>.`. Nothing
+   follows the period on the same line.
 3. Optionally print the rendered line through the harness Bash tool when
    the request asks for an interactive demonstration. The fence below
-   illustrates the canonical invocation:
+   illustrates the canonical invocation — `printf` terminates the line
+   with a single newline, which is the line terminator the shell needs
+   and is not part of the greeting itself:
 
    ```bash
    printf 'Good day, %s.\n' "$RECIPIENT"
@@ -32,4 +34,4 @@ honorific tone.
 ## Output Format
 
 One plain-text line. No markdown, no fences in the final answer, no
-trailing whitespace.
+trailing whitespace beyond the single line terminator.

--- a/examples/skills/hello-router/capabilities/greet-formal/capability.md
+++ b/examples/skills/hello-router/capabilities/greet-formal/capability.md
@@ -10,7 +10,7 @@ metadata:
 
 ## Purpose
 
-Renders one formal greeting line for a single recipient. Loaded on demand from `hello-router` when the request asks for a formal, business, or honorific tone.
+Renders one formal greeting line for a single recipient. Use when the request asks for a formal, business-appropriate, or honorific greeting.
 
 ## Instructions
 

--- a/examples/skills/hello-router/capabilities/greet-formal/capability.md
+++ b/examples/skills/hello-router/capabilities/greet-formal/capability.md
@@ -1,0 +1,35 @@
+---
+description: >
+  Produces a formal, business-appropriate greeting line for a named
+  recipient. Activates when the parent router selects the formal tone.
+metadata:
+  version: "1.0.0"
+---
+# Greet Formal
+
+## Purpose
+
+Renders one formal greeting line for a single recipient. Loaded on demand
+from `hello-router` when the request asks for a formal, business, or
+honorific tone.
+
+## Instructions
+
+1. Read the recipient name from the request. Preserve any honorific
+   provided ("Dr.", "Prof.", "Ms.") verbatim.
+2. Render the greeting using the format `Good day, <name>.` followed by no
+   trailing characters.
+3. Optionally print the rendered line through the harness Bash tool when
+   the request asks for an interactive demonstration. The fence below
+   illustrates the canonical invocation:
+
+   ```bash
+   printf 'Good day, %s.\n' "$RECIPIENT"
+   ```
+
+4. Stop after a single line. The capability never loops or chains.
+
+## Output Format
+
+One plain-text line. No markdown, no fences in the final answer, no
+trailing whitespace.

--- a/examples/skills/hello-router/capabilities/greet-formal/capability.md
+++ b/examples/skills/hello-router/capabilities/greet-formal/capability.md
@@ -1,7 +1,8 @@
 ---
 description: >
   Produces a formal, business-appropriate greeting line for a named
-  recipient. Activates when the parent router selects the formal tone.
+  recipient. Activates when the request asks for a formal,
+  business-appropriate, or honorific greeting.
 metadata:
   version: "1.0.0"
 ---

--- a/examples/skills/hello-router/capabilities/greet-formal/capability.md
+++ b/examples/skills/hello-router/capabilities/greet-formal/capability.md
@@ -9,21 +9,13 @@ metadata:
 
 ## Purpose
 
-Renders one formal greeting line for a single recipient. Loaded on demand
-from `hello-router` when the request asks for a formal, business, or
-honorific tone.
+Renders one formal greeting line for a single recipient. Loaded on demand from `hello-router` when the request asks for a formal, business, or honorific tone.
 
 ## Instructions
 
-1. Read the recipient name from the request. Preserve any honorific
-   provided ("Dr.", "Prof.", "Ms.") verbatim.
-2. Render the greeting using the format `Good day, <name>.`. Nothing
-   follows the period on the same line.
-3. Optionally print the rendered line through the harness Bash tool when
-   the request asks for an interactive demonstration. The fence below
-   illustrates the canonical invocation — `printf` terminates the line
-   with a single newline, which is the line terminator the shell needs
-   and is not part of the greeting itself:
+1. Read the recipient name from the request. Preserve any honorific provided ("Dr.", "Prof.", "Ms.") verbatim.
+2. Render the greeting using the format `Good day, <name>.`. Nothing follows the period on the same line.
+3. Optionally print the rendered line through the harness Bash tool when the request asks for an interactive demonstration. The fence below illustrates the canonical invocation — `printf` terminates the line with a single newline, which is the line terminator the shell needs and is not part of the greeting itself:
 
    ```bash
    printf 'Good day, %s.\n' "$RECIPIENT"
@@ -33,5 +25,4 @@ honorific tone.
 
 ## Output Format
 
-One plain-text line. No markdown, no fences in the final answer, no
-trailing whitespace beyond the single line terminator.
+One plain-text line. No markdown, no fences in the final answer, no trailing whitespace beyond the single line terminator.

--- a/tests/test_validate_examples_script.py
+++ b/tests/test_validate_examples_script.py
@@ -1,0 +1,344 @@
+"""Tests for .github/scripts/validate-examples.py.
+
+Covers ``discover_skill_dirs`` (only directories with SKILL.md, hidden
+entries skipped, missing root tolerated, sorted output), ``validate_one``
+(success, failure with empty stdout, invalid JSON, non-zero exit code
+treated as failure), ``format_verdict`` (success and failure rendering,
+missing JSON), ``run_validation`` (aggregates, ``all_success`` flag), and
+``main`` integration against the real ``validate_skill.py`` (happy path,
+missing validator, missing examples, sibling roles directory ignored).
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from unittest import mock
+
+
+_CI_SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", ".github", "scripts"),
+)
+_script_path = os.path.join(_CI_SCRIPTS_DIR, "validate-examples.py")
+_spec = importlib.util.spec_from_file_location(
+    "validate_examples", _script_path,
+)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"Could not load module from {_script_path}")
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+discover_skill_dirs = _mod.discover_skill_dirs
+validate_one = _mod.validate_one
+format_verdict = _mod.format_verdict
+run_validation = _mod.run_validation
+main = _mod.main
+
+
+_REAL_VALIDATOR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "skill-system-foundry",
+        "scripts",
+        "validate_skill.py",
+    )
+)
+
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+
+def _write(path: str, content: str) -> None:
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+
+def _write_minimal_skill(skill_dir: str, *, name: str) -> None:
+    """Create a minimal valid skill at *skill_dir* with directory name *name*."""
+    description = (
+        "Greets a single recipient with a one-line message. "
+        "Test fixture used by the validate-examples CI helper. "
+        "Activates only when the conversation explicitly asks for a hello."
+    )
+    content = textwrap.dedent(
+        f"""\
+        ---
+        name: {name}
+        description: >
+          {description}
+        ---
+
+        # Test Skill
+
+        ## Purpose
+
+        Reference fixture only.
+
+        ## Instructions
+
+        1. Emit a greeting.
+        """
+    )
+    _write(os.path.join(skill_dir, "SKILL.md"), content)
+
+
+# ===================================================================
+# discover_skill_dirs
+# ===================================================================
+
+
+class DiscoverSkillDirsTests(unittest.TestCase):
+
+    def test_returns_only_directories_with_skill_md(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, "with-skill"))
+            _write(os.path.join(root, "with-skill", "SKILL.md"), "stub")
+            os.makedirs(os.path.join(root, "no-skill"))
+            _write(os.path.join(root, "loose-file.txt"), "stub")
+            found = discover_skill_dirs(root)
+            self.assertEqual(len(found), 1)
+            self.assertTrue(found[0].endswith("with-skill"))
+
+    def test_skips_hidden_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, ".hidden"))
+            _write(os.path.join(root, ".hidden", "SKILL.md"), "stub")
+            self.assertEqual(discover_skill_dirs(root), [])
+
+    def test_missing_root_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            missing = os.path.join(root, "does-not-exist")
+            self.assertEqual(discover_skill_dirs(missing), [])
+
+    def test_results_are_sorted(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            for name in ("zebra", "alpha", "mike"):
+                os.makedirs(os.path.join(root, name))
+                _write(os.path.join(root, name, "SKILL.md"), "stub")
+            found = discover_skill_dirs(root)
+            self.assertEqual(
+                [os.path.basename(p) for p in found],
+                ["alpha", "mike", "zebra"],
+            )
+
+
+# ===================================================================
+# validate_one
+# ===================================================================
+
+
+class _FakeCompleted:
+
+    def __init__(self, stdout: str, returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+class ValidateOneTests(unittest.TestCase):
+
+    def test_success_path(self) -> None:
+        payload = {
+            "tool": "validate_skill",
+            "success": True,
+            "summary": {"failures": 0, "warnings": 0, "info": 0, "passes": 5},
+        }
+        fake = _FakeCompleted(json.dumps(payload), returncode=0)
+        with mock.patch.object(_mod.subprocess, "run", return_value=fake):
+            success, parsed, raw = validate_one("/tmp/skill", "/tmp/v.py")
+        self.assertTrue(success)
+        self.assertEqual(parsed["summary"]["failures"], 0)
+        self.assertIn("validate_skill", raw)
+
+    def test_failure_payload_marks_unsuccessful(self) -> None:
+        payload = {
+            "tool": "validate_skill",
+            "success": False,
+            "summary": {"failures": 2, "warnings": 0, "info": 0, "passes": 3},
+            "errors": {"failures": ["FAIL: bad thing"], "warnings": [], "info": []},
+        }
+        fake = _FakeCompleted(json.dumps(payload), returncode=1)
+        with mock.patch.object(_mod.subprocess, "run", return_value=fake):
+            success, parsed, _ = validate_one("/tmp/skill", "/tmp/v.py")
+        self.assertFalse(success)
+        self.assertEqual(parsed["summary"]["failures"], 2)
+
+    def test_invalid_json_returns_none(self) -> None:
+        fake = _FakeCompleted("not-json-at-all", returncode=0)
+        with mock.patch.object(_mod.subprocess, "run", return_value=fake):
+            success, parsed, raw = validate_one("/tmp/skill", "/tmp/v.py")
+        self.assertFalse(success)
+        self.assertIsNone(parsed)
+        self.assertEqual(raw, "not-json-at-all")
+
+    def test_empty_stdout_returns_none(self) -> None:
+        fake = _FakeCompleted("", returncode=1)
+        with mock.patch.object(_mod.subprocess, "run", return_value=fake):
+            success, parsed, _ = validate_one("/tmp/skill", "/tmp/v.py")
+        self.assertFalse(success)
+        self.assertIsNone(parsed)
+
+    def test_returncode_nonzero_overrides_success_flag(self) -> None:
+        payload = {
+            "tool": "validate_skill",
+            "success": True,
+            "summary": {"failures": 0, "warnings": 0, "info": 0, "passes": 1},
+        }
+        fake = _FakeCompleted(json.dumps(payload), returncode=2)
+        with mock.patch.object(_mod.subprocess, "run", return_value=fake):
+            success, _, _ = validate_one("/tmp/skill", "/tmp/v.py")
+        self.assertFalse(success)
+
+
+# ===================================================================
+# format_verdict
+# ===================================================================
+
+
+class FormatVerdictTests(unittest.TestCase):
+
+    def test_success_renders_check_mark(self) -> None:
+        payload = {
+            "success": True,
+            "summary": {"failures": 0, "warnings": 1, "info": 2},
+        }
+        line = format_verdict("/tmp/skills/alpha", payload)
+        self.assertIn("alpha", line)
+        self.assertIn("0 fail / 1 warn / 2 info", line)
+        self.assertIn("✓", line)
+
+    def test_failure_renders_cross_mark(self) -> None:
+        payload = {
+            "success": False,
+            "summary": {"failures": 1, "warnings": 0, "info": 0},
+        }
+        line = format_verdict("/tmp/skills/alpha", payload)
+        self.assertIn("✗", line)
+        self.assertIn("1 fail", line)
+
+    def test_missing_payload_renders_explanation(self) -> None:
+        line = format_verdict("/tmp/skills/alpha", None)
+        self.assertIn("alpha", line)
+        self.assertIn("no JSON output", line)
+
+
+# ===================================================================
+# run_validation
+# ===================================================================
+
+
+class RunValidationTests(unittest.TestCase):
+
+    def test_all_success_when_every_skill_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            _write_minimal_skill(os.path.join(root, "alpha"), name="alpha")
+            _write_minimal_skill(os.path.join(root, "bravo"), name="bravo")
+            results, all_ok = run_validation(root, _REAL_VALIDATOR)
+        self.assertTrue(all_ok)
+        self.assertEqual(len(results), 2)
+        for _, success, _, _ in results:
+            self.assertTrue(success)
+
+    def test_all_success_false_when_one_skill_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            _write_minimal_skill(os.path.join(root, "alpha"), name="alpha")
+            broken_dir = os.path.join(root, "broken")
+            os.makedirs(broken_dir)
+            # SKILL.md exists but frontmatter is missing — guaranteed FAIL.
+            _write(os.path.join(broken_dir, "SKILL.md"), "# Broken\n")
+            results, all_ok = run_validation(root, _REAL_VALIDATOR)
+        self.assertFalse(all_ok)
+        self.assertEqual(len(results), 2)
+        labels = {os.path.basename(r[0]): r[1] for r in results}
+        self.assertTrue(labels["alpha"])
+        self.assertFalse(labels["broken"])
+
+
+# ===================================================================
+# main
+# ===================================================================
+
+
+class MainTests(unittest.TestCase):
+
+    def test_happy_path_returns_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            skills_root = os.path.join(root, "skills")
+            os.makedirs(skills_root)
+            _write_minimal_skill(
+                os.path.join(skills_root, "alpha"), name="alpha",
+            )
+            with mock.patch.object(sys.stdout, "write"):
+                rc = main([
+                    "--skills-root", skills_root,
+                    "--validator", _REAL_VALIDATOR,
+                ])
+        self.assertEqual(rc, 0)
+
+    def test_missing_validator_returns_one(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            skills_root = os.path.join(root, "skills")
+            os.makedirs(skills_root)
+            with mock.patch.object(sys.stderr, "write"):
+                rc = main([
+                    "--skills-root", skills_root,
+                    "--validator", os.path.join(root, "no-such-validator.py"),
+                ])
+        self.assertEqual(rc, 1)
+
+    def test_no_skills_returns_one(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            empty_root = os.path.join(root, "skills")
+            os.makedirs(empty_root)
+            with mock.patch.object(sys.stderr, "write"):
+                rc = main([
+                    "--skills-root", empty_root,
+                    "--validator", _REAL_VALIDATOR,
+                ])
+        self.assertEqual(rc, 1)
+
+    def test_sibling_roles_directory_is_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            skills_root = os.path.join(root, "skills")
+            roles_root = os.path.join(root, "roles")
+            os.makedirs(skills_root)
+            os.makedirs(roles_root)
+            _write_minimal_skill(
+                os.path.join(skills_root, "alpha"), name="alpha",
+            )
+            # A loose markdown file that would FAIL if validated as a skill.
+            _write(os.path.join(roles_root, "some-role.md"), "# Role\n")
+            with mock.patch.object(sys.stdout, "write"):
+                rc = main([
+                    "--skills-root", skills_root,
+                    "--validator", _REAL_VALIDATOR,
+                ])
+        # roles/ is outside skills_root, so the helper never sees it and
+        # the run succeeds.
+        self.assertEqual(rc, 0)
+
+    def test_main_reports_failure_when_skill_breaks(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            skills_root = os.path.join(root, "skills")
+            broken_dir = os.path.join(skills_root, "broken")
+            os.makedirs(broken_dir)
+            _write(os.path.join(broken_dir, "SKILL.md"), "# Broken\n")
+            with mock.patch.object(sys.stdout, "write"):
+                rc = main([
+                    "--skills-root", skills_root,
+                    "--validator", _REAL_VALIDATOR,
+                ])
+        self.assertEqual(rc, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_validate_examples_script.py
+++ b/tests/test_validate_examples_script.py
@@ -37,6 +37,7 @@ _spec.loader.exec_module(_mod)
 discover_skill_dirs = _mod.discover_skill_dirs
 discover_capability_dirs = _mod.discover_capability_dirs
 find_malformed_skill_dirs = _mod.find_malformed_skill_dirs
+find_malformed_capability_dirs = _mod.find_malformed_capability_dirs
 validate_one = _mod.validate_one
 format_verdict = _mod.format_verdict
 run_validation = _mod.run_validation
@@ -214,6 +215,35 @@ class FindMalformedSkillDirsTests(unittest.TestCase):
                 os.makedirs(os.path.join(root, name))
                 _write(os.path.join(root, name, "SKILL.md"), "stub")
             self.assertEqual(find_malformed_skill_dirs(root), [])
+
+
+# ===================================================================
+# find_malformed_capability_dirs
+# ===================================================================
+
+
+class FindMalformedCapabilityDirsTests(unittest.TestCase):
+
+    def test_returns_capability_dirs_missing_capability_md(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            valid = os.path.join(root, "capabilities", "ok")
+            os.makedirs(valid)
+            _write(os.path.join(valid, "capability.md"), "stub")
+            broken = os.path.join(root, "capabilities", "broken")
+            os.makedirs(broken)
+            malformed = find_malformed_capability_dirs(root)
+            self.assertEqual(len(malformed), 1)
+            self.assertTrue(malformed[0].endswith("broken"))
+
+    def test_returns_empty_without_capabilities_subtree(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(find_malformed_capability_dirs(root), [])
+
+    def test_skips_hidden_and_loose_files(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, "capabilities", ".hidden"))
+            _write(os.path.join(root, "capabilities", "loose.md"), "stub")
+            self.assertEqual(find_malformed_capability_dirs(root), [])
 
 
 # ===================================================================
@@ -614,6 +644,30 @@ class MainTests(unittest.TestCase):
                     "--validator", _REAL_VALIDATOR,
                 ])
         self.assertEqual(rc, 1)
+
+    def test_main_fails_fast_on_malformed_capability_dir(self) -> None:
+        # A non-hidden capabilities/<name>/ directory missing
+        # capability.md must fail the run before validation begins,
+        # mirroring the SKILL.md-level guard.
+        with tempfile.TemporaryDirectory() as root:
+            skills_root = os.path.join(root, "skills")
+            os.makedirs(skills_root)
+            router_dir = os.path.join(skills_root, "router")
+            _write_minimal_skill(router_dir, name="router")
+            os.makedirs(os.path.join(router_dir, "capabilities", "broken-cap"))
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with contextlib.redirect_stdout(stdout), \
+                 contextlib.redirect_stderr(stderr):
+                rc = main([
+                    "--skills-root", skills_root,
+                    "--validator", _REAL_VALIDATOR,
+                ])
+        self.assertEqual(rc, 1)
+        err = stderr.getvalue()
+        self.assertIn("malformed example capability directories", err)
+        self.assertIn("broken-cap", err)
+        self.assertIn("missing capability.md", err)
 
     def test_main_fails_fast_on_malformed_skill_dir(self) -> None:
         # A non-hidden child directory missing SKILL.md must fail the run

--- a/tests/test_validate_examples_script.py
+++ b/tests/test_validate_examples_script.py
@@ -14,9 +14,6 @@ import importlib.util
 import io
 import json
 import os
-import shutil
-import subprocess
-import sys
 import tempfile
 import textwrap
 import unittest

--- a/tests/test_validate_examples_script.py
+++ b/tests/test_validate_examples_script.py
@@ -9,7 +9,9 @@ missing JSON), ``run_validation`` (aggregates, ``all_success`` flag), and
 missing validator, missing examples, sibling roles directory ignored).
 """
 
+import contextlib
 import importlib.util
+import io
 import json
 import os
 import shutil
@@ -343,7 +345,8 @@ class MainTests(unittest.TestCase):
             _write_minimal_skill(
                 os.path.join(skills_root, "alpha"), name="alpha",
             )
-            with mock.patch.object(sys.stdout, "write"):
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
                 rc = main([
                     "--skills-root", skills_root,
                     "--validator", _REAL_VALIDATOR,
@@ -354,23 +357,27 @@ class MainTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as root:
             skills_root = os.path.join(root, "skills")
             os.makedirs(skills_root)
-            with mock.patch.object(sys.stderr, "write"):
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
                 rc = main([
                     "--skills-root", skills_root,
                     "--validator", os.path.join(root, "no-such-validator.py"),
                 ])
         self.assertEqual(rc, 1)
+        self.assertIn("validator not found", stderr.getvalue())
 
     def test_no_skills_returns_one(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             empty_root = os.path.join(root, "skills")
             os.makedirs(empty_root)
-            with mock.patch.object(sys.stderr, "write"):
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
                 rc = main([
                     "--skills-root", empty_root,
                     "--validator", _REAL_VALIDATOR,
                 ])
         self.assertEqual(rc, 1)
+        self.assertIn("no example skills found", stderr.getvalue())
 
     def test_sibling_roles_directory_is_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as root:
@@ -383,7 +390,8 @@ class MainTests(unittest.TestCase):
             )
             # A loose markdown file that would FAIL if validated as a skill.
             _write(os.path.join(roles_root, "some-role.md"), "# Role\n")
-            with mock.patch.object(sys.stdout, "write"):
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
                 rc = main([
                     "--skills-root", skills_root,
                     "--validator", _REAL_VALIDATOR,
@@ -398,7 +406,8 @@ class MainTests(unittest.TestCase):
             broken_dir = os.path.join(skills_root, "broken")
             os.makedirs(broken_dir)
             _write(os.path.join(broken_dir, "SKILL.md"), "# Broken\n")
-            with mock.patch.object(sys.stdout, "write"):
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
                 rc = main([
                     "--skills-root", skills_root,
                     "--validator", _REAL_VALIDATOR,
@@ -437,12 +446,7 @@ class MainTests(unittest.TestCase):
             _FakeCompleted(json.dumps(early_exit_payload), returncode=1),
             _FakeCompleted("not-json", returncode=2, stderr="trace"),
         ]
-        captured: list[str] = []
-
-        def _capture(text: str) -> int:
-            captured.append(text)
-            return len(text)
-
+        stdout = io.StringIO()
         with tempfile.TemporaryDirectory() as root:
             skills_root = os.path.join(root, "skills")
             for label in ("alpha", "bravo", "charlie"):
@@ -450,13 +454,13 @@ class MainTests(unittest.TestCase):
                 _write(os.path.join(skills_root, label, "SKILL.md"), "stub")
             with mock.patch.object(
                 _mod.subprocess, "run", side_effect=side_effect,
-            ), mock.patch.object(sys.stdout, "write", side_effect=_capture):
+            ), contextlib.redirect_stdout(stdout):
                 rc = main([
                     "--skills-root", skills_root,
                     "--validator", _REAL_VALIDATOR,
                 ])
 
-        out = "".join(captured)
+        out = stdout.getvalue()
         self.assertEqual(rc, 1)
         self.assertIn("WARN: drift", out)
         self.assertIn("INFO: nit", out)

--- a/tests/test_validate_examples_script.py
+++ b/tests/test_validate_examples_script.py
@@ -139,8 +139,11 @@ class DiscoverSkillDirsTests(unittest.TestCase):
 
 class _FakeCompleted:
 
-    def __init__(self, stdout: str, returncode: int = 0) -> None:
+    def __init__(
+        self, stdout: str, returncode: int = 0, stderr: str = "",
+    ) -> None:
         self.stdout = stdout
+        self.stderr = stderr
         self.returncode = returncode
 
 
@@ -154,10 +157,13 @@ class ValidateOneTests(unittest.TestCase):
         }
         fake = _FakeCompleted(json.dumps(payload), returncode=0)
         with mock.patch.object(_mod.subprocess, "run", return_value=fake):
-            success, parsed, raw = validate_one("/tmp/skill", "/tmp/v.py")
+            success, parsed, raw, stderr = validate_one(
+                "/tmp/skill", "/tmp/v.py",
+            )
         self.assertTrue(success)
         self.assertEqual(parsed["summary"]["failures"], 0)
         self.assertIn("validate_skill", raw)
+        self.assertEqual(stderr, "")
 
     def test_failure_payload_marks_unsuccessful(self) -> None:
         payload = {
@@ -168,24 +174,56 @@ class ValidateOneTests(unittest.TestCase):
         }
         fake = _FakeCompleted(json.dumps(payload), returncode=1)
         with mock.patch.object(_mod.subprocess, "run", return_value=fake):
-            success, parsed, _ = validate_one("/tmp/skill", "/tmp/v.py")
+            success, parsed, _, _ = validate_one("/tmp/skill", "/tmp/v.py")
         self.assertFalse(success)
         self.assertEqual(parsed["summary"]["failures"], 2)
 
-    def test_invalid_json_returns_none(self) -> None:
-        fake = _FakeCompleted("not-json-at-all", returncode=0)
+    def test_warnings_count_as_failure(self) -> None:
+        payload = {
+            "tool": "validate_skill",
+            "success": True,
+            "summary": {"failures": 0, "warnings": 1, "info": 0, "passes": 4},
+            "errors": {"failures": [], "warnings": ["WARN: drift"], "info": []},
+        }
+        fake = _FakeCompleted(json.dumps(payload), returncode=0)
         with mock.patch.object(_mod.subprocess, "run", return_value=fake):
-            success, parsed, raw = validate_one("/tmp/skill", "/tmp/v.py")
+            success, _, _, _ = validate_one("/tmp/skill", "/tmp/v.py")
+        self.assertFalse(success)
+
+    def test_info_findings_count_as_failure(self) -> None:
+        payload = {
+            "tool": "validate_skill",
+            "success": True,
+            "summary": {"failures": 0, "warnings": 0, "info": 1, "passes": 4},
+            "errors": {"failures": [], "warnings": [], "info": ["INFO: nit"]},
+        }
+        fake = _FakeCompleted(json.dumps(payload), returncode=0)
+        with mock.patch.object(_mod.subprocess, "run", return_value=fake):
+            success, _, _, _ = validate_one("/tmp/skill", "/tmp/v.py")
+        self.assertFalse(success)
+
+    def test_invalid_json_returns_none_and_captures_stderr(self) -> None:
+        fake = _FakeCompleted(
+            "not-json-at-all", returncode=0, stderr="boom",
+        )
+        with mock.patch.object(_mod.subprocess, "run", return_value=fake):
+            success, parsed, raw, stderr = validate_one(
+                "/tmp/skill", "/tmp/v.py",
+            )
         self.assertFalse(success)
         self.assertIsNone(parsed)
         self.assertEqual(raw, "not-json-at-all")
+        self.assertEqual(stderr, "boom")
 
     def test_empty_stdout_returns_none(self) -> None:
-        fake = _FakeCompleted("", returncode=1)
+        fake = _FakeCompleted("", returncode=1, stderr="trace")
         with mock.patch.object(_mod.subprocess, "run", return_value=fake):
-            success, parsed, _ = validate_one("/tmp/skill", "/tmp/v.py")
+            success, parsed, _, stderr = validate_one(
+                "/tmp/skill", "/tmp/v.py",
+            )
         self.assertFalse(success)
         self.assertIsNone(parsed)
+        self.assertEqual(stderr, "trace")
 
     def test_returncode_nonzero_overrides_success_flag(self) -> None:
         payload = {
@@ -195,7 +233,7 @@ class ValidateOneTests(unittest.TestCase):
         }
         fake = _FakeCompleted(json.dumps(payload), returncode=2)
         with mock.patch.object(_mod.subprocess, "run", return_value=fake):
-            success, _, _ = validate_one("/tmp/skill", "/tmp/v.py")
+            success, _, _, _ = validate_one("/tmp/skill", "/tmp/v.py")
         self.assertFalse(success)
 
 
@@ -209,11 +247,11 @@ class FormatVerdictTests(unittest.TestCase):
     def test_success_renders_check_mark(self) -> None:
         payload = {
             "success": True,
-            "summary": {"failures": 0, "warnings": 1, "info": 2},
+            "summary": {"failures": 0, "warnings": 0, "info": 0},
         }
-        line = format_verdict("/tmp/skills/alpha", payload)
+        line = format_verdict("/tmp/skills/alpha", payload, success=True)
         self.assertIn("alpha", line)
-        self.assertIn("0 fail / 1 warn / 2 info", line)
+        self.assertIn("0 fail / 0 warn / 0 info", line)
         self.assertIn("✓", line)
 
     def test_failure_renders_cross_mark(self) -> None:
@@ -221,14 +259,23 @@ class FormatVerdictTests(unittest.TestCase):
             "success": False,
             "summary": {"failures": 1, "warnings": 0, "info": 0},
         }
-        line = format_verdict("/tmp/skills/alpha", payload)
+        line = format_verdict("/tmp/skills/alpha", payload, success=False)
         self.assertIn("✗", line)
         self.assertIn("1 fail", line)
 
+    def test_warning_only_renders_cross_mark_when_success_false(self) -> None:
+        payload = {
+            "success": True,
+            "summary": {"failures": 0, "warnings": 1, "info": 0},
+        }
+        line = format_verdict("/tmp/skills/alpha", payload, success=False)
+        self.assertIn("✗", line)
+        self.assertIn("1 warn", line)
+
     def test_missing_payload_renders_explanation(self) -> None:
-        line = format_verdict("/tmp/skills/alpha", None)
+        line = format_verdict("/tmp/skills/alpha", None, success=False)
         self.assertIn("alpha", line)
-        self.assertIn("no JSON output", line)
+        self.assertIn("no valid JSON output", line)
 
 
 # ===================================================================
@@ -245,7 +292,7 @@ class RunValidationTests(unittest.TestCase):
             results, all_ok = run_validation(root, _REAL_VALIDATOR)
         self.assertTrue(all_ok)
         self.assertEqual(len(results), 2)
-        for _, success, _, _ in results:
+        for _, success, _, _, _ in results:
             self.assertTrue(success)
 
     def test_all_success_false_when_one_skill_fails(self) -> None:
@@ -338,6 +385,53 @@ class MainTests(unittest.TestCase):
                     "--validator", _REAL_VALIDATOR,
                 ])
         self.assertEqual(rc, 1)
+
+    def test_main_prints_warn_info_and_stderr_lines(self) -> None:
+        # Two skills under skills_root: one with WARN/INFO findings (the
+        # stricter predicate now treats this as failure), one whose
+        # validator emits invalid JSON to stdout and a traceback to
+        # stderr. The single fake replaces ``subprocess.run`` for both
+        # invocations and returns payloads in walk order.
+        warn_payload = {
+            "tool": "validate_skill",
+            "success": True,
+            "summary": {"failures": 0, "warnings": 1, "info": 1, "passes": 1},
+            "errors": {
+                "failures": [],
+                "warnings": ["WARN: drift"],
+                "info": ["INFO: nit"],
+            },
+        }
+        side_effect = [
+            _FakeCompleted(json.dumps(warn_payload), returncode=0),
+            _FakeCompleted("not-json", returncode=2, stderr="trace"),
+        ]
+        captured: list[str] = []
+
+        def _capture(text: str) -> int:
+            captured.append(text)
+            return len(text)
+
+        with tempfile.TemporaryDirectory() as root:
+            skills_root = os.path.join(root, "skills")
+            os.makedirs(os.path.join(skills_root, "alpha"))
+            _write(os.path.join(skills_root, "alpha", "SKILL.md"), "stub")
+            os.makedirs(os.path.join(skills_root, "bravo"))
+            _write(os.path.join(skills_root, "bravo", "SKILL.md"), "stub")
+            with mock.patch.object(
+                _mod.subprocess, "run", side_effect=side_effect,
+            ), mock.patch.object(sys.stdout, "write", side_effect=_capture):
+                rc = main([
+                    "--skills-root", skills_root,
+                    "--validator", _REAL_VALIDATOR,
+                ])
+
+        out = "".join(captured)
+        self.assertEqual(rc, 1)
+        self.assertIn("WARN: drift", out)
+        self.assertIn("INFO: nit", out)
+        self.assertIn("raw stdout: not-json", out)
+        self.assertIn("raw stderr: trace", out)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_examples_script.py
+++ b/tests/test_validate_examples_script.py
@@ -35,6 +35,7 @@ if _spec is None or _spec.loader is None:
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 discover_skill_dirs = _mod.discover_skill_dirs
+discover_capability_dirs = _mod.discover_capability_dirs
 find_malformed_skill_dirs = _mod.find_malformed_skill_dirs
 validate_one = _mod.validate_one
 format_verdict = _mod.format_verdict
@@ -132,6 +133,51 @@ class DiscoverSkillDirsTests(unittest.TestCase):
             self.assertEqual(
                 [os.path.basename(p) for p in found],
                 ["alpha", "mike", "zebra"],
+            )
+
+
+# ===================================================================
+# discover_capability_dirs
+# ===================================================================
+
+
+class DiscoverCapabilityDirsTests(unittest.TestCase):
+
+    def test_returns_capability_dirs_with_capability_md(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            cap = os.path.join(root, "capabilities", "alpha")
+            os.makedirs(cap)
+            _write(os.path.join(cap, "capability.md"), "stub")
+            other = os.path.join(root, "capabilities", "no-cap")
+            os.makedirs(other)
+            found = discover_capability_dirs(root)
+            self.assertEqual(len(found), 1)
+            self.assertTrue(found[0].endswith("alpha"))
+
+    def test_no_capabilities_subtree_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(discover_capability_dirs(root), [])
+
+    def test_skips_hidden_and_loose_files(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, "capabilities", ".hidden"))
+            _write(
+                os.path.join(root, "capabilities", ".hidden", "capability.md"),
+                "stub",
+            )
+            _write(os.path.join(root, "capabilities", "loose.md"), "stub")
+            self.assertEqual(discover_capability_dirs(root), [])
+
+    def test_results_are_sorted(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            for name in ("zulu", "alpha", "mike"):
+                cap = os.path.join(root, "capabilities", name)
+                os.makedirs(cap)
+                _write(os.path.join(cap, "capability.md"), "stub")
+            found = discover_capability_dirs(root)
+            self.assertEqual(
+                [os.path.basename(p) for p in found],
+                ["alpha", "mike", "zulu"],
             )
 
 
@@ -277,6 +323,31 @@ class ValidateOneTests(unittest.TestCase):
             success, _, _, _ = validate_one("/tmp/skill", "/tmp/v.py")
         self.assertFalse(success)
 
+    def test_capability_flag_is_passed_to_subprocess(self) -> None:
+        # When capability=True the helper must add ``--capability`` so the
+        # validator looks for capability.md instead of SKILL.md.
+        captured: dict[str, list[str]] = {}
+
+        def _fake_run(cmd: list[str], **kwargs: object) -> _FakeCompleted:
+            captured["cmd"] = list(cmd)
+            payload = {
+                "tool": "validate_skill",
+                "success": True,
+                "summary": {"failures": 0, "warnings": 0, "info": 0, "passes": 1},
+            }
+            return _FakeCompleted(json.dumps(payload), returncode=0)
+
+        with mock.patch.object(_mod.subprocess, "run", side_effect=_fake_run):
+            success, _, _, _ = validate_one(
+                "/tmp/cap", "/tmp/v.py", capability=True,
+            )
+        self.assertTrue(success)
+        self.assertIn("--capability", captured["cmd"])
+        # Skill mode (default) must not include the flag.
+        with mock.patch.object(_mod.subprocess, "run", side_effect=_fake_run):
+            validate_one("/tmp/skill", "/tmp/v.py")
+        self.assertNotIn("--capability", captured["cmd"])
+
 
 # ===================================================================
 # format_verdict
@@ -318,6 +389,21 @@ class FormatVerdictTests(unittest.TestCase):
         self.assertIn("alpha", line)
         self.assertIn("no valid JSON output", line)
 
+    def test_capability_kind_renders_with_indent_and_prefix(self) -> None:
+        payload = {
+            "success": True,
+            "summary": {"failures": 0, "warnings": 0, "info": 0},
+        }
+        line = format_verdict(
+            "/tmp/skills/router/capabilities/do-thing",
+            payload,
+            success=True,
+            kind="capability",
+        )
+        self.assertIn("└─", line)
+        self.assertIn("capabilities/do-thing", line)
+        self.assertTrue(line.startswith("    "))
+
     def test_top_level_error_field_surfaces_in_verdict(self) -> None:
         # Early-exit JSON payloads from validate_skill.py omit the
         # ``summary`` object and emit a top-level ``error`` instead. The
@@ -349,7 +435,8 @@ class RunValidationTests(unittest.TestCase):
             results, all_ok = run_validation(root, _REAL_VALIDATOR)
         self.assertTrue(all_ok)
         self.assertEqual(len(results), 2)
-        for _, success, _, _, _ in results:
+        for _, kind, success, _, _, _ in results:
+            self.assertEqual(kind, "skill")
             self.assertTrue(success)
 
     def test_all_success_false_when_one_skill_fails(self) -> None:
@@ -362,9 +449,87 @@ class RunValidationTests(unittest.TestCase):
             results, all_ok = run_validation(root, _REAL_VALIDATOR)
         self.assertFalse(all_ok)
         self.assertEqual(len(results), 2)
-        labels = {os.path.basename(r[0]): r[1] for r in results}
+        labels = {os.path.basename(r[0]): r[2] for r in results}
         self.assertTrue(labels["alpha"])
         self.assertFalse(labels["broken"])
+
+    def test_router_capabilities_are_validated(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            router_dir = os.path.join(root, "router")
+            _write_minimal_skill(router_dir, name="router")
+            cap_dir = os.path.join(router_dir, "capabilities", "do-thing")
+            os.makedirs(cap_dir)
+            _write(
+                os.path.join(cap_dir, "capability.md"),
+                textwrap.dedent(
+                    """\
+                    ---
+                    description: >
+                      Renders one greeting line. Use when a friendly
+                      greeting is requested with a recipient name.
+                    ---
+                    # Do Thing
+
+                    ## Purpose
+
+                    Test capability fixture.
+
+                    ## Instructions
+
+                    1. Emit a greeting.
+                    """,
+                ),
+            )
+            results, all_ok = run_validation(root, _REAL_VALIDATOR)
+        self.assertTrue(all_ok)
+        self.assertEqual(len(results), 2)
+        kinds = [r[1] for r in results]
+        self.assertEqual(kinds, ["skill", "capability"])
+        # Capability row immediately follows its parent skill.
+        self.assertTrue(results[0][0].endswith("router"))
+        self.assertTrue(results[1][0].endswith("do-thing"))
+
+    def test_broken_capability_fails_aggregate(self) -> None:
+        # Use a mocked validator: capability validation is lenient about
+        # missing frontmatter (it's optional), so the deterministic way
+        # to exercise the aggregate-fail-on-capability path is to inject
+        # a failing JSON payload for the capability call only.
+        skill_payload = {
+            "tool": "validate_skill",
+            "success": True,
+            "summary": {"failures": 0, "warnings": 0, "info": 0, "passes": 5},
+        }
+        cap_payload = {
+            "tool": "validate_skill",
+            "success": False,
+            "summary": {"failures": 1, "warnings": 0, "info": 0, "passes": 0},
+            "errors": {
+                "failures": ["body exceeds line cap"],
+                "warnings": [],
+                "info": [],
+            },
+        }
+        side_effect = [
+            _FakeCompleted(json.dumps(skill_payload), returncode=0),
+            _FakeCompleted(json.dumps(cap_payload), returncode=1),
+        ]
+        with tempfile.TemporaryDirectory() as root:
+            router_dir = os.path.join(root, "router")
+            os.makedirs(router_dir)
+            _write(os.path.join(router_dir, "SKILL.md"), "stub")
+            cap_dir = os.path.join(router_dir, "capabilities", "broken")
+            os.makedirs(cap_dir)
+            _write(os.path.join(cap_dir, "capability.md"), "stub")
+            with mock.patch.object(
+                _mod.subprocess, "run", side_effect=side_effect,
+            ):
+                results, all_ok = run_validation(root, _REAL_VALIDATOR)
+        self.assertFalse(all_ok)
+        self.assertEqual(len(results), 2)
+        skill_row = next(r for r in results if r[1] == "skill")
+        cap_row = next(r for r in results if r[1] == "capability")
+        self.assertTrue(skill_row[2])
+        self.assertFalse(cap_row[2])
 
 
 # ===================================================================

--- a/tests/test_validate_examples_script.py
+++ b/tests/test_validate_examples_script.py
@@ -170,7 +170,7 @@ class ValidateOneTests(unittest.TestCase):
             "tool": "validate_skill",
             "success": False,
             "summary": {"failures": 2, "warnings": 0, "info": 0, "passes": 3},
-            "errors": {"failures": ["FAIL: bad thing"], "warnings": [], "info": []},
+            "errors": {"failures": ["bad thing"], "warnings": [], "info": []},
         }
         fake = _FakeCompleted(json.dumps(payload), returncode=1)
         with mock.patch.object(_mod.subprocess, "run", return_value=fake):
@@ -179,11 +179,14 @@ class ValidateOneTests(unittest.TestCase):
         self.assertEqual(parsed["summary"]["failures"], 2)
 
     def test_warnings_count_as_failure(self) -> None:
+        # ``errors.warnings`` entries are stored prefix-free in the real
+        # validator's --json output; the helper's main() loop is what
+        # prepends the ``WARN: `` label.
         payload = {
             "tool": "validate_skill",
             "success": True,
             "summary": {"failures": 0, "warnings": 1, "info": 0, "passes": 4},
-            "errors": {"failures": [], "warnings": ["WARN: drift"], "info": []},
+            "errors": {"failures": [], "warnings": ["drift"], "info": []},
         }
         fake = _FakeCompleted(json.dumps(payload), returncode=0)
         with mock.patch.object(_mod.subprocess, "run", return_value=fake):
@@ -195,7 +198,7 @@ class ValidateOneTests(unittest.TestCase):
             "tool": "validate_skill",
             "success": True,
             "summary": {"failures": 0, "warnings": 0, "info": 1, "passes": 4},
-            "errors": {"failures": [], "warnings": [], "info": ["INFO: nit"]},
+            "errors": {"failures": [], "warnings": [], "info": ["nit"]},
         }
         fake = _FakeCompleted(json.dumps(payload), returncode=0)
         with mock.patch.object(_mod.subprocess, "run", return_value=fake):
@@ -276,6 +279,22 @@ class FormatVerdictTests(unittest.TestCase):
         line = format_verdict("/tmp/skills/alpha", None, success=False)
         self.assertIn("alpha", line)
         self.assertIn("no valid JSON output", line)
+
+    def test_top_level_error_field_surfaces_in_verdict(self) -> None:
+        # Early-exit JSON payloads from validate_skill.py omit the
+        # ``summary`` object and emit a top-level ``error`` instead. The
+        # verdict must surface that message rather than print misleading
+        # zero counts.
+        payload = {
+            "tool": "validate_skill",
+            "success": False,
+            "error": "'/no/such' is not a directory",
+        }
+        line = format_verdict("/tmp/skills/alpha", payload, success=False)
+        self.assertIn("✗", line)
+        self.assertIn("validator error:", line)
+        self.assertIn("not a directory", line)
+        self.assertNotIn("0 fail", line)
 
 
 # ===================================================================
@@ -387,23 +406,35 @@ class MainTests(unittest.TestCase):
         self.assertEqual(rc, 1)
 
     def test_main_prints_warn_info_and_stderr_lines(self) -> None:
-        # Two skills under skills_root: one with WARN/INFO findings (the
-        # stricter predicate now treats this as failure), one whose
-        # validator emits invalid JSON to stdout and a traceback to
-        # stderr. The single fake replaces ``subprocess.run`` for both
-        # invocations and returns payloads in walk order.
+        # Three skills under skills_root, exercising every diagnostic
+        # branch in main():
+        #   * alpha — clean payload but non-zero return code, plus
+        #     non-empty stderr; helper must print the stderr even though
+        #     stdout was valid JSON.
+        #   * bravo — top-level ``error`` field on an early-exit payload.
+        #   * charlie — invalid JSON on stdout and a traceback on stderr.
+        # Fixture strings for ``errors.*`` are prefix-free, matching the
+        # real validator's --json schema.
         warn_payload = {
             "tool": "validate_skill",
             "success": True,
             "summary": {"failures": 0, "warnings": 1, "info": 1, "passes": 1},
             "errors": {
                 "failures": [],
-                "warnings": ["WARN: drift"],
-                "info": ["INFO: nit"],
+                "warnings": ["drift"],
+                "info": ["nit"],
             },
         }
+        early_exit_payload = {
+            "tool": "validate_skill",
+            "success": False,
+            "error": "'/no/such' is not a directory",
+        }
         side_effect = [
-            _FakeCompleted(json.dumps(warn_payload), returncode=0),
+            _FakeCompleted(
+                json.dumps(warn_payload), returncode=2, stderr="env-warn",
+            ),
+            _FakeCompleted(json.dumps(early_exit_payload), returncode=1),
             _FakeCompleted("not-json", returncode=2, stderr="trace"),
         ]
         captured: list[str] = []
@@ -414,10 +445,9 @@ class MainTests(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as root:
             skills_root = os.path.join(root, "skills")
-            os.makedirs(os.path.join(skills_root, "alpha"))
-            _write(os.path.join(skills_root, "alpha", "SKILL.md"), "stub")
-            os.makedirs(os.path.join(skills_root, "bravo"))
-            _write(os.path.join(skills_root, "bravo", "SKILL.md"), "stub")
+            for label in ("alpha", "bravo", "charlie"):
+                os.makedirs(os.path.join(skills_root, label))
+                _write(os.path.join(skills_root, label, "SKILL.md"), "stub")
             with mock.patch.object(
                 _mod.subprocess, "run", side_effect=side_effect,
             ), mock.patch.object(sys.stdout, "write", side_effect=_capture):
@@ -430,6 +460,9 @@ class MainTests(unittest.TestCase):
         self.assertEqual(rc, 1)
         self.assertIn("WARN: drift", out)
         self.assertIn("INFO: nit", out)
+        self.assertIn("raw stderr: env-warn", out)
+        self.assertIn("validator error:", out)
+        self.assertIn("not a directory", out)
         self.assertIn("raw stdout: not-json", out)
         self.assertIn("raw stderr: trace", out)
 

--- a/tests/test_validate_examples_script.py
+++ b/tests/test_validate_examples_script.py
@@ -35,6 +35,7 @@ if _spec is None or _spec.loader is None:
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 discover_skill_dirs = _mod.discover_skill_dirs
+find_malformed_skill_dirs = _mod.find_malformed_skill_dirs
 validate_one = _mod.validate_one
 format_verdict = _mod.format_verdict
 run_validation = _mod.run_validation
@@ -132,6 +133,41 @@ class DiscoverSkillDirsTests(unittest.TestCase):
                 [os.path.basename(p) for p in found],
                 ["alpha", "mike", "zebra"],
             )
+
+
+# ===================================================================
+# find_malformed_skill_dirs
+# ===================================================================
+
+
+class FindMalformedSkillDirsTests(unittest.TestCase):
+
+    def test_returns_directories_missing_skill_md(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, "with-skill"))
+            _write(os.path.join(root, "with-skill", "SKILL.md"), "stub")
+            os.makedirs(os.path.join(root, "broken"))
+            malformed = find_malformed_skill_dirs(root)
+            self.assertEqual(len(malformed), 1)
+            self.assertTrue(malformed[0].endswith("broken"))
+
+    def test_skips_hidden_and_loose_files(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, ".hidden"))
+            _write(os.path.join(root, "loose.txt"), "stub")
+            self.assertEqual(find_malformed_skill_dirs(root), [])
+
+    def test_missing_root_returns_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            missing = os.path.join(root, "does-not-exist")
+            self.assertEqual(find_malformed_skill_dirs(missing), [])
+
+    def test_returns_empty_when_every_child_has_skill_md(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            for name in ("alpha", "bravo"):
+                os.makedirs(os.path.join(root, name))
+                _write(os.path.join(root, name, "SKILL.md"), "stub")
+            self.assertEqual(find_malformed_skill_dirs(root), [])
 
 
 # ===================================================================
@@ -413,6 +449,31 @@ class MainTests(unittest.TestCase):
                     "--validator", _REAL_VALIDATOR,
                 ])
         self.assertEqual(rc, 1)
+
+    def test_main_fails_fast_on_malformed_skill_dir(self) -> None:
+        # A non-hidden child directory missing SKILL.md must fail the run
+        # rather than silently disappear from CI's view. A real example
+        # alongside it must not rescue the build.
+        with tempfile.TemporaryDirectory() as root:
+            skills_root = os.path.join(root, "skills")
+            os.makedirs(skills_root)
+            _write_minimal_skill(
+                os.path.join(skills_root, "alpha"), name="alpha",
+            )
+            os.makedirs(os.path.join(skills_root, "broken-no-skill-md"))
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with contextlib.redirect_stdout(stdout), \
+                 contextlib.redirect_stderr(stderr):
+                rc = main([
+                    "--skills-root", skills_root,
+                    "--validator", _REAL_VALIDATOR,
+                ])
+        self.assertEqual(rc, 1)
+        err = stderr.getvalue()
+        self.assertIn("malformed example skill directories", err)
+        self.assertIn("broken-no-skill-md", err)
+        self.assertIn("missing SKILL.md", err)
 
     def test_main_prints_warn_info_and_stderr_lines(self) -> None:
         # Three skills under skills_root, exercising every diagnostic


### PR DESCRIPTION
## Summary

Closes #96. Adds a top-level `examples/` directory with three reference skills demonstrating the standalone, router, and role patterns the Skill System Foundry supports. Each skill example validates clean under `validate_skill.py`, and a new CI job runs that validation on ubuntu and windows for every push and pull request.

The directory is laid out as a self-contained mini system root (`examples/skills/`, `examples/roles/`) so the role example can use canonical system-root-relative paths to compose the two skill examples. This is a deliberate deviation from issue #96's literal AC #1 wording (three sibling directories) — the rationale is that the canonical layout is what the audit, bundle, and orchestration tools actually recognise, so the examples teach the right paths from the first read.

`release.yml` zips only `skill-system-foundry/`, so nothing in `examples/` reaches the distributed bundle.

## What's included

- `examples/skills/hello-greeter/SKILL.md` — smallest valid standalone skill, no `allowed-tools`.
- `examples/skills/hello-router/SKILL.md` plus `capabilities/greet-formal/capability.md` and `capabilities/greet-casual/capability.md` — router pattern with `allowed-tools: Bash` and one bash fence so tool-coherence stays satisfied.
- `examples/roles/hello-orchestrator.md` — role contract composing the two skills with the canonical responsibility / allowed / forbidden / handoff / "Skills Used" structure. Paths in "Skills Used" use `skills/<domain>/SKILL.md` form.
- `examples/README.md` — landing doc explaining what each example demonstrates.
- `.github/scripts/validate-examples.py` — stdlib-only CI helper that walks `examples/skills/*` and runs `validate_skill.py --json` against each. 98% branch coverage.
- `tests/test_validate_examples_script.py` — 19 unit tests covering discovery, subprocess invocation, verdict formatting, aggregate run, and main integration paths.
- `validate-examples` job in `.github/workflows/python-tests.yaml` — same matrix as the existing `test` job (ubuntu-latest + windows-latest, Python 3.12), runs in parallel, no coverage entanglement.
- "Reference examples" section in the root `README.md` linking the three examples.

## Acceptance criteria

- [x] `examples/skills/hello-greeter/`, `examples/skills/hello-router/`, `examples/roles/hello-orchestrator.md` exist (revised layout — see Summary).
- [x] Each skill example passes `validate_skill.py` with no FAIL, WARN, or INFO findings.
- [x] The role example references the standalone and router examples in its "Skills Used" table.
- [x] A CI job validates every example on ubuntu + windows.
- [x] README gains a "Reference examples" section linking the three.

## Out of scope (will be filed as follow-ups)

- A dedicated role validator (frontmatter policy, required sections, "Skills Used" parsing, no-self-reference, ref resolution, line-count). Today the role example is reviewed manually only.
- CHANGELOG entry and version bump — those land in a separate release-prep PR per repository convention.

## Test plan

- [x] `python -m coverage run -m unittest discover -s tests -p "test_*.py" -v` — 1992 tests pass.
- [x] `python -m coverage report` — total 96%, new helper script at 98%.
- [x] `python skill-system-foundry/scripts/validate_skill.py examples/skills/hello-greeter` — clean.
- [x] `python skill-system-foundry/scripts/validate_skill.py examples/skills/hello-router` — clean.
- [x] Both router capabilities validated with `--capability` — clean.
- [x] `python .github/scripts/validate-examples.py` — clean.
- [x] `cd skill-system-foundry && python scripts/audit_skill_system.py . --foundry-self` — clean.
- [x] CI passes on ubuntu and windows (verifies on push).