### PR TITLE
Add description trigger-phrase heuristic to validate_skill and audit_skill_system

### DIFF
--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -82,6 +82,7 @@ from lib.constants import (
 )
 from lib.prose_yaml import collect_prose_findings, format_finding_as_string
 from lib.router_table import audit_router_table
+from lib.validation import validate_description_triggers
 
 
 def _read_plugin_json(path: str) -> tuple[dict | None, str | None]:
@@ -440,10 +441,18 @@ def audit_skill_system(
             errors.append(
                 f"{LEVEL_FAIL}: {skill['name']}/{FILE_SKILL_MD} missing 'description' field"
             )
-        elif len(str(fm["description"])) > MAX_DESCRIPTION_CHARS:
-            errors.append(
-                f"{LEVEL_FAIL}: {skill['name']}/{FILE_SKILL_MD} description exceeds {MAX_DESCRIPTION_CHARS} chars"
-            )
+        else:
+            description = str(fm["description"])
+            if len(description) > MAX_DESCRIPTION_CHARS:
+                errors.append(
+                    f"{LEVEL_FAIL}: {skill['name']}/{FILE_SKILL_MD} description exceeds {MAX_DESCRIPTION_CHARS} chars"
+                )
+            trigger_errors, _ = validate_description_triggers(description)
+            for trigger_error in trigger_errors:
+                level, _, detail = trigger_error.partition(": ")
+                errors.append(
+                    f"{level}: {skill['name']}/{FILE_SKILL_MD} {detail}"
+                )
 
         body_lines = count_body_lines(body)
         if body_lines > MAX_BODY_LINES:

--- a/skill-system-foundry/scripts/audit_skill_system.py
+++ b/skill-system-foundry/scripts/audit_skill_system.py
@@ -443,16 +443,27 @@ def audit_skill_system(
             )
         else:
             description = str(fm["description"])
-            if len(description) > MAX_DESCRIPTION_CHARS:
+            if not description.strip():
+                # Empty / whitespace-only descriptions are spec
+                # violations (the spec mandates non-empty).  Without
+                # this branch the per-skill audit treats blank values
+                # as silently valid because the trigger heuristic
+                # short-circuits on whitespace and the length check
+                # passes a zero-length string.
                 errors.append(
-                    f"{LEVEL_FAIL}: {skill['name']}/{FILE_SKILL_MD} description exceeds {MAX_DESCRIPTION_CHARS} chars"
+                    f"{LEVEL_FAIL}: {skill['name']}/{FILE_SKILL_MD} 'description' field is empty"
                 )
-            trigger_errors, _ = validate_description_triggers(description)
-            for trigger_error in trigger_errors:
-                level, _, detail = trigger_error.partition(": ")
-                errors.append(
-                    f"{level}: {skill['name']}/{FILE_SKILL_MD} {detail}"
-                )
+            else:
+                if len(description) > MAX_DESCRIPTION_CHARS:
+                    errors.append(
+                        f"{LEVEL_FAIL}: {skill['name']}/{FILE_SKILL_MD} description exceeds {MAX_DESCRIPTION_CHARS} chars"
+                    )
+                trigger_errors, _ = validate_description_triggers(description)
+                for trigger_error in trigger_errors:
+                    level, _, detail = trigger_error.partition(": ")
+                    errors.append(
+                        f"{level}: {skill['name']}/{FILE_SKILL_MD} {detail}"
+                    )
 
         body_lines = count_body_lines(body)
         if body_lines > MAX_BODY_LINES:

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -27,13 +27,19 @@ skill:
     # cannot enumerate every valid wording — so the rule emits WARN,
     # not FAIL.  Extend the list via PR when a legitimate pattern is
     # missed.
+    #
+    # Match semantics: case-insensitive substring on the lowered,
+    # folded description.  Phrases match anywhere — including inside
+    # longer words ("activates when" matches "activates whenever").
+    # Avoid phrases short or generic enough to collide with incidental
+    # prose ("use for" matched "use forensic" / "use for example",
+    # which is why it is not in the starter set).
     trigger_phrases:
       - triggers on
       - triggers when
       - activates on
       - activates when
       - use when
-      - use for
       - when to use
       - invoked on
       - invoked when

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -19,6 +19,24 @@ skill:
   description:
     max_length: 1024
     xml_tag_pattern: <[^>]+>
+    # Heuristic phrase list for the trigger-clause check.  The
+    # agentskills.io spec requires descriptions to state both *what* the
+    # skill does and *when* it activates; this list enforces the
+    # "when" half by case-insensitive substring match against the
+    # folded description.  Detection is heuristic — phrase matching
+    # cannot enumerate every valid wording — so the rule emits WARN,
+    # not FAIL.  Extend the list via PR when a legitimate pattern is
+    # missed.
+    trigger_phrases:
+      - triggers on
+      - triggers when
+      - activates on
+      - activates when
+      - use when
+      - use for
+      - when to use
+      - invoked on
+      - invoked when
     voice_patterns:
       first_person: (?i)\b(I can|I will|I help|I am)\b
       first_person_plural: (?i)\b(we can|we will|we help|our tool|our skill)\b

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -170,6 +170,30 @@ RE_FIRST_PERSON_PLURAL = re.compile(_voice["first_person_plural"])
 RE_SECOND_PERSON = re.compile(_voice["second_person"])
 RE_IMPERATIVE_START = re.compile(_voice["imperative_start"])
 
+# Trigger-phrase heuristic: the agentskills.io spec requires
+# descriptions to state both *what* the skill does and *when* it
+# activates.  validate_description_triggers enforces the "when"
+# half by checking that the folded, lowercased description contains
+# at least one phrase from this list.  Stored as a frozenset of
+# lowercased strings to mirror RESERVED_NAMES / KNOWN_FRONTMATTER_KEYS
+# — the structure is a configured policy, not mutable state.
+if "trigger_phrases" not in _skill_desc:
+    raise RuntimeError(
+        "configuration.yaml is missing required section "
+        "'skill.description.trigger_phrases'; update your checkout "
+        "or restore the full configuration file."
+    )
+_raw_trigger_phrases = _skill_desc["trigger_phrases"]
+if not isinstance(_raw_trigger_phrases, list) or not _raw_trigger_phrases:
+    raise RuntimeError(
+        "configuration.yaml has invalid value for "
+        "'skill.description.trigger_phrases': expected a non-empty "
+        f"list, got {_raw_trigger_phrases!r}."
+    )
+DESCRIPTION_TRIGGER_PHRASES = frozenset(
+    str(phrase).lower() for phrase in _raw_trigger_phrases
+)
+
 # Skill body constraints
 _skill_body = _skill["body"]
 MAX_BODY_LINES = int(_skill_body["max_lines"])

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -207,14 +207,34 @@ for _phrase in _raw_trigger_phrases:
         )
     if _candidate in _seen_trigger_phrases:
         raise RuntimeError(
-            "configuration.yaml has a duplicate entry "
-            f"'{_candidate}' in 'skill.description.trigger_phrases'; "
-            "remove the redundant entry — duplicates indicate a config "
-            "edit accident."
+            f"configuration.yaml has a duplicate entry '{_phrase}' "
+            f"(normalized: '{_candidate}') in "
+            "'skill.description.trigger_phrases'; remove the redundant "
+            "entry — duplicates indicate a config edit accident."
         )
     _seen_trigger_phrases.add(_candidate)
     _normalized_trigger_phrases.append(_candidate)
 DESCRIPTION_TRIGGER_PHRASES = tuple(sorted(_normalized_trigger_phrases))
+
+# Curated subset used as illustrative examples in the WARN message.
+# Selected by first-word-distinct dedup over the sorted phrase tuple
+# so the user-facing examples cover different root verbs (e.g.
+# "activates on", "invoked on", "triggers on") rather than two
+# variants of the same root ("activates on", "activates when").  Up
+# to three entries — the helper that renders the WARN does not need
+# more, and capping here keeps the message concise.  Deterministic
+# across processes because the input is already a sorted tuple.
+_example_seen_first_words: set[str] = set()
+_example_phrases_buffer: list[str] = []
+for _phrase in DESCRIPTION_TRIGGER_PHRASES:
+    _first_word = _phrase.split(" ", 1)[0]
+    if _first_word in _example_seen_first_words:
+        continue
+    _example_seen_first_words.add(_first_word)
+    _example_phrases_buffer.append(_phrase)
+    if len(_example_phrases_buffer) >= 3:
+        break
+DESCRIPTION_TRIGGER_EXAMPLE_PHRASES = tuple(_example_phrases_buffer)
 
 # Skill body constraints
 _skill_body = _skill["body"]

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -195,6 +195,7 @@ if not isinstance(_raw_trigger_phrases, list) or not _raw_trigger_phrases:
         f"list, got {_raw_trigger_phrases!r}."
     )
 _normalized_trigger_phrases: list[str] = []
+_seen_trigger_phrases: set[str] = set()
 for _phrase in _raw_trigger_phrases:
     _candidate = str(_phrase).strip().lower()
     if not _candidate:
@@ -204,8 +205,16 @@ for _phrase in _raw_trigger_phrases:
             "or replace it with a real phrase — empty entries silently "
             "disable the rule."
         )
+    if _candidate in _seen_trigger_phrases:
+        raise RuntimeError(
+            "configuration.yaml has a duplicate entry "
+            f"'{_candidate}' in 'skill.description.trigger_phrases'; "
+            "remove the redundant entry — duplicates indicate a config "
+            "edit accident."
+        )
+    _seen_trigger_phrases.add(_candidate)
     _normalized_trigger_phrases.append(_candidate)
-DESCRIPTION_TRIGGER_PHRASES = tuple(sorted(set(_normalized_trigger_phrases)))
+DESCRIPTION_TRIGGER_PHRASES = tuple(sorted(_normalized_trigger_phrases))
 
 # Skill body constraints
 _skill_body = _skill["body"]

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -174,9 +174,13 @@ RE_IMPERATIVE_START = re.compile(_voice["imperative_start"])
 # descriptions to state both *what* the skill does and *when* it
 # activates.  validate_description_triggers enforces the "when"
 # half by checking that the folded, lowercased description contains
-# at least one phrase from this list.  Stored as a frozenset of
-# lowercased strings to mirror RESERVED_NAMES / KNOWN_FRONTMATTER_KEYS
-# — the structure is a configured policy, not mutable state.
+# at least one phrase from this list.  Stored as a sorted tuple of
+# lowercased strings — order is deterministic across processes so
+# --verbose output naming the matched phrase is reproducible, and
+# the structure signals "configured policy, do not mutate" the same
+# way RESERVED_NAMES does.  Empty / whitespace-only entries are
+# rejected at load time: a substring match against an empty string
+# always succeeds, which would silently neuter the rule.
 if "trigger_phrases" not in _skill_desc:
     raise RuntimeError(
         "configuration.yaml is missing required section "
@@ -190,9 +194,18 @@ if not isinstance(_raw_trigger_phrases, list) or not _raw_trigger_phrases:
         "'skill.description.trigger_phrases': expected a non-empty "
         f"list, got {_raw_trigger_phrases!r}."
     )
-DESCRIPTION_TRIGGER_PHRASES = frozenset(
-    str(phrase).lower() for phrase in _raw_trigger_phrases
-)
+_normalized_trigger_phrases: list[str] = []
+for _phrase in _raw_trigger_phrases:
+    _candidate = str(_phrase).strip().lower()
+    if not _candidate:
+        raise RuntimeError(
+            "configuration.yaml has an empty / whitespace-only entry "
+            "in 'skill.description.trigger_phrases'; remove the entry "
+            "or replace it with a real phrase — empty entries silently "
+            "disable the rule."
+        )
+    _normalized_trigger_phrases.append(_candidate)
+DESCRIPTION_TRIGGER_PHRASES = tuple(sorted(set(_normalized_trigger_phrases)))
 
 # Skill body constraints
 _skill_body = _skill["body"]

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -114,12 +114,14 @@ def validate_description_triggers(
     ``skill.description.trigger_phrases`` in ``configuration.yaml``).
 
     Detection is heuristic — phrase matching cannot enumerate every
-    valid wording — so the rule emits WARN, not FAIL.  Empty / blank
-    inputs short-circuit silently because the existing length /
-    presence checks already produce a FAIL for those cases; the
-    helper is invoked only after the description is known to be
-    non-empty in every call site, but the guard is kept so the helper
-    is safe to call directly.
+    valid wording — so the rule emits WARN, not FAIL.  Empty /
+    whitespace-only inputs short-circuit silently: the spec-required
+    non-empty FAIL is owned by the caller (``validate_description``
+    in ``validate_skill.py`` and the per-skill block in
+    ``audit_skill_system.py``), and stacking a trigger WARN on top
+    of that FAIL would be redundant.  The guard is kept so direct
+    API callers (e.g. ad-hoc scripts) can invoke the helper without
+    a separate non-empty check of their own.
 
     Returns ``(errors, passes)`` per the standard validator contract.
     """

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -137,11 +137,19 @@ def validate_description_triggers(
             )
             return errors, passes
 
+    # Build the example list from the configured phrases so the message
+    # never drifts from the YAML — first three phrases (sorted at load
+    # time) are illustrative; the YAML pointer remains the canonical
+    # source.
+    example_phrases = ", ".join(
+        f"'{phrase.capitalize()} ...'"
+        for phrase in DESCRIPTION_TRIGGER_PHRASES[:3]
+    )
     errors.append(
         f"{LEVEL_WARN}: [spec] 'description' does not state when the skill "
-        "activates — add a trigger clause (e.g. 'Triggers when ...', "
-        "'Activates on ...', 'Use when ...').  Phrase list configured "
-        "under skill.description.trigger_phrases in configuration.yaml."
+        f"activates — add a trigger clause (e.g. {example_phrases}).  "
+        "Phrase list configured under skill.description.trigger_phrases "
+        "in configuration.yaml."
     )
     return errors, passes
 

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -14,6 +14,7 @@ from .constants import (
     FRONTMATTER_SUGGEST_MAX_MATCHES, FRONTMATTER_SUGGEST_CUTOFF,
     RE_MCP_TOOL_NAME, RE_HARNESS_TOOL_SHAPE,
     TOOL_FENCE_LANGUAGES, TOOLS_INDICATING_SCRIPTS,
+    DESCRIPTION_TRIGGER_PHRASES,
     DIR_CAPABILITIES, DIR_SCRIPTS,
     FILE_CAPABILITY_MD, FILE_SKILL_MD,
     LEVEL_FAIL, LEVEL_WARN, LEVEL_INFO,
@@ -99,6 +100,50 @@ def _is_explicit_empty_allowed_tools(value: object) -> bool:
     if isinstance(value, str):
         return not value.strip()
     return False
+
+
+def validate_description_triggers(
+    description: str,
+) -> tuple[list[str], list[str]]:
+    """Check that the description contains at least one trigger phrase.
+
+    The agentskills.io specification requires descriptions to state
+    both *what* the skill does and *when* it activates.  This rule
+    enforces the "when" half by case-insensitive substring matching
+    against ``DESCRIPTION_TRIGGER_PHRASES`` (configured under
+    ``skill.description.trigger_phrases`` in ``configuration.yaml``).
+
+    Detection is heuristic — phrase matching cannot enumerate every
+    valid wording — so the rule emits WARN, not FAIL.  Empty / blank
+    inputs short-circuit silently because the existing length /
+    presence checks already produce a FAIL for those cases; the
+    helper is invoked only after the description is known to be
+    non-empty in every call site, but the guard is kept so the helper
+    is safe to call directly.
+
+    Returns ``(errors, passes)`` per the standard validator contract.
+    """
+    errors: list[str] = []
+    passes: list[str] = []
+
+    if not description or not description.strip():
+        return errors, passes
+
+    lowered = description.lower()
+    for phrase in DESCRIPTION_TRIGGER_PHRASES:
+        if phrase in lowered:
+            passes.append(
+                f"description: contains trigger phrase '{phrase}'"
+            )
+            return errors, passes
+
+    errors.append(
+        f"{LEVEL_WARN}: [spec] 'description' does not state when the skill "
+        "activates — add a trigger clause (e.g. 'Triggers when ...', "
+        "'Activates on ...', 'Use when ...').  Phrase list configured "
+        "under skill.description.trigger_phrases in configuration.yaml."
+    )
+    return errors, passes
 
 
 def validate_name(name: str, dir_name: str) -> tuple[list[str], list[str]]:

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -14,7 +14,7 @@ from .constants import (
     FRONTMATTER_SUGGEST_MAX_MATCHES, FRONTMATTER_SUGGEST_CUTOFF,
     RE_MCP_TOOL_NAME, RE_HARNESS_TOOL_SHAPE,
     TOOL_FENCE_LANGUAGES, TOOLS_INDICATING_SCRIPTS,
-    DESCRIPTION_TRIGGER_PHRASES,
+    DESCRIPTION_TRIGGER_PHRASES, DESCRIPTION_TRIGGER_EXAMPLE_PHRASES,
     DIR_CAPABILITIES, DIR_SCRIPTS,
     FILE_CAPABILITY_MD, FILE_SKILL_MD,
     LEVEL_FAIL, LEVEL_WARN, LEVEL_INFO,
@@ -137,13 +137,13 @@ def validate_description_triggers(
             )
             return errors, passes
 
-    # Build the example list from the configured phrases so the message
-    # never drifts from the YAML — first three phrases (sorted at load
-    # time) are illustrative; the YAML pointer remains the canonical
-    # source.
+    # Build the example list from the curated example subset so the
+    # message never drifts from the YAML.  Examples are first-word
+    # distinct (different root verbs) for educational variety; the
+    # YAML pointer remains the canonical source for the full list.
     example_phrases = ", ".join(
         f"'{phrase.capitalize()} ...'"
-        for phrase in DESCRIPTION_TRIGGER_PHRASES[:3]
+        for phrase in DESCRIPTION_TRIGGER_EXAMPLE_PHRASES
     )
     errors.append(
         f"{LEVEL_WARN}: [spec] 'description' does not state when the skill "

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -81,7 +81,7 @@ def validate_description(description: str) -> tuple[list[str], list[str]]:
     errors: list[str] = []
     passes: list[str] = []
 
-    if not description:
+    if not description or not description.strip():
         errors.append(f"{LEVEL_FAIL}: [spec] 'description' field is empty")
         return errors, passes
 

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -32,6 +32,7 @@ from lib.reporting import (
 from lib.validation import (
     validate_name,
     validate_allowed_tools,
+    validate_description_triggers,
     validate_metadata,
     validate_license,
     validate_known_keys,
@@ -128,6 +129,10 @@ def validate_description(description: str) -> tuple[list[str], list[str]]:
         )
     else:
         passes.append("description: third-person voice")
+
+    trigger_errors, trigger_passes = validate_description_triggers(description)
+    errors.extend(trigger_errors)
+    passes.extend(trigger_passes)
 
     return errors, passes
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,9 @@
 import os
 
 
-DEFAULT_DESCRIPTION = "Packages a minimal demo skill for bundling smoke tests."
+DEFAULT_DESCRIPTION = (
+    "Packages a minimal demo skill. Use when running bundling smoke tests."
+)
 
 
 def write_text(path: str, content: str) -> None:

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -379,6 +379,29 @@ class AuditSpecComplianceTests(unittest.TestCase):
         self.assertEqual(len(trigger_warns), 1)
         self.assertIn("[spec]", trigger_warns[0])
 
+    def test_skill_overlong_description_without_trigger_emits_both_findings(
+        self,
+    ) -> None:
+        """An over-long description that also lacks every configured
+        trigger phrase emits BOTH the length FAIL and the trigger WARN.
+        Pins the contract: the trigger check is independent of the
+        length check; one finding does not suppress the other."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
+            long_desc = "x" * (MAX_DESCRIPTION_CHARS + 1)
+            write_skill_md(skill_dir, description=long_desc)
+            errors = audit_skill_system(tmpdir, verbose=False)
+        length_fails = [
+            e for e in errors
+            if e.startswith(LEVEL_FAIL) and "exceeds" in e
+        ]
+        trigger_warns = [
+            e for e in errors
+            if e.startswith(LEVEL_WARN) and "when the skill activates" in e
+        ]
+        self.assertEqual(len(length_fails), 1)
+        self.assertEqual(len(trigger_warns), 1)
+
     def test_skill_description_with_trigger_phrase_emits_no_trigger_warn(
         self,
     ) -> None:

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -345,6 +345,33 @@ class AuditSpecComplianceTests(unittest.TestCase):
         desc_fails = [e for e in fail_errors if "description" in e.lower()]
         self.assertGreaterEqual(len(desc_fails), 1)
 
+    def test_skill_whitespace_only_description_returns_fail(self) -> None:
+        """A whitespace-only description value is a spec violation:
+        the audit must FAIL on it (the trigger heuristic
+        short-circuits on whitespace, and the length check passes a
+        zero-length string, so without an explicit empty-after-strip
+        guard the audit would emit no diagnostic at all)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
+            write_text(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: demo-skill\ndescription: \"   \"\n---\n\n# Skill\n",
+            )
+            errors = audit_skill_system(tmpdir, verbose=False)
+        fail_errors = [e for e in errors if e.startswith(LEVEL_FAIL)]
+        empty_fails = [
+            e for e in fail_errors
+            if "empty" in e and "demo-skill/SKILL.md" in e
+        ]
+        self.assertEqual(len(empty_fails), 1)
+        # No trigger WARN — the FAIL for emptiness suppresses the
+        # downstream heuristic, avoiding diagnostic noise.
+        trigger_warns = [
+            e for e in errors
+            if "when the skill activates" in e
+        ]
+        self.assertEqual(trigger_warns, [])
+
     def test_skill_description_exceeding_max_chars_returns_fail(self) -> None:
         """A skill with a description exceeding MAX_DESCRIPTION_CHARS returns a FAIL."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_audit_skill_system.py
+++ b/tests/test_audit_skill_system.py
@@ -133,7 +133,11 @@ def _create_full_valid_system(system_root: str) -> None:
 
     # Second skill for role composition
     skill2_dir = os.path.join(system_root, "skills", "other-skill")
-    write_skill_md(skill2_dir, name="other-skill", description="Another skill.")
+    write_skill_md(
+        skill2_dir,
+        name="other-skill",
+        description="Another skill. Use when running role composition smoke tests.",
+    )
 
     # Role composing 2 skills
     role_path = os.path.join(system_root, "roles", "test", "reviewer.md")
@@ -352,6 +356,49 @@ class AuditSpecComplianceTests(unittest.TestCase):
         desc_fails = [e for e in fail_errors if "description" in e.lower()]
         self.assertGreaterEqual(len(desc_fails), 1)
         self.assertIn(str(MAX_DESCRIPTION_CHARS), desc_fails[0])
+
+    def test_skill_description_without_trigger_phrase_returns_warn(self) -> None:
+        """A SKILL.md description missing every configured trigger phrase
+        emits a [spec] WARN through the audit, prefixed with the skill
+        name and SKILL.md filename per audit conventions."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
+            write_skill_md(
+                skill_dir,
+                description=(
+                    "Validates data files and generates summary reports."
+                ),
+            )
+            errors = audit_skill_system(tmpdir, verbose=False)
+        warn_errors = [e for e in errors if e.startswith(LEVEL_WARN)]
+        trigger_warns = [
+            e for e in warn_errors
+            if "when the skill activates" in e
+            and "demo-skill/SKILL.md" in e
+        ]
+        self.assertEqual(len(trigger_warns), 1)
+        self.assertIn("[spec]", trigger_warns[0])
+
+    def test_skill_description_with_trigger_phrase_emits_no_trigger_warn(
+        self,
+    ) -> None:
+        """A SKILL.md description containing a configured trigger phrase
+        produces no trigger-clause WARN through the audit."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "skills", "demo-skill")
+            write_skill_md(
+                skill_dir,
+                description=(
+                    "Validates data files and generates summary reports. "
+                    "Triggers when a data file changes."
+                ),
+            )
+            errors = audit_skill_system(tmpdir, verbose=False)
+        trigger_warns = [
+            e for e in errors
+            if "when the skill activates" in e
+        ]
+        self.assertEqual(trigger_warns, [])
 
     def test_skill_body_exceeding_max_lines_returns_warn(self) -> None:
         """A skill with a body exceeding MAX_BODY_LINES returns a WARN."""

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -108,8 +108,11 @@ class YamlConformanceConfigTests(unittest.TestCase):
 class DescriptionTriggerPhrasesTests(unittest.TestCase):
     """``DESCRIPTION_TRIGGER_PHRASES`` exposes the configured phrase list."""
 
-    def test_is_frozenset(self) -> None:
-        self.assertIsInstance(constants.DESCRIPTION_TRIGGER_PHRASES, frozenset)
+    def test_is_tuple(self) -> None:
+        # Stored as a tuple (not frozenset) so iteration order is
+        # deterministic — --verbose pass-message phrase reporting must
+        # not vary across processes / platforms.
+        self.assertIsInstance(constants.DESCRIPTION_TRIGGER_PHRASES, tuple)
 
     def test_is_non_empty(self) -> None:
         self.assertGreater(len(constants.DESCRIPTION_TRIGGER_PHRASES), 0)
@@ -118,16 +121,34 @@ class DescriptionTriggerPhrasesTests(unittest.TestCase):
         for phrase in constants.DESCRIPTION_TRIGGER_PHRASES:
             self.assertEqual(phrase, phrase.lower())
 
+    def test_phrases_are_sorted(self) -> None:
+        # Sorted-tuple invariant — see ``test_is_tuple`` rationale.
+        self.assertEqual(
+            list(constants.DESCRIPTION_TRIGGER_PHRASES),
+            sorted(constants.DESCRIPTION_TRIGGER_PHRASES),
+        )
+
+    def test_phrases_are_unique(self) -> None:
+        phrases = list(constants.DESCRIPTION_TRIGGER_PHRASES)
+        self.assertEqual(len(phrases), len(set(phrases)))
+
     def test_starter_phrases_present(self) -> None:
         # Pin the spec-derived starter set so accidental config edits
         # surface as a test failure rather than a silent rule weakening.
+        # ``use for`` is intentionally excluded — too generic, collides
+        # with incidental prose like ``use forensic`` / ``use for example``.
         for phrase in (
             "triggers on", "triggers when",
             "activates on", "activates when",
-            "use when", "use for", "when to use",
+            "use when", "when to use",
             "invoked on", "invoked when",
         ):
             self.assertIn(phrase, constants.DESCRIPTION_TRIGGER_PHRASES)
+
+    def test_starter_set_excludes_use_for(self) -> None:
+        # Negative pin: ``use for`` was deliberately removed because
+        # substring matching turned it into a false-negative source.
+        self.assertNotIn("use for", constants.DESCRIPTION_TRIGGER_PHRASES)
 
 
 class AllowedToolsCatalogTests(unittest.TestCase):
@@ -459,6 +480,20 @@ class MissingSectionFailFastTests(unittest.TestCase):
                 )
             )
         self.assertIn("trigger_phrases", str(ctx.exception))
+
+    def test_empty_string_entry_in_trigger_phrases_raises(self) -> None:
+        # An empty / whitespace-only entry would silently disable the
+        # rule — substring-match against "" is always True.  Loader
+        # must refuse it loudly.
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_with_substitution(
+                    "      - triggers on\n",
+                    "      - triggers on\n      - \"\"\n",
+                )
+            )
+        self.assertIn("trigger_phrases", str(ctx.exception))
+        self.assertIn("empty", str(ctx.exception).lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -151,6 +151,51 @@ class DescriptionTriggerPhrasesTests(unittest.TestCase):
         self.assertNotIn("use for", constants.DESCRIPTION_TRIGGER_PHRASES)
 
 
+class DescriptionTriggerExamplePhrasesTests(unittest.TestCase):
+    """``DESCRIPTION_TRIGGER_EXAMPLE_PHRASES`` is the curated subset
+    rendered in the WARN message.  First-word distinct so examples
+    cover different root verbs, capped at three entries."""
+
+    def test_is_tuple(self) -> None:
+        self.assertIsInstance(
+            constants.DESCRIPTION_TRIGGER_EXAMPLE_PHRASES, tuple,
+        )
+
+    def test_is_non_empty(self) -> None:
+        self.assertGreater(
+            len(constants.DESCRIPTION_TRIGGER_EXAMPLE_PHRASES), 0,
+        )
+
+    def test_capped_at_three(self) -> None:
+        self.assertLessEqual(
+            len(constants.DESCRIPTION_TRIGGER_EXAMPLE_PHRASES), 3,
+        )
+
+    def test_first_words_are_distinct(self) -> None:
+        # Core invariant: each example uses a different root verb so
+        # the user sees varied guidance, not two flavors of one verb.
+        first_words = [
+            phrase.split(" ", 1)[0]
+            for phrase in constants.DESCRIPTION_TRIGGER_EXAMPLE_PHRASES
+        ]
+        self.assertEqual(len(first_words), len(set(first_words)))
+
+    def test_examples_are_subset_of_full_list(self) -> None:
+        for phrase in constants.DESCRIPTION_TRIGGER_EXAMPLE_PHRASES:
+            self.assertIn(phrase, constants.DESCRIPTION_TRIGGER_PHRASES)
+
+    def test_examples_include_triggers_root(self) -> None:
+        # Pin: "triggers" is the most natural English activation root
+        # and must appear in the rendered examples.  If the curation
+        # ever drops it, fail loudly so the WARN's user value is
+        # not silently degraded.
+        first_words = {
+            phrase.split(" ", 1)[0]
+            for phrase in constants.DESCRIPTION_TRIGGER_EXAMPLE_PHRASES
+        }
+        self.assertIn("triggers", first_words)
+
+
 class AllowedToolsCatalogTests(unittest.TestCase):
     """Per-harness catalog constants exposed by ``allowed_tools.catalogs``."""
 
@@ -508,6 +553,24 @@ class MissingSectionFailFastTests(unittest.TestCase):
             )
         self.assertIn("trigger_phrases", str(ctx.exception))
         self.assertIn("duplicate", str(ctx.exception).lower())
+
+    def test_duplicate_error_surfaces_raw_and_normalized_forms(self) -> None:
+        # Author writes 'Triggers When' (mixed case) and again as
+        # 'triggers when' — both normalize to the same value.  The
+        # error must surface the raw value the author actually wrote
+        # so they can find the offending line in the YAML, plus the
+        # normalized form so they understand why it collided.
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_with_substitution(
+                    "      - triggers on\n",
+                    "      - triggers on\n      - Triggers On\n",
+                )
+            )
+        message = str(ctx.exception)
+        self.assertIn("Triggers On", message)
+        self.assertIn("triggers on", message)
+        self.assertIn("normalized", message)
 
 
 if __name__ == "__main__":

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -495,6 +495,20 @@ class MissingSectionFailFastTests(unittest.TestCase):
         self.assertIn("trigger_phrases", str(ctx.exception))
         self.assertIn("empty", str(ctx.exception).lower())
 
+    def test_duplicate_entry_in_trigger_phrases_raises(self) -> None:
+        # Duplicate entries indicate a config edit accident.  The
+        # loader fails fast (symmetric with the empty-entry guard)
+        # rather than silently deduplicating.
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_with_substitution(
+                    "      - triggers on\n",
+                    "      - triggers on\n      - triggers on\n",
+                )
+            )
+        self.assertIn("trigger_phrases", str(ctx.exception))
+        self.assertIn("duplicate", str(ctx.exception).lower())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -105,6 +105,31 @@ class YamlConformanceConfigTests(unittest.TestCase):
         )
 
 
+class DescriptionTriggerPhrasesTests(unittest.TestCase):
+    """``DESCRIPTION_TRIGGER_PHRASES`` exposes the configured phrase list."""
+
+    def test_is_frozenset(self) -> None:
+        self.assertIsInstance(constants.DESCRIPTION_TRIGGER_PHRASES, frozenset)
+
+    def test_is_non_empty(self) -> None:
+        self.assertGreater(len(constants.DESCRIPTION_TRIGGER_PHRASES), 0)
+
+    def test_phrases_are_lowercased(self) -> None:
+        for phrase in constants.DESCRIPTION_TRIGGER_PHRASES:
+            self.assertEqual(phrase, phrase.lower())
+
+    def test_starter_phrases_present(self) -> None:
+        # Pin the spec-derived starter set so accidental config edits
+        # surface as a test failure rather than a silent rule weakening.
+        for phrase in (
+            "triggers on", "triggers when",
+            "activates on", "activates when",
+            "use when", "use for", "when to use",
+            "invoked on", "invoked when",
+        ):
+            self.assertIn(phrase, constants.DESCRIPTION_TRIGGER_PHRASES)
+
+
 class AllowedToolsCatalogTests(unittest.TestCase):
     """Per-harness catalog constants exposed by ``allowed_tools.catalogs``."""
 
@@ -425,6 +450,15 @@ class MissingSectionFailFastTests(unittest.TestCase):
                 )
             )
         self.assertIn("cutoff", str(ctx.exception))
+
+    def test_missing_description_trigger_phrases_raises(self) -> None:
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_minus_nested(
+                    "description", "trigger_phrases",
+                )
+            )
+        self.assertIn("trigger_phrases", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -102,6 +102,19 @@ class ValidateDescriptionTests(unittest.TestCase):
         self.assertIn("empty", errors[0])
         self.assertEqual(passes, [])
 
+    def test_whitespace_only_description_returns_fail(self) -> None:
+        """A whitespace-only description is a spec violation and must
+        FAIL exactly like the empty case — the trigger heuristic
+        short-circuits on whitespace, so a falsy-only test would let
+        ``"   "`` slip through with no diagnostic."""
+        for value in ("   ", "\n\n\t  ", " "):
+            with self.subTest(value=repr(value)):
+                errors, passes = validate_description(value)
+                fail_errors = [e for e in errors if e.startswith(LEVEL_FAIL)]
+                empty_fails = [e for e in fail_errors if "empty" in e]
+                self.assertEqual(len(empty_fails), 1)
+                self.assertEqual(passes, [])
+
     def test_valid_third_person_description(self) -> None:
         """A valid third-person description within limits produces passes."""
         desc = "Processes data files and generates summary reports."

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -269,6 +269,34 @@ class ValidateDescriptionTests(unittest.TestCase):
         voice_pass = [p for p in passes if "third-person" in p]
         self.assertEqual(len(voice_pass), 1)
 
+    def test_description_with_trigger_phrase_emits_no_trigger_warn(self) -> None:
+        """A description containing a configured trigger phrase emits no
+        trigger-clause WARN through the end-to-end validate_description."""
+        desc = (
+            "Manages project timelines and tracks milestones. Triggers when "
+            "a milestone changes."
+        )
+        errors, passes = validate_description(desc)
+        trigger_warns = [
+            e for e in errors
+            if e.startswith(LEVEL_WARN) and "when the skill activates" in e
+        ]
+        self.assertEqual(trigger_warns, [])
+        trigger_passes = [p for p in passes if "trigger phrase" in p]
+        self.assertEqual(len(trigger_passes), 1)
+
+    def test_description_without_trigger_phrase_emits_warn(self) -> None:
+        """A description missing every configured trigger phrase emits a
+        single [spec] WARN through validate_description."""
+        desc = "Manages project timelines and tracks milestones."
+        errors, _ = validate_description(desc)
+        trigger_warns = [
+            e for e in errors
+            if e.startswith(LEVEL_WARN) and "when the skill activates" in e
+        ]
+        self.assertEqual(len(trigger_warns), 1)
+        self.assertIn("[spec]", trigger_warns[0])
+
 
 # ===================================================================
 # validate_body
@@ -2894,7 +2922,8 @@ class ValidateSkillOptionalFieldsTests(unittest.TestCase):
             write_text(
                 os.path.join(skill_dir, "SKILL.md"),
                 "---\nname: demo-skill\n"
-                "description: Validates data files and generates reports.\n"
+                "description: Validates data files and generates reports. "
+                "Triggers when a data file is touched.\n"
                 "compatibility: Requires Python 3.12 or later.\n"
                 "allowed-tools: bash git python\n"
                 "license: MIT\n"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -978,8 +978,10 @@ class ValidateDescriptionTriggersTests(unittest.TestCase):
     The helper enforces the agentskills.io spec requirement that a
     description state when the skill activates.  Detection is a
     case-insensitive substring match against
-    DESCRIPTION_TRIGGER_PHRASES; missing every phrase produces a
-    single WARN.
+    DESCRIPTION_TRIGGER_PHRASES; for non-empty descriptions, missing
+    every phrase produces a single WARN.  Empty / whitespace-only
+    inputs short-circuit silently — the spec-required non-empty FAIL
+    is owned by the caller, not this helper.
     """
 
     def test_phrase_present_emits_no_warn(self) -> None:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -20,10 +20,12 @@ if SCRIPTS_DIR not in sys.path:
 from helpers import write_capability_md, write_skill_md, write_text
 from lib.validation import (
     parse_allowed_tools_tokens,
+    validate_description_triggers,
     validate_name,
     validate_tool_coherence,
 )
 from lib.constants import (
+    DESCRIPTION_TRIGGER_PHRASES,
     LEVEL_FAIL,
     LEVEL_INFO,
     LEVEL_WARN,
@@ -963,6 +965,83 @@ class ValidateToolCoherenceTests(unittest.TestCase):
         errors, _ = validate_tool_coherence(self.skill_dir, {})
         warn_errors = [e for e in errors if e.startswith(LEVEL_WARN)]
         self.assertEqual(len(warn_errors), 1)
+
+
+# ===================================================================
+# Description Trigger-Phrase Heuristic
+# ===================================================================
+
+
+class ValidateDescriptionTriggersTests(unittest.TestCase):
+    """Tests for validate_description_triggers.
+
+    The helper enforces the agentskills.io spec requirement that a
+    description state when the skill activates.  Detection is a
+    case-insensitive substring match against
+    DESCRIPTION_TRIGGER_PHRASES; missing every phrase produces a
+    single WARN.
+    """
+
+    def test_phrase_present_emits_no_warn(self) -> None:
+        desc = "Validates skills against the spec. Triggers when a skill is created."
+        errors, passes = validate_description_triggers(desc)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+        self.assertIn("triggers when", passes[0])
+
+    def test_phrase_absent_emits_single_warn(self) -> None:
+        desc = "Validates skills against the spec. Reports findings to stdout."
+        errors, passes = validate_description_triggers(desc)
+        warn_errors = [e for e in errors if e.startswith(LEVEL_WARN)]
+        self.assertEqual(len(warn_errors), 1)
+        self.assertIn("[spec]", warn_errors[0])
+        self.assertIn("when the skill activates", warn_errors[0])
+        self.assertEqual(passes, [])
+
+    def test_match_is_case_insensitive(self) -> None:
+        desc = "Validates skills against the spec. ACTIVATES WHEN a skill is touched."
+        errors, _ = validate_description_triggers(desc)
+        self.assertEqual(errors, [])
+
+    def test_match_after_folded_multiline_input(self) -> None:
+        # YAML folded block scalars collapse newlines to spaces before
+        # the value reaches this helper.  Simulate the post-folding
+        # shape: original text was split across lines, folding joins
+        # the segments with a space, and the phrase lands on one line.
+        desc = (
+            "Validates skills against the spec. Activates "
+            "when a skill is created or edited."
+        )
+        errors, _ = validate_description_triggers(desc)
+        self.assertEqual(errors, [])
+
+    def test_phrase_matches_within_longer_word(self) -> None:
+        # "activates whenever" contains "activates when" as a
+        # substring; the issue's acceptance examples rely on this.
+        desc = (
+            "Greets a single recipient with a friendly welcome message. "
+            "Activates whenever the conversation asks to say hello."
+        )
+        errors, _ = validate_description_triggers(desc)
+        self.assertEqual(errors, [])
+
+    def test_empty_input_short_circuits(self) -> None:
+        for value in ("", "   ", "\n\n  \t"):
+            errors, passes = validate_description_triggers(value)
+            self.assertEqual(errors, [])
+            self.assertEqual(passes, [])
+
+    def test_pass_message_names_matched_phrase(self) -> None:
+        # Pass entry should reference one of the configured phrases so
+        # --verbose output explains why the rule was satisfied.
+        desc = "Audits skill systems. Use when the structure may have drifted."
+        _, passes = validate_description_triggers(desc)
+        self.assertEqual(len(passes), 1)
+        matched = next(
+            (p for p in DESCRIPTION_TRIGGER_PHRASES if p in passes[0]),
+            None,
+        )
+        self.assertIsNotNone(matched)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #99. Adds a WARN-level heuristic that fires when a `SKILL.md` description does not state when the skill activates, surfacing the agentskills.io spec requirement that descriptions state both *what* and *when*. Detection is configuration-driven: the phrase list lives in `configuration.yaml` under `skill.description.trigger_phrases`, and the rule is invoked from both `validate_skill.py` and `audit_skill_system.py` so integrators see the advisory in either workflow.

## What changed

- New helper `validate_description_triggers` in `lib/validation.py` performs case-insensitive substring matching of the (folded) description against the configured phrase list. Returns `(errors, passes)` per the standard validator contract; emits one `WARN` tagged `[spec]` when no phrase is present.
- Phrase list lives in `configuration.yaml` under `skill.description.trigger_phrases` with 8 starter entries (`triggers on/when`, `activates on/when`, `use when`, `when to use`, `invoked on/when`).
- `constants.py` loads the list as `DESCRIPTION_TRIGGER_PHRASES` (sorted tuple) with fail-fast guards on missing key, empty list, empty entries, and duplicate entries. Sibling tuple `DESCRIPTION_TRIGGER_EXAMPLE_PHRASES` is curated by first-word-distinct dedup so the WARN message renders varied root verbs.
- `validate_description` (validate_skill.py) calls the helper after the existing voice checks. The audit's per-skill description block calls the helper too, prefixing findings with the standard `{skill_name}/{FILE_SKILL_MD}` path.
- 21 new tests across `test_constants.py`, `test_validation.py`, `test_validate_skill.py`, `test_audit_skill_system.py` covering positive, negative, case-variant, post-folding multi-line, substring-within-longer-word, empty input, configuration fail-fast (missing key, empty list, empty entry, duplicate entry), curated-example-set invariants, and the audit's interaction between length FAIL and trigger WARN.

## Design decisions worth surfacing

1. **Scope: SKILL.md only.** Capabilities deferred to issue #120, which already declares capability descriptions redundant with the router-table entry. Roles untouched.
2. **`use for` excluded from the starter list.** Substring matching turned it into a false-negative source (\"use forensic\", \"use for example\"). Negative pin in tests prevents regression.
3. **Sorted tuple, not frozenset.** Frozenset iteration order is implementation-defined; a sorted tuple keeps `--verbose` pass-message phrase reporting deterministic across processes.
4. **Fail-fast on empty and duplicate entries.** An empty entry would silently neuter the rule (substring match against `\"\"` is always true); a duplicate indicates a config-edit accident. The duplicate error message includes both the raw value the author wrote and the normalized form so they can find the offending YAML line regardless of casing or whitespace.
5. **Curated example phrases.** The WARN message renders examples from `DESCRIPTION_TRIGGER_EXAMPLE_PHRASES`, a sibling tuple selected by first-word-distinct dedup. Shows different root verbs (`'Activates on …', 'Invoked on …', 'Triggers on …'`) instead of two flavors of one root.
6. **Severity `[spec]` WARN.** The spec mandates \"what AND when\"; detection is heuristic (phrase matching cannot enumerate every valid wording), so WARN — not FAIL — is the appropriate level.

## Notification path for upgraders

Integrators upgrading to a foundry version that includes this rule will see the new advisory the next time they run `validate_skill.py` or `audit_skill_system.py` against their skills. WARNs do not change exit codes, so nothing is blocked. They can either update their description copy or extend the phrase list via PR if they have a legitimate wording the heuristic missed.

## Testing

- Full suite: 2043 tests pass.
- Branch coverage: 96% (threshold 70%).
- Foundry self-validation (`validate_skill.py . --allow-nested-references --foundry-self`): clean.
- Skill-root audit (`audit_skill_system.py .`): clean.
- Repo-root audit: only the expected partial-audit warning.
- `examples/skills/hello-greeter` and `examples/skills/hello-router`: both validate clean against the new rule.

## Acceptance criteria from #99

- [x] New key `description_trigger_phrases` in `configuration.yaml` (lives at `skill.description.trigger_phrases` for consistency with sibling description rules)
- [x] Rule fires WARN on descriptions missing every trigger phrase
- [x] Rule passes on descriptions containing at least one phrase
- [x] Matching is case-insensitive and post-folding
- [x] Tests cover positive, negative, and case-variant cases
- [x] Meta-skill and all `examples/` pass the new rule