### PR TITLE
Add stats entry point that reports skill token budgets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,8 @@ This repository contains **one skill** (`skill-system-foundry/`) and its **test 
 │       ├── validate_skill.py        ← validate a single skill
 │       ├── audit_skill_system.py    ← audit entire skill system
 │       ├── scaffold.py              ← scaffold new components from templates
-│       └── bundle.py                ← bundle for distribution (zip)
+│       ├── bundle.py                ← bundle for distribution (zip)
+│       └── stats.py                 ← report skill token-budget proxies
 ├── scripts/                         ← repository infrastructure (not part of the meta-skill)
 │   ├── generate_changelog.py        ← changelog generator (git history → CHANGELOG.md)
 │   └── lib/
@@ -170,6 +171,17 @@ The repo root has no `skills/` tree and no top-level `SKILL.md`, so this invocat
 | `--verbose` | Prints per-file progress messages for the prose check (`Checking prose YAML: <path> (<N> fences)`) and shows passing checks otherwise. Silent under `--json`. | Local debugging / triage. |
 
 In addition, `python scripts/yaml_conformance_report.py` runs the YAML 1.2.2 conformance corpus and emits the same `yaml_conformance.corpus` JSON slot for tooling consumers; exit 0 on all-pass, non-zero on any failure.
+
+### Measuring the Meta-Skill's Token Budget
+
+```bash
+cd skill-system-foundry
+python scripts/stats.py . --json
+```
+
+`stats.py` reports two byte-based proxies for a skill's context cost: `discovery_bytes` (the SKILL.md frontmatter block) and `load_bytes` (SKILL.md plus every capability and reference file reachable through markdown links, backticks, and bare router-table path cells). Files under `scripts/` and `assets/` are excluded — they are not loaded into the model's context during skill use. Bytes are not tokens and are not comparable across models or tokenizers; treat the number as a deterministic on-disk signal for tracking the relative cost of authoring decisions over time. Counts are taken from raw on-disk UTF-8 bytes, so CRLF terminators on Windows checkouts produce higher numbers than the same content on POSIX checkouts.
+
+Only a missing `SKILL.md` is a FAIL; broken references, parent-traversal attempts, and external references are surfaced as WARN/INFO findings while the run still emits a usable metric.
 
 ### Linting Shell Scripts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,8 @@ This repository contains **one skill** (`skill-system-foundry/`) and its **test 
 │       ├── audit_skill_system.py    ← audit entire skill system
 │       ├── scaffold.py              ← scaffold new components from templates
 │       ├── bundle.py                ← bundle for distribution (zip)
-│       └── stats.py                 ← report skill token-budget proxies
+│       ├── stats.py                 ← report skill token-budget proxies
+│       └── yaml_conformance_report.py  ← run the YAML 1.2.2 corpus
 ├── scripts/                         ← repository infrastructure (not part of the meta-skill)
 │   ├── generate_changelog.py        ← changelog generator (git history → CHANGELOG.md)
 │   └── lib/
@@ -181,7 +182,7 @@ python scripts/stats.py . --json
 
 `stats.py` reports two byte-based proxies for a skill's context cost: `discovery_bytes` (the SKILL.md frontmatter block) and `load_bytes` (SKILL.md plus every capability and reference file reachable through markdown links, backticks, and bare router-table path cells). Files under `scripts/` and `assets/` are excluded — they are not loaded into the model's context during skill use. Bytes are not tokens and are not comparable across models or tokenizers; treat the number as a deterministic on-disk signal for tracking the relative cost of authoring decisions over time. Counts are taken from raw on-disk UTF-8 bytes, so CRLF terminators on Windows checkouts produce higher numbers than the same content on POSIX checkouts.
 
-Only a missing `SKILL.md` is a FAIL; broken references, parent-traversal attempts, and external references are surfaced as WARN/INFO findings while the run still emits a usable metric.
+A missing or unreadable `SKILL.md` is a FAIL — that includes the file not existing, an I/O error during read, or invalid UTF-8 in either the frontmatter scan or the body. Everything else recovers: broken references, parent-traversal attempts, external references, undecodable referenced files, and frontmatter parse errors are surfaced as WARN/INFO findings while the run still emits a usable metric.
 
 ### Linting Shell Scripts
 

--- a/skill-system-foundry/SKILL.md
+++ b/skill-system-foundry/SKILL.md
@@ -68,9 +68,11 @@ Cross-cutting reference material shared across capabilities. Capabilities refere
 
 Skill, capability, role, and manifest templates copied and filled in when creating new components.
 
-### scripts/ — Validation, scaffolding, and bundling tools
+### scripts/ — Validation, scaffolding, bundling, and measurement tools
 
-Four entry points (`validate_skill.py`, `audit_skill_system.py`, `scaffold.py`, `bundle.py`) and shared library modules. All entry points support `--json` for machine-readable output.
+Five entry points (`validate_skill.py`, `audit_skill_system.py`, `scaffold.py`, `bundle.py`, `stats.py`) and shared library modules. All entry points support `--json` for machine-readable output.
+
+`stats.py` reports two byte-based proxies for a skill's context cost: `discovery_bytes` (the SKILL.md frontmatter block) and `load_bytes` (SKILL.md plus every transitively reachable capability and reference file, with `scripts/` and `assets/` excluded). Bytes are a deterministic on-disk signal, not tokenizer-accurate — use the trend across edits, not the absolute number across models.
 
 ## Core Principles
 

--- a/skill-system-foundry/SKILL.md
+++ b/skill-system-foundry/SKILL.md
@@ -70,7 +70,7 @@ Skill, capability, role, and manifest templates copied and filled in when creati
 
 ### scripts/ — Validation, scaffolding, bundling, and measurement tools
 
-Five entry points (`validate_skill.py`, `audit_skill_system.py`, `scaffold.py`, `bundle.py`, `stats.py`) and shared library modules. All entry points support `--json` for machine-readable output.
+Six entry points (`validate_skill.py`, `audit_skill_system.py`, `scaffold.py`, `bundle.py`, `stats.py`, `yaml_conformance_report.py`) and shared library modules. All entry points support `--json` for machine-readable output.
 
 `stats.py` reports two byte-based proxies for a skill's context cost: `discovery_bytes` (the SKILL.md frontmatter block) and `load_bytes` (SKILL.md plus every transitively reachable capability and reference file, with `scripts/` and `assets/` excluded). Bytes are a deterministic on-disk signal, not tokenizer-accurate — use the trend across edits, not the absolute number across models.
 

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -51,8 +51,8 @@ skill:
   body:
     max_lines: 500
     reference_patterns:
-      markdown_link: \[.*?\]\(((?:references|scripts|assets)/[^)]+)\)
-      backtick: "`((?:references|scripts|assets)/[^`]+)`"
+      markdown_link: \[.*?\]\(((?:capabilities|references|scripts|assets)/[^)]+)\)
+      backtick: "`((?:capabilities|references|scripts|assets)/[^`]+)`"
   compatibility:
     max_length: 500
 

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -372,9 +372,14 @@ def extract_capability_paths(body: str) -> list[str]:
     — the caller is expected to dedupe alongside other reference
     sources.
 
-    The router-table semantics live in this module by design — stats,
-    bundling, and the audit all consume capability paths through this
-    one helper instead of reimplementing the strict + recovery cascade.
+    The router-table semantics live in this module by design.  Stats
+    consumes this helper so its load-graph traversal does not have
+    to reimplement the strict + recovery cascade.  ``audit_router_table``
+    keeps its own per-row walk because the audit needs row-level
+    finding tuples (FAIL/WARN with line numbers); a future
+    consolidation could share the recovery cascade by extracting it
+    into a separate sub-helper consumed by both, but that refactor
+    is out of scope here.
     """
     parsed = parse_router_table(body)
     if parsed is None:

--- a/skill-system-foundry/scripts/lib/router_table.py
+++ b/skill-system-foundry/scripts/lib/router_table.py
@@ -356,6 +356,43 @@ def _recover_segment(path_cell: str) -> str | None:
     return _parse_path_cell(candidate)
 
 
+def extract_capability_paths(body: str) -> list[str]:
+    """Return canonical ``capabilities/<name>/capability.md`` paths from
+    a router table inside *body*.
+
+    Strict shape parsing is tried first; rows whose path cell carries
+    common author decoration (backticks, ``[text](url)`` wrappers,
+    leading ``./``, trailing ``#fragment``) fall through to the same
+    decoration-stripping recovery that ``audit_router_table`` uses, so
+    the recovered name still produces the canonical path string.
+
+    Returns an empty list when *body* contains no router-shaped table
+    or when no row has a recoverable canonical path.  Order follows
+    the first-seen position in the table; duplicates are not removed
+    — the caller is expected to dedupe alongside other reference
+    sources.
+
+    The router-table semantics live in this module by design — stats,
+    bundling, and the audit all consume capability paths through this
+    one helper instead of reimplementing the strict + recovery cascade.
+    """
+    parsed = parse_router_table(body)
+    if parsed is None:
+        return []
+    rows, _findings = parsed
+    paths: list[str] = []
+    for _capability, _trigger, path_cell in rows:
+        name = _parse_path_cell(path_cell.strip())
+        if name is None:
+            name = _recover_segment(path_cell)
+        if name is None:
+            continue
+        paths.append(
+            f"{DIR_CAPABILITIES}/{name}/{FILE_CAPABILITY_MD}"
+        )
+    return paths
+
+
 def audit_router_table(skill_path: str) -> list[tuple[str, str]]:
     """Audit the router table of the skill at *skill_path*.
 

--- a/skill-system-foundry/scripts/lib/stats.py
+++ b/skill-system-foundry/scripts/lib/stats.py
@@ -26,9 +26,7 @@ import re
 
 from .constants import (
     DIR_ASSETS,
-    DIR_CAPABILITIES,
     DIR_SCRIPTS,
-    FILE_CAPABILITY_MD,
     FILE_SKILL_MD,
     LEVEL_FAIL,
     LEVEL_INFO,
@@ -36,12 +34,9 @@ from .constants import (
     RE_BACKTICK_REF,
     RE_MARKDOWN_LINK_REF,
 )
-from .references import strip_fragment
-from .router_table import (
-    _parse_path_cell,
-    _recover_segment,
-    parse_router_table,
-)
+from .frontmatter import load_frontmatter
+from .references import is_within_directory, strip_fragment
+from .router_table import extract_capability_paths
 
 
 # Directory categories whose bytes are excluded from ``load_bytes``.
@@ -115,14 +110,19 @@ def discovery_bytes_for_skill_md(skill_md_path: str) -> int:
 # ===================================================================
 
 
-def extract_body_references(content: str) -> list[str]:
+def extract_body_references(
+    content: str, *, include_router_table: bool = False,
+) -> list[str]:
     """Return cleaned reference paths from a markdown body.
 
     Applies the body ``reference_patterns`` from ``configuration.yaml``
     (markdown-link and backtick forms) after stripping fenced code
-    blocks, then augments the result with capability paths recovered
-    from a SKILL.md router table — those paths are bare cells, not
-    markdown links, so the body regexes alone would miss them.
+    blocks.  When *include_router_table* is True, the result is also
+    augmented with capability paths recovered from a router table in
+    *content* — those paths are bare cells, not markdown links, so the
+    body regexes alone would miss them.  Only the SKILL.md entry point
+    legitimately carries a router table, so callers pass
+    ``include_router_table=True`` only for that file.
 
     Anchor fragments, queries, and title suffixes are stripped via
     :func:`strip_fragment`.  Template placeholders (containing ``<``
@@ -134,7 +134,8 @@ def extract_body_references(content: str) -> list[str]:
     raw_refs: list[str] = []
     raw_refs.extend(RE_MARKDOWN_LINK_REF.findall(stripped))
     raw_refs.extend(RE_BACKTICK_REF.findall(stripped))
-    raw_refs.extend(_router_table_capability_paths(content))
+    if include_router_table:
+        raw_refs.extend(extract_capability_paths(content))
 
     seen: set[str] = set()
     cleaned: list[str] = []
@@ -149,35 +150,6 @@ def extract_body_references(content: str) -> list[str]:
         seen.add(clean)
         cleaned.append(clean)
     return cleaned
-
-
-def _router_table_capability_paths(content: str) -> list[str]:
-    """Return ``capabilities/<name>/capability.md`` paths from a router table.
-
-    Returns an empty list when *content* contains no router table or
-    when none of its rows have a recoverable canonical path cell.
-    Decoration recovery (backticks, ``[text](url)`` wrappers, leading
-    ``./``, trailing ``#fragment``) is applied so authors can decorate
-    table cells without their capabilities disappearing from the load
-    graph.
-    """
-    parsed = parse_router_table(content)
-    if parsed is None:
-        return []
-    rows, _findings = parsed
-    paths: list[str] = []
-    for _capability, _trigger, path_cell in rows:
-        # Try strict parse first, then the decoration-stripping
-        # recovery used by the router-table audit.
-        name = _parse_path_cell(path_cell.strip())
-        if name is None:
-            name = _recover_segment(path_cell)
-        if name is None:
-            continue
-        paths.append(
-            f"{DIR_CAPABILITIES}/{name}/{FILE_CAPABILITY_MD}"
-        )
-    return paths
 
 
 def category_of(rel_path: str) -> str:
@@ -268,9 +240,6 @@ def compute_stats(skill_path: str) -> dict:
 
     # Best-effort skill-name resolution from frontmatter; falls back to
     # the directory basename when frontmatter is absent or malformed.
-    # Importing lazily avoids a circular dependency through constants.
-    from .frontmatter import load_frontmatter
-
     frontmatter, _body, _scalar_findings = load_frontmatter(skill_md)
     if frontmatter and "_parse_error" not in frontmatter and frontmatter.get("name"):
         result["skill"] = str(frontmatter["name"])
@@ -328,7 +297,10 @@ def compute_stats(skill_path: str) -> dict:
             )
             return
 
-        for ref in extract_body_references(content):
+        is_entry = filepath == os.path.abspath(skill_md)
+        for ref in extract_body_references(
+            content, include_router_table=is_entry,
+        ):
             if os.path.isabs(ref):
                 result["errors"].append(
                     f"{LEVEL_WARN}: [foundry] absolute reference '{ref}' "
@@ -344,12 +316,13 @@ def compute_stats(skill_path: str) -> dict:
                 continue
 
             ref_abs = os.path.normpath(os.path.join(skill_path, ref_norm))
-            ref_rel = _to_skill_root_relative(ref_abs, skill_path)
 
             # External / cross-skill references resolve outside the
             # skill root; report once and skip — they are not part of
-            # this skill's load budget.
-            if ref_rel.startswith(".."):
+            # this skill's load budget.  Use is_within_directory rather
+            # than a lexical relpath check so symlinks pointing outside
+            # the skill are correctly classified.
+            if not is_within_directory(ref_abs, skill_path):
                 result["errors"].append(
                     f"{LEVEL_INFO}: [foundry] reference '{ref}' in '{rel}' "
                     f"resolves outside the skill directory — excluded "

--- a/skill-system-foundry/scripts/lib/stats.py
+++ b/skill-system-foundry/scripts/lib/stats.py
@@ -26,7 +26,9 @@ import re
 
 from .constants import (
     DIR_ASSETS,
+    DIR_CAPABILITIES,
     DIR_SCRIPTS,
+    FILE_CAPABILITY_MD,
     FILE_SKILL_MD,
     LEVEL_FAIL,
     LEVEL_INFO,
@@ -148,6 +150,20 @@ def extract_body_references(
     raw_refs.extend(RE_BACKTICK_REF.findall(stripped))
     if include_router_table:
         raw_refs.extend(extract_capability_paths(content))
+    else:
+        # Capability *entry-point* paths are entry-point-only edges.
+        # A non-entry body that references ``capabilities/<name>/capability.md``
+        # is either a documentation example or an architecture violation
+        # (capabilities don't reference each other — see
+        # audit_skill_system).  Either way, do not treat it as a live
+        # load edge.  Nested capability resources like
+        # ``capabilities/<name>/references/foo.md`` remain legitimate
+        # — those are skill-root-relative links from within a
+        # capability into its own local references and must stay in
+        # the load graph.
+        raw_refs = [
+            r for r in raw_refs if not _is_capability_entry_path(r)
+        ]
 
     seen: set[str] = set()
     cleaned: list[str] = []
@@ -178,6 +194,25 @@ def category_of(rel_path: str) -> str:
 def is_excluded_from_load(rel_path: str) -> bool:
     """Return True when a path's bytes should not contribute to load."""
     return category_of(rel_path) in _EXCLUDED_LOAD_CATEGORIES
+
+
+def _is_capability_entry_path(ref_path: str) -> bool:
+    """Return True when *ref_path* is a capability entry point.
+
+    A capability entry point matches the canonical shape
+    ``capabilities/<name>/capability.md`` exactly — three segments,
+    leading directory ``capabilities``, trailing file
+    ``capability.md``.  Nested capability resources like
+    ``capabilities/<name>/references/foo.md`` do NOT match — those
+    are legitimate intra-capability references that must stay in the
+    load graph.
+    """
+    parts = ref_path.replace("\\", "/").split("/")
+    return (
+        len(parts) == 3
+        and parts[0] == DIR_CAPABILITIES
+        and parts[2] == FILE_CAPABILITY_MD
+    )
 
 
 # ===================================================================
@@ -252,11 +287,28 @@ def compute_stats(skill_path: str) -> dict:
 
     # Best-effort skill-name resolution from frontmatter; falls back to
     # the directory basename when frontmatter is absent or malformed.
-    frontmatter, _body, _scalar_findings = load_frontmatter(skill_md)
+    # Wrap both entry-file reads in try/except so a permission error or
+    # invalid UTF-8 surfaces as a structured FAIL instead of a
+    # traceback through the CLI.
+    try:
+        frontmatter, _body, _scalar_findings = load_frontmatter(skill_md)
+    except (OSError, UnicodeError) as exc:
+        result["errors"].append(
+            f"{LEVEL_FAIL}: [foundry] cannot read {FILE_SKILL_MD} "
+            f"({exc.__class__.__name__}: {exc})"
+        )
+        return result
     if frontmatter and "_parse_error" not in frontmatter and frontmatter.get("name"):
         result["skill"] = str(frontmatter["name"])
 
-    discovery_count = discovery_bytes_of(skill_md)
+    try:
+        discovery_count = discovery_bytes_of(skill_md)
+    except (OSError, UnicodeError) as exc:
+        result["errors"].append(
+            f"{LEVEL_FAIL}: [foundry] cannot scan {FILE_SKILL_MD} "
+            f"frontmatter ({exc.__class__.__name__}: {exc})"
+        )
+        return result
     if discovery_count == 0:
         result["errors"].append(
             f"{LEVEL_WARN}: [foundry] {FILE_SKILL_MD} has no parseable "
@@ -333,6 +385,15 @@ def compute_stats(skill_path: str) -> dict:
                 continue
 
             ref_abs = os.path.normpath(os.path.join(skill_path, ref_norm))
+
+            # Decline at the gate for excluded categories.  A missing
+            # scripts/foo.py or assets/template.md must not emit a
+            # broken-ref WARN, since those categories are silently
+            # excluded from load_bytes anyway — the existence check
+            # below would fire a false-positive warning on every
+            # missing helper script that the entry happens to mention.
+            if is_excluded_from_load(ref_norm):
+                continue
 
             # External / cross-skill references resolve outside the
             # skill root; report once and skip — they are not part of

--- a/skill-system-foundry/scripts/lib/stats.py
+++ b/skill-system-foundry/scripts/lib/stats.py
@@ -8,11 +8,14 @@ Computes two byte-based proxies for a skill's context cost:
 
 * ``load_bytes`` — the raw bytes of ``SKILL.md`` plus every in-scope
   referenced file reachable transitively from the entry point through
-  the body reference patterns defined in ``configuration.yaml``.  Files
-  under ``scripts/`` and ``assets/`` are excluded because they are not
-  loaded into the model's context during skill use; only ``SKILL.md``,
-  ``capabilities/.../capability.md``, and ``references/.../*`` count
-  toward the load budget.
+  the body reference patterns defined in ``configuration.yaml``.
+  Files under ``scripts/`` and ``assets/`` are excluded because they
+  are not loaded into the model's context during skill use; everything
+  else reachable under ``capabilities/`` or ``references/`` counts
+  toward the load budget — that includes capability entry points
+  (``capabilities/<name>/capability.md``), capability-local resources
+  (``capabilities/<name>/references/<doc>.md``), and shared
+  ``references/<doc>.md`` files.
 
 Bytes are not tokens.  Byte counts are not comparable across models or
 tokenizers — they are a deterministic, on-disk signal for tracking the
@@ -36,7 +39,7 @@ from .constants import (
     RE_BACKTICK_REF,
     RE_MARKDOWN_LINK_REF,
 )
-from .frontmatter import load_frontmatter
+from .frontmatter import load_frontmatter, strip_frontmatter_for_scan
 from .references import is_within_directory, strip_fragment
 from .router_table import extract_capability_paths
 
@@ -384,9 +387,16 @@ def compute_stats(skill_path: str) -> dict:
         if content is None:
             return
 
+        # Strip the YAML frontmatter block before reference extraction
+        # so metadata strings (e.g. ``description: see references/foo.md``)
+        # are not mistaken for live load edges.  The body regex is
+        # otherwise applied to the entire file, including the
+        # frontmatter, which would inflate ``load_bytes`` whenever a
+        # frontmatter scalar happens to contain a path-shaped string.
+        body_only = strip_frontmatter_for_scan(content)
         is_entry = filepath == os.path.abspath(skill_md)
         for ref in extract_body_references(
-            content, include_router_table=is_entry,
+            body_only, include_router_table=is_entry,
         ):
             if os.path.isabs(ref):
                 result["errors"].append(

--- a/skill-system-foundry/scripts/lib/stats.py
+++ b/skill-system-foundry/scripts/lib/stats.py
@@ -161,8 +161,15 @@ def extract_body_references(
         # — those are skill-root-relative links from within a
         # capability into its own local references and must stay in
         # the load graph.
+        #
+        # Apply ``strip_fragment`` before the shape check so anchored
+        # links (``capabilities/foo/capability.md#section``) and
+        # query-suffixed links are recognized as entry-point paths
+        # too — they would otherwise survive this filter and be
+        # followed during traversal as a live edge.
         raw_refs = [
-            r for r in raw_refs if not _is_capability_entry_path(r)
+            r for r in raw_refs
+            if not _is_capability_entry_path(strip_fragment(r))
         ]
 
     seen: set[str] = set()

--- a/skill-system-foundry/scripts/lib/stats.py
+++ b/skill-system-foundry/scripts/lib/stats.py
@@ -308,7 +308,18 @@ def compute_stats(skill_path: str) -> dict:
             f"({exc.__class__.__name__}: {exc})"
         )
         return result
-    if frontmatter and "_parse_error" not in frontmatter and frontmatter.get("name"):
+    if frontmatter and "_parse_error" in frontmatter:
+        # The skill is not discoverable as-is — surface the parse error
+        # so consumers don't read the metric as a clean signal.  Stats
+        # continues anyway so the load graph (which doesn't depend on
+        # the parsed frontmatter) is still useful for debugging.
+        result["errors"].append(
+            f"{LEVEL_WARN}: [foundry] {FILE_SKILL_MD} frontmatter has a "
+            f"parse error ({frontmatter['_parse_error']}); the skill "
+            f"is not discoverable as-is — fix the frontmatter before "
+            f"trusting these numbers"
+        )
+    elif frontmatter and frontmatter.get("name"):
         result["skill"] = str(frontmatter["name"])
 
     try:

--- a/skill-system-foundry/scripts/lib/stats.py
+++ b/skill-system-foundry/scripts/lib/stats.py
@@ -339,9 +339,30 @@ def compute_stats(skill_path: str) -> dict:
         except OSError as exc:
             result["errors"].append(
                 f"{LEVEL_WARN}: [foundry] cannot read '{rel}' "
-                f"({exc.__class__.__name__}: {exc})"
+                f"({exc.__class__.__name__}: {exc}) — excluded from "
+                f"load_bytes"
             )
             return
+
+        # For markdown files, attempt the UTF-8 decode BEFORE
+        # recording in ``visited`` so that an undecodable file is
+        # excluded from ``files[]`` and ``load_bytes`` rather than
+        # being counted with a trailing WARN.  Non-markdown files
+        # (within the load-budget categories) record only their
+        # byte count — there is no body to walk.
+        is_markdown = filepath.lower().endswith(".md")
+        content: str | None = None
+        if is_markdown:
+            try:
+                with open(filepath, "r", encoding="utf-8") as f:
+                    content = f.read()
+            except (OSError, UnicodeError) as exc:
+                result["errors"].append(
+                    f"{LEVEL_WARN}: [foundry] cannot decode '{rel}' as "
+                    f"UTF-8 ({exc.__class__.__name__}: {exc}) — "
+                    f"excluded from load_bytes"
+                )
+                return
 
         parents: set[str] = set()
         if parent_rel is not None:
@@ -352,18 +373,8 @@ def compute_stats(skill_path: str) -> dict:
             "parents": parents,
         }
 
-        # Only markdown bodies carry references in the patterns we use.
-        if not filepath.lower().endswith(".md"):
-            return
-
-        try:
-            with open(filepath, "r", encoding="utf-8") as f:
-                content = f.read()
-        except (OSError, UnicodeError) as exc:
-            result["errors"].append(
-                f"{LEVEL_WARN}: [foundry] cannot decode '{rel}' as UTF-8 "
-                f"for reference scanning ({exc.__class__.__name__}: {exc})"
-            )
+        # Non-markdown: byte count recorded, nothing to walk further.
+        if content is None:
             return
 
         is_entry = filepath == os.path.abspath(skill_md)

--- a/skill-system-foundry/scripts/lib/stats.py
+++ b/skill-system-foundry/scripts/lib/stats.py
@@ -66,8 +66,8 @@ def read_bytes_count(filepath: str) -> int:
         return len(f.read())
 
 
-def discovery_bytes_for_skill_md(skill_md_path: str) -> int:
-    """Return the byte count of the YAML frontmatter block.
+def discovery_bytes_of(markdown_path: str) -> int:
+    """Return the byte count of a markdown file's YAML frontmatter block.
 
     The block runs from the opening ``---`` line through the closing
     ``---`` line, inclusive of both fences and the newlines that
@@ -75,9 +75,15 @@ def discovery_bytes_for_skill_md(skill_md_path: str) -> int:
     ``---`` opener or has no closing ``---`` — those cases are
     surfaced as findings by ``compute_stats``.
 
-    Counted from raw on-disk bytes (CRLF preserved).
+    Counted from raw on-disk bytes (CRLF preserved).  This helper
+    deliberately walks the bytes itself rather than reusing
+    ``frontmatter.split_frontmatter`` — the parser normalizes CRLF to
+    LF before splitting, which would lose the carriage returns that
+    Windows checkouts genuinely pay for at discovery time.  The
+    resulting two implementations are kept in sync by the
+    ``DiscoveryBoundaryAgreementTests`` assertion in test_stats.py.
     """
-    with open(skill_md_path, "rb") as f:
+    with open(markdown_path, "rb") as f:
         data = f.read()
     if not data.startswith(b"---"):
         return 0
@@ -244,7 +250,7 @@ def compute_stats(skill_path: str) -> dict:
     if frontmatter and "_parse_error" not in frontmatter and frontmatter.get("name"):
         result["skill"] = str(frontmatter["name"])
 
-    discovery_count = discovery_bytes_for_skill_md(skill_md)
+    discovery_count = discovery_bytes_of(skill_md)
     if discovery_count == 0:
         result["errors"].append(
             f"{LEVEL_WARN}: [foundry] {FILE_SKILL_MD} has no parseable "
@@ -260,6 +266,11 @@ def compute_stats(skill_path: str) -> dict:
     def _visit(filepath: str, parent_rel: str | None) -> None:
         filepath = os.path.abspath(filepath)
         rel = _to_skill_root_relative(filepath, skill_path)
+        # Decline at the boundary for excluded categories — scripts and
+        # assets are not loaded into the model context, so reading
+        # their bytes only to drop the row later wastes I/O.
+        if is_excluded_from_load(rel):
+            return
         if filepath in visited:
             if parent_rel is not None:
                 visited[filepath]["parents"].add(parent_rel)
@@ -347,13 +358,12 @@ def compute_stats(skill_path: str) -> dict:
 
     _visit(skill_md, None)
 
-    # Build the sorted file list and total load_bytes, filtering out
-    # categories that don't contribute to the model's context.
+    # Build the sorted file list and total load_bytes.  ``visited``
+    # already excludes scripts/assets thanks to the early-return in
+    # ``_visit``, so this loop is an unconditional aggregator.
     entries: list[dict] = []
     load_total = 0
     for state in visited.values():
-        if is_excluded_from_load(state["path"]):
-            continue
         entries.append({
             "path": state["path"],
             "bytes": state["bytes"],

--- a/skill-system-foundry/scripts/lib/stats.py
+++ b/skill-system-foundry/scripts/lib/stats.py
@@ -57,13 +57,14 @@ _RE_FENCED_BLOCK = re.compile(r"```[^\n]*\n.*?```", re.DOTALL)
 def read_bytes_count(filepath: str) -> int:
     """Return the raw on-disk byte count of *filepath*.
 
-    Reads in binary mode so CRLF is preserved (a Windows checkout of
-    the same file therefore reports a higher count than a POSIX
-    checkout).  Raises ``OSError`` on read failure; callers convert
-    that into a finding rather than letting it abort the run.
+    Uses ``os.path.getsize`` so the count is taken from the inode size
+    without reading the file contents.  CRLF terminators are preserved
+    in that count (a Windows checkout of the same file therefore
+    reports a higher size than a POSIX checkout).  Raises ``OSError``
+    on stat failure; callers convert that into a finding rather than
+    letting it abort the run.
     """
-    with open(filepath, "rb") as f:
-        return len(f.read())
+    return os.path.getsize(filepath)
 
 
 def discovery_bytes_of(markdown_path: str) -> int:
@@ -75,16 +76,21 @@ def discovery_bytes_of(markdown_path: str) -> int:
     ``---`` opener or has no closing ``---`` — those cases are
     surfaced as findings by ``compute_stats``.
 
-    Counted from raw on-disk bytes (CRLF preserved).  This helper
-    deliberately walks the bytes itself rather than reusing
+    Counted from raw on-disk bytes (CRLF preserved).  Reads in UTF-8
+    text mode with ``newline=""`` so carriage returns are not
+    swallowed by universal-newline translation, then re-encodes to
+    bytes for the byte-oriented scanner.  The text mode keeps the
+    ``encoding="utf-8"`` convention without losing the CRLF byte cost
+    that Windows checkouts genuinely pay at discovery time.
+
+    Deliberately walks the bytes rather than reusing
     ``frontmatter.split_frontmatter`` — the parser normalizes CRLF to
-    LF before splitting, which would lose the carriage returns that
-    Windows checkouts genuinely pay for at discovery time.  The
-    resulting two implementations are kept in sync by the
+    LF before splitting, which would also lose those carriage returns.
+    The two implementations are kept in sync by the
     ``DiscoveryBoundaryAgreementTests`` assertion in test_stats.py.
     """
-    with open(markdown_path, "rb") as f:
-        data = f.read()
+    with open(markdown_path, "r", encoding="utf-8", newline="") as f:
+        data = f.read().encode("utf-8")
     if not data.startswith(b"---"):
         return 0
     # Walk line by line to find the closing fence.  Track the byte

--- a/skill-system-foundry/scripts/lib/stats.py
+++ b/skill-system-foundry/scripts/lib/stats.py
@@ -1,0 +1,394 @@
+"""Token-budget measurement for a single skill.
+
+Computes two byte-based proxies for a skill's context cost:
+
+* ``discovery_bytes`` — the raw bytes of the ``SKILL.md`` YAML
+  frontmatter block, inclusive of the two ``---`` fences.  This is what
+  the harness reads at startup to decide whether the skill is relevant.
+
+* ``load_bytes`` — the raw bytes of ``SKILL.md`` plus every in-scope
+  referenced file reachable transitively from the entry point through
+  the body reference patterns defined in ``configuration.yaml``.  Files
+  under ``scripts/`` and ``assets/`` are excluded because they are not
+  loaded into the model's context during skill use; only ``SKILL.md``,
+  ``capabilities/.../capability.md``, and ``references/.../*`` count
+  toward the load budget.
+
+Bytes are not tokens.  Byte counts are not comparable across models or
+tokenizers — they are a deterministic, on-disk signal for tracking the
+relative cost of authoring decisions over time.  All counts are taken
+from the raw on-disk UTF-8 bytes (CRLF preserved); a Windows checkout
+of the same content will report higher than a POSIX checkout.
+"""
+
+import os
+import re
+
+from .constants import (
+    DIR_ASSETS,
+    DIR_CAPABILITIES,
+    DIR_SCRIPTS,
+    FILE_CAPABILITY_MD,
+    FILE_SKILL_MD,
+    LEVEL_FAIL,
+    LEVEL_INFO,
+    LEVEL_WARN,
+    RE_BACKTICK_REF,
+    RE_MARKDOWN_LINK_REF,
+)
+from .references import strip_fragment
+from .router_table import (
+    _parse_path_cell,
+    _recover_segment,
+    parse_router_table,
+)
+
+
+# Directory categories whose bytes are excluded from ``load_bytes``.
+# Scripts execute outside the model's context window; assets are
+# templates copied or rewritten by tooling, not loaded as instructions.
+_EXCLUDED_LOAD_CATEGORIES = frozenset({DIR_SCRIPTS, DIR_ASSETS})
+
+# Pattern that strips fenced code blocks before reference scanning, so
+# example links inside ``` are not treated as real references.
+_RE_FENCED_BLOCK = re.compile(r"```[^\n]*\n.*?```", re.DOTALL)
+
+
+# ===================================================================
+# File-level helpers
+# ===================================================================
+
+
+def read_bytes_count(filepath: str) -> int:
+    """Return the raw on-disk byte count of *filepath*.
+
+    Reads in binary mode so CRLF is preserved (a Windows checkout of
+    the same file therefore reports a higher count than a POSIX
+    checkout).  Raises ``OSError`` on read failure; callers convert
+    that into a finding rather than letting it abort the run.
+    """
+    with open(filepath, "rb") as f:
+        return len(f.read())
+
+
+def discovery_bytes_for_skill_md(skill_md_path: str) -> int:
+    """Return the byte count of the YAML frontmatter block.
+
+    The block runs from the opening ``---`` line through the closing
+    ``---`` line, inclusive of both fences and the newlines that
+    terminate them.  Returns ``0`` when the file does not start with a
+    ``---`` opener or has no closing ``---`` — those cases are
+    surfaced as findings by ``compute_stats``.
+
+    Counted from raw on-disk bytes (CRLF preserved).
+    """
+    with open(skill_md_path, "rb") as f:
+        data = f.read()
+    if not data.startswith(b"---"):
+        return 0
+    # Walk line by line to find the closing fence.  Track the byte
+    # offset where the closing fence's terminator ends so the count
+    # includes both fences and the newline that follows the closer.
+    offset = 0
+    line_index = 0
+    while offset < len(data):
+        newline = data.find(b"\n", offset)
+        if newline == -1:
+            line_end = len(data)
+            line = data[offset:line_end]
+            terminator_end = line_end
+        else:
+            line = data[offset:newline]
+            terminator_end = newline + 1
+        stripped = line.rstrip(b"\r")
+        if line_index > 0 and stripped == b"---":
+            return terminator_end
+        if line_index == 0 and stripped != b"---":
+            return 0
+        offset = terminator_end
+        line_index += 1
+    return 0
+
+
+# ===================================================================
+# Reference extraction
+# ===================================================================
+
+
+def extract_body_references(content: str) -> list[str]:
+    """Return cleaned reference paths from a markdown body.
+
+    Applies the body ``reference_patterns`` from ``configuration.yaml``
+    (markdown-link and backtick forms) after stripping fenced code
+    blocks, then augments the result with capability paths recovered
+    from a SKILL.md router table — those paths are bare cells, not
+    markdown links, so the body regexes alone would miss them.
+
+    Anchor fragments, queries, and title suffixes are stripped via
+    :func:`strip_fragment`.  Template placeholders (containing ``<``
+    or ``>``) are dropped.  Order is preserved as the body presents
+    them, with duplicates removed on first sight.  Router-table
+    capability paths follow whatever links were found in prose.
+    """
+    stripped = _RE_FENCED_BLOCK.sub("", content)
+    raw_refs: list[str] = []
+    raw_refs.extend(RE_MARKDOWN_LINK_REF.findall(stripped))
+    raw_refs.extend(RE_BACKTICK_REF.findall(stripped))
+    raw_refs.extend(_router_table_capability_paths(content))
+
+    seen: set[str] = set()
+    cleaned: list[str] = []
+    for ref in raw_refs:
+        if "<" in ref or ">" in ref:
+            continue
+        clean = strip_fragment(ref)
+        if not clean:
+            continue
+        if clean in seen:
+            continue
+        seen.add(clean)
+        cleaned.append(clean)
+    return cleaned
+
+
+def _router_table_capability_paths(content: str) -> list[str]:
+    """Return ``capabilities/<name>/capability.md`` paths from a router table.
+
+    Returns an empty list when *content* contains no router table or
+    when none of its rows have a recoverable canonical path cell.
+    Decoration recovery (backticks, ``[text](url)`` wrappers, leading
+    ``./``, trailing ``#fragment``) is applied so authors can decorate
+    table cells without their capabilities disappearing from the load
+    graph.
+    """
+    parsed = parse_router_table(content)
+    if parsed is None:
+        return []
+    rows, _findings = parsed
+    paths: list[str] = []
+    for _capability, _trigger, path_cell in rows:
+        # Try strict parse first, then the decoration-stripping
+        # recovery used by the router-table audit.
+        name = _parse_path_cell(path_cell.strip())
+        if name is None:
+            name = _recover_segment(path_cell)
+        if name is None:
+            continue
+        paths.append(
+            f"{DIR_CAPABILITIES}/{name}/{FILE_CAPABILITY_MD}"
+        )
+    return paths
+
+
+def category_of(rel_path: str) -> str:
+    """Return the top-level directory of a skill-root-relative path.
+
+    Returns the entry-file basename for top-level files (e.g.
+    ``"SKILL.md"``) and the leading directory name for files inside a
+    subdirectory (e.g. ``"capabilities"``, ``"references"``).
+    """
+    parts = rel_path.replace("\\", "/").split("/", 1)
+    return parts[0]
+
+
+def is_excluded_from_load(rel_path: str) -> bool:
+    """Return True when a path's bytes should not contribute to load."""
+    return category_of(rel_path) in _EXCLUDED_LOAD_CATEGORIES
+
+
+# ===================================================================
+# Stats computation
+# ===================================================================
+
+
+def _to_skill_root_relative(filepath: str, skill_root: str) -> str:
+    """Return a POSIX path relative to *skill_root* for display."""
+    rel = os.path.relpath(filepath, skill_root)
+    return rel.replace(os.sep, "/")
+
+
+def compute_stats(skill_path: str) -> dict:
+    """Compute byte-based stats for the skill rooted at *skill_path*.
+
+    Returns a dict with keys::
+
+        {
+            "skill":           str,           # skill name (frontmatter or dir basename)
+            "metric":          "bytes",
+            "discovery_bytes": int,
+            "load_bytes":      int,
+            "files":           list[dict],    # sorted by relative POSIX path
+            "errors":          list[str],     # FAIL/WARN/INFO finding strings
+        }
+
+    Each ``files`` entry has the shape::
+
+        {
+            "path":            str,                 # relative to skill root, POSIX
+            "bytes":           int,
+            "reachable_from":  list[str],           # parents, sorted alphabetically
+        }
+
+    The traversal:
+
+    * Starts at ``SKILL.md`` and follows body reference patterns.
+    * Filters out scripts/assets from ``load_bytes`` and from the
+      reported file list — they are not loaded into the model context.
+    * Visits each file at most once; duplicate references accumulate
+      additional parents in ``reachable_from`` and naturally short-
+      circuit cycles (a back-edge to an already-visited file just
+      records the extra parent and stops recursing).
+    * Produces a WARN when a referenced file is missing or unreadable
+      and continues from any other parents.
+    * Produces an INFO when a reference resolves outside the skill
+      directory (cross-skill or shared-system reference) — those files
+      are not counted toward ``load_bytes``.
+
+    A FAIL is returned only when ``SKILL.md`` itself is missing; the
+    caller treats that as an early exit via the ``errors`` list (no
+    metrics are computed).  Every other condition is recoverable.
+    """
+    skill_path = os.path.abspath(skill_path)
+    skill_md = os.path.join(skill_path, FILE_SKILL_MD)
+
+    result: dict = {
+        "skill": os.path.basename(skill_path.rstrip(os.sep)),
+        "metric": "bytes",
+        "discovery_bytes": 0,
+        "load_bytes": 0,
+        "files": [],
+        "errors": [],
+    }
+
+    if not os.path.isfile(skill_md):
+        result["errors"].append(
+            f"{LEVEL_FAIL}: [foundry] No {FILE_SKILL_MD} found in {skill_path}"
+        )
+        return result
+
+    # Best-effort skill-name resolution from frontmatter; falls back to
+    # the directory basename when frontmatter is absent or malformed.
+    # Importing lazily avoids a circular dependency through constants.
+    from .frontmatter import load_frontmatter
+
+    frontmatter, _body, _scalar_findings = load_frontmatter(skill_md)
+    if frontmatter and "_parse_error" not in frontmatter and frontmatter.get("name"):
+        result["skill"] = str(frontmatter["name"])
+
+    discovery_count = discovery_bytes_for_skill_md(skill_md)
+    if discovery_count == 0:
+        result["errors"].append(
+            f"{LEVEL_WARN}: [foundry] {FILE_SKILL_MD} has no parseable "
+            f"frontmatter block; discovery_bytes recorded as 0"
+        )
+    result["discovery_bytes"] = discovery_count
+
+    # ``visited`` keys are absolute paths; values capture per-file
+    # state (relative path, byte count, parent set).  Reading happens
+    # once per file regardless of how many parents reach it.
+    visited: dict[str, dict] = {}
+
+    def _visit(filepath: str, parent_rel: str | None) -> None:
+        filepath = os.path.abspath(filepath)
+        rel = _to_skill_root_relative(filepath, skill_path)
+        if filepath in visited:
+            if parent_rel is not None:
+                visited[filepath]["parents"].add(parent_rel)
+            return
+
+        try:
+            byte_count = read_bytes_count(filepath)
+        except OSError as exc:
+            result["errors"].append(
+                f"{LEVEL_WARN}: [foundry] cannot read '{rel}' "
+                f"({exc.__class__.__name__}: {exc})"
+            )
+            return
+
+        parents: set[str] = set()
+        if parent_rel is not None:
+            parents.add(parent_rel)
+        visited[filepath] = {
+            "path": rel,
+            "bytes": byte_count,
+            "parents": parents,
+        }
+
+        # Only markdown bodies carry references in the patterns we use.
+        if not filepath.lower().endswith(".md"):
+            return
+
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                content = f.read()
+        except (OSError, UnicodeError) as exc:
+            result["errors"].append(
+                f"{LEVEL_WARN}: [foundry] cannot decode '{rel}' as UTF-8 "
+                f"for reference scanning ({exc.__class__.__name__}: {exc})"
+            )
+            return
+
+        for ref in extract_body_references(content):
+            if os.path.isabs(ref):
+                result["errors"].append(
+                    f"{LEVEL_WARN}: [foundry] absolute reference '{ref}' "
+                    f"in '{rel}' skipped — references must be relative"
+                )
+                continue
+            ref_norm = ref.replace("\\", "/")
+            if ".." in ref_norm.split("/"):
+                result["errors"].append(
+                    f"{LEVEL_WARN}: [foundry] reference '{ref}' in '{rel}' "
+                    f"uses parent traversal — skipped from stats"
+                )
+                continue
+
+            ref_abs = os.path.normpath(os.path.join(skill_path, ref_norm))
+            ref_rel = _to_skill_root_relative(ref_abs, skill_path)
+
+            # External / cross-skill references resolve outside the
+            # skill root; report once and skip — they are not part of
+            # this skill's load budget.
+            if ref_rel.startswith(".."):
+                result["errors"].append(
+                    f"{LEVEL_INFO}: [foundry] reference '{ref}' in '{rel}' "
+                    f"resolves outside the skill directory — excluded "
+                    f"from load_bytes"
+                )
+                continue
+
+            if not os.path.exists(ref_abs):
+                result["errors"].append(
+                    f"{LEVEL_WARN}: [foundry] reference '{ref}' in '{rel}' "
+                    f"does not exist — excluded from load_bytes"
+                )
+                continue
+            if not os.path.isfile(ref_abs):
+                result["errors"].append(
+                    f"{LEVEL_WARN}: [foundry] reference '{ref}' in '{rel}' "
+                    f"is not a regular file — excluded from load_bytes"
+                )
+                continue
+
+            _visit(ref_abs, rel)
+
+    _visit(skill_md, None)
+
+    # Build the sorted file list and total load_bytes, filtering out
+    # categories that don't contribute to the model's context.
+    entries: list[dict] = []
+    load_total = 0
+    for state in visited.values():
+        if is_excluded_from_load(state["path"]):
+            continue
+        entries.append({
+            "path": state["path"],
+            "bytes": state["bytes"],
+            "reachable_from": sorted(state["parents"]),
+        })
+        load_total += state["bytes"]
+
+    entries.sort(key=lambda entry: entry["path"])
+    result["files"] = entries
+    result["load_bytes"] = load_total
+    return result

--- a/skill-system-foundry/scripts/stats.py
+++ b/skill-system-foundry/scripts/stats.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Report a skill's token-budget proxies (discovery + load bytes).
+
+Usage:
+    python scripts/stats.py <skill-path>
+    python scripts/stats.py skill-system-foundry/
+    python scripts/stats.py skill-system-foundry/ --json
+    python scripts/stats.py skill-system-foundry/ --verbose
+
+Two byte-based proxies are reported:
+
+* ``discovery_bytes`` — the SKILL.md YAML frontmatter block (between
+  and including the ``---`` fences).  This is what the harness reads
+  at startup to decide whether to surface the skill.
+
+* ``load_bytes`` — SKILL.md plus every transitively reachable
+  ``capabilities/**/capability.md`` and ``references/**/*`` file.
+  ``scripts/`` and ``assets/`` are excluded — they are not loaded into
+  the model's context during skill use.
+
+Bytes are not tokens.  Counts are not comparable across models or
+tokenizers — they are a deterministic on-disk signal for tracking the
+relative cost of authoring decisions over time.  Counts are taken
+from raw on-disk UTF-8 bytes (CRLF preserved); a Windows checkout of
+the same content reports a higher count than a POSIX checkout.
+"""
+
+import argparse
+import os
+import sys
+
+_scripts_dir = os.path.dirname(os.path.abspath(__file__))
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+from lib.constants import LEVEL_FAIL, SEPARATOR_WIDTH
+from lib.reporting import (
+    categorize_errors,
+    categorize_errors_for_json,
+    print_error_line,
+    print_summary,
+    to_json_output,
+)
+from lib.stats import compute_stats
+
+
+def _format_bytes(value: int) -> str:
+    """Render *value* with thousands separators for the human table."""
+    return f"{value:,} B"
+
+
+def _print_human(result: dict, verbose: bool) -> None:
+    """Print the default human-readable report.
+
+    Two sections: a header (skill name + totals) and a per-file table
+    sorted alphabetically.  Findings — when present — print after the
+    table in the same format the other entry points use.  ``verbose``
+    expands the ``reachable_from`` column to show every parent rather
+    than just the first one.
+    """
+    print(f"Skill: {result['skill']}")
+    print(f"Metric: {result['metric']}")
+    print(f"Discovery: {_format_bytes(result['discovery_bytes'])}")
+    print(
+        f"Load:      {_format_bytes(result['load_bytes'])} "
+        f"({len(result['files'])} files)"
+    )
+    print("-" * SEPARATOR_WIDTH)
+
+    if result["files"]:
+        # Right-align byte counts; left-align paths.  The path column
+        # widens to fit the longest entry, capped at 60 chars to keep
+        # the line readable on narrow terminals.
+        max_path_width = max(len(entry["path"]) for entry in result["files"])
+        path_width = min(max_path_width, 60)
+        for entry in result["files"]:
+            parents = entry["reachable_from"]
+            if not parents:
+                arrow = ""
+            elif verbose or len(parents) == 1:
+                arrow = "  ← " + ", ".join(parents)
+            else:
+                arrow = (
+                    f"  ← {parents[0]} (+{len(parents) - 1} more)"
+                )
+            print(
+                f"{entry['path']:<{path_width}}  "
+                f"{_format_bytes(entry['bytes']):>10}{arrow}"
+            )
+
+    if result["errors"]:
+        print("-" * SEPARATOR_WIDTH)
+        for error in result["errors"]:
+            print_error_line(error)
+        fails, warns, infos = categorize_errors(result["errors"])
+        print("-" * SEPARATOR_WIDTH)
+        print_summary(fails, warns, infos)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Report token-budget proxies (discovery + load bytes) for "
+            "a single skill.  Bytes are not tokens — they are a "
+            "deterministic on-disk signal, not a tokenizer-accurate "
+            "estimate.  CRLF is preserved in the count, so Windows "
+            "checkouts report higher than POSIX checkouts of the "
+            "same content."
+        ),
+        epilog=(
+            "Examples:\n"
+            "  python scripts/stats.py skill-system-foundry/\n"
+            "  python scripts/stats.py skill-system-foundry/ --json\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "skill_path",
+        help="Path to the skill directory (must contain SKILL.md).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Emit machine-readable JSON.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help=(
+            "Expand the reachable_from column to list every parent "
+            "rather than just the first."
+        ),
+    )
+    return parser
+
+
+def main() -> None:
+    _json_mode = "--json" in sys.argv
+
+    if len(sys.argv) == 1:
+        print(__doc__)
+        sys.exit(1)
+
+    parser = _build_parser()
+
+    def _json_aware_error(message: str) -> None:
+        if _json_mode:
+            print(to_json_output({
+                "tool": "stats",
+                "success": False,
+                "error": message,
+            }))
+            sys.exit(1)
+        parser.print_usage(sys.stderr)
+        print(f"{parser.prog}: error: {message}", file=sys.stderr)
+        sys.exit(1)
+
+    parser.error = _json_aware_error  # type: ignore[assignment]
+
+    args = parser.parse_args()
+    skill_path: str = args.skill_path
+    json_output: bool = args.json_output
+    verbose: bool = args.verbose
+
+    if not os.path.isdir(skill_path):
+        if json_output:
+            print(to_json_output({
+                "tool": "stats",
+                "path": os.path.abspath(skill_path),
+                "success": False,
+                "error": f"'{skill_path}' is not a directory",
+            }))
+        else:
+            print(f"Error: '{skill_path}' is not a directory")
+        sys.exit(1)
+
+    result = compute_stats(skill_path)
+    fails, warns, infos = categorize_errors(result["errors"])
+
+    if json_output:
+        payload = {
+            "tool": "stats",
+            "path": os.path.abspath(skill_path),
+            "success": len(fails) == 0,
+            "skill": result["skill"],
+            "metric": result["metric"],
+            "discovery_bytes": result["discovery_bytes"],
+            "load_bytes": result["load_bytes"],
+            "files": result["files"],
+            "summary": {
+                "failures": len(fails),
+                "warnings": len(warns),
+                "info": len(infos),
+                "files": len(result["files"]),
+            },
+            "errors": categorize_errors_for_json(result["errors"]),
+        }
+        print(to_json_output(payload))
+        sys.exit(1 if fails else 0)
+
+    # Early-exit human path: a FAIL means SKILL.md is missing.
+    if fails and not result["files"]:
+        for error in result["errors"]:
+            print_error_line(error)
+        sys.exit(1)
+
+    _print_human(result, verbose)
+    sys.exit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skill-system-foundry/scripts/stats.py
+++ b/skill-system-foundry/scripts/stats.py
@@ -13,10 +13,13 @@ Two byte-based proxies are reported:
   and including the ``---`` fences).  This is what the harness reads
   at startup to decide whether to surface the skill.
 
-* ``load_bytes`` — SKILL.md plus every transitively reachable
-  ``capabilities/**/capability.md`` and ``references/**/*`` file.
-  ``scripts/`` and ``assets/`` are excluded — they are not loaded into
-  the model's context during skill use.
+* ``load_bytes`` — SKILL.md plus every transitively reachable file
+  under ``capabilities/`` or ``references/``, excluding ``scripts/``
+  and ``assets/``.  That covers capability entry points
+  (``capabilities/<name>/capability.md``), capability-local resources
+  (``capabilities/<name>/references/<doc>.md``), and shared
+  references (``references/<doc>.md``).  Excluded categories are
+  not loaded into the model's context during skill use.
 
 Bytes are not tokens.  Counts are not comparable across models or
 tokenizers — they are a deterministic on-disk signal for tracking the

--- a/skill-system-foundry/scripts/stats.py
+++ b/skill-system-foundry/scripts/stats.py
@@ -68,9 +68,14 @@ def _print_human(result: dict, verbose: bool) -> None:
     print("-" * SEPARATOR_WIDTH)
 
     if result["files"]:
-        # Right-align byte counts; left-align paths.  The path column
-        # widens to fit the longest entry, capped at 60 chars to keep
-        # the line readable on narrow terminals.
+        # Right-align byte counts; left-align paths.  ``path_width`` is
+        # the *minimum* column width: short paths get padded out to it,
+        # but a path longer than 60 chars prints at its natural length
+        # and pushes the byte-count column to the right on that line
+        # only.  The 60-char ceiling on the padding bound keeps the
+        # table readable on narrow terminals when a single very long
+        # path would otherwise force every short row to be padded out
+        # to match.
         max_path_width = max(len(entry["path"]) for entry in result["files"])
         path_width = min(max_path_width, 60)
         for entry in result["files"]:

--- a/skill-system-foundry/scripts/stats.py
+++ b/skill-system-foundry/scripts/stats.py
@@ -33,7 +33,7 @@ _scripts_dir = os.path.dirname(os.path.abspath(__file__))
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
 
-from lib.constants import LEVEL_FAIL, SEPARATOR_WIDTH
+from lib.constants import SEPARATOR_WIDTH
 from lib.reporting import (
     categorize_errors,
     categorize_errors_for_json,

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -330,15 +330,24 @@ def validate_body(
 
 def validate_skill_references(
     skill_path: str, skill_root: str, entry_file: str,
+    allow_nested_refs: bool = False,
 ) -> tuple[list[str], list[str]]:
     """Validate references in all markdown files across the skill tree.
 
     Walks *skill_path*, reads each ``.md`` file, and checks that all
     intra-skill references resolve from *skill_root*.  The entry file
     (*entry_file*) is skipped because it is already validated by
-    :func:`validate_body`.  Nested-reference depth checks are always
-    skipped for non-entry files because the spec constrains nesting
-    from entry points only.
+    :func:`validate_body`.
+
+    Nested-reference depth checks are skipped for plain reference and
+    asset files (the spec constrains depth from entry points only),
+    but ``capability.md`` files are themselves entry points under the
+    foundry's router-skill convention — their own one-hop boundary is
+    enforced when *allow_nested_refs* is False, matching how the
+    parent ``SKILL.md`` is validated.  This catches chains like
+    ``SKILL.md -> capabilities/x/capability.md -> references/a.md ->
+    references/b.md`` that would otherwise slip past the audit
+    because the parent's own check stops at the capability boundary.
     """
     errors: list[str] = []
     passes: list[str] = []
@@ -365,9 +374,24 @@ def validate_skill_references(
                 continue
 
             rel_label = os.path.relpath(filepath, skill_root)
+            # Capability entry points get the same one-hop boundary
+            # treatment as the parent SKILL.md — mirror the user's
+            # ``--allow-nested-references`` flag.  Non-capability,
+            # non-entry files are not subject to the depth rule.
+            rel_to_root = os.path.relpath(filepath, skill_root).replace(
+                os.sep, "/",
+            )
+            rel_parts = rel_to_root.split("/")
+            is_capability_entry = (
+                len(rel_parts) == 3
+                and rel_parts[0] == DIR_CAPABILITIES
+                and rel_parts[2] == FILE_CAPABILITY_MD
+            )
+            file_allow_nested = (
+                allow_nested_refs if is_capability_entry else True
+            )
             file_errors, _file_passes = _check_references(
-                content, rel_label, skill_root,
-                True,  # nested refs allowed in non-entry files; spec constrains depth from entry points only
+                content, rel_label, skill_root, file_allow_nested,
             )
 
             files_checked += 1
@@ -464,7 +488,7 @@ def validate_skill(
         # Validate references in all .md files across the skill tree
         # (walk skill_root, not skill_path, so the entire skill is scanned)
         ref_errors, ref_passes = validate_skill_references(
-            skill_root, skill_root, skill_md,
+            skill_root, skill_root, skill_md, allow_nested_refs,
         )
         errors.extend(ref_errors)
         passes.extend(ref_passes)
@@ -547,7 +571,7 @@ def validate_skill(
 
     # Validate references in all other .md files in the skill tree
     sref_errors, sref_passes = validate_skill_references(
-        skill_path, skill_root, skill_md,
+        skill_path, skill_root, skill_md, allow_nested_refs,
     )
     errors.extend(sref_errors)
     passes.extend(sref_passes)

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -47,6 +47,7 @@ from lib.constants import (
     RE_SECOND_PERSON, RE_IMPERATIVE_START,
     RE_MARKDOWN_LINK_REF, RE_BACKTICK_REF,
     RECOGNIZED_DIRS,
+    DIR_CAPABILITIES,
     FILE_SKILL_MD, FILE_CAPABILITY_MD, SEPARATOR_WIDTH,
     EXT_MARKDOWN,
     LEVEL_FAIL, LEVEL_WARN, LEVEL_INFO,
@@ -245,8 +246,21 @@ def _check_references(
         # a capability body that reach into references/ are first-
         # level under that entry point, not nested under the parent
         # SKILL.md.  Skip the recursion in that case.
+        #
+        # Match the canonical three-segment shape exactly —
+        # capabilities/<name>/capability.md relative to the skill
+        # root.  An unrelated reference file or asset that happens
+        # to be named capability.md (e.g., references/capability.md)
+        # is NOT a spec entry point and must still have its own
+        # links checked for nesting.
+        rel_to_root = os.path.relpath(ref_path, skill_root).replace(
+            os.sep, "/",
+        )
+        rel_parts = rel_to_root.split("/")
         is_capability_entry = (
-            os.path.basename(ref_path) == FILE_CAPABILITY_MD
+            len(rel_parts) == 3
+            and rel_parts[0] == DIR_CAPABILITIES
+            and rel_parts[2] == FILE_CAPABILITY_MD
         )
         if not allow_nested_refs and not is_capability_entry:
             # Strip fenced code blocks from referenced content so example

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -362,26 +362,29 @@ def validate_skill_references(
             if os.path.abspath(filepath) == entry_abs:
                 continue
 
+            # Build the cross-platform display label up front so every
+            # finding (read error, nested-ref WARN) uses the POSIX form
+            # — Windows runners would otherwise emit backslash paths in
+            # WARN messages, which is inconsistent with the rest of the
+            # codebase and breaks substring assertions in tests.
+            rel_label = os.path.relpath(filepath, skill_root).replace(
+                os.sep, "/",
+            )
             try:
                 with open(filepath, "r", encoding="utf-8") as f:
                     content = f.read()
             except (OSError, UnicodeError) as exc:
-                rel_label = os.path.relpath(filepath, skill_root)
                 errors.append(
                     f"{LEVEL_WARN}: [spec] '{rel_label}' cannot be read "
                     f"({exc.__class__.__name__}: {exc})"
                 )
                 continue
 
-            rel_label = os.path.relpath(filepath, skill_root)
             # Capability entry points get the same one-hop boundary
             # treatment as the parent SKILL.md — mirror the user's
             # ``--allow-nested-references`` flag.  Non-capability,
             # non-entry files are not subject to the depth rule.
-            rel_to_root = os.path.relpath(filepath, skill_root).replace(
-                os.sep, "/",
-            )
-            rel_parts = rel_to_root.split("/")
+            rel_parts = rel_label.split("/")
             is_capability_entry = (
                 len(rel_parts) == 3
                 and rel_parts[0] == DIR_CAPABILITIES

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -240,18 +240,20 @@ def _check_references(
             continue
 
         # Nested reference check — only when flag is not set.
-        # capability.md is its own entry point per the spec ("cross-
-        # references stay one level deep from each entry point —
-        # entry points are SKILL.md and capability.md"), so links in
-        # a capability body that reach into references/ are first-
-        # level under that entry point, not nested under the parent
-        # SKILL.md.  Skip the recursion in that case.
+        # The agentskills.io spec only requires references to stay
+        # one level deep from SKILL.md.  The foundry extends this
+        # convention so that ``capability.md`` is also treated as
+        # an entry point with its own one-hop scope (see
+        # ``.github/instructions/markdown.instructions.md``):
+        # links from a capability body that reach into ``references/``
+        # are first-level under that entry point, not nested under
+        # the parent SKILL.md.  Skip the recursion in that case.
         #
         # Match the canonical three-segment shape exactly —
         # capabilities/<name>/capability.md relative to the skill
         # root.  An unrelated reference file or asset that happens
         # to be named capability.md (e.g., references/capability.md)
-        # is NOT a spec entry point and must still have its own
+        # is NOT a foundry entry point and must still have its own
         # links checked for nesting.
         rel_to_root = os.path.relpath(ref_path, skill_root).replace(
             os.sep, "/",

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -238,8 +238,17 @@ def _check_references(
             )
             continue
 
-        # Nested reference check — only when flag is not set
-        if not allow_nested_refs:
+        # Nested reference check — only when flag is not set.
+        # capability.md is its own entry point per the spec ("cross-
+        # references stay one level deep from each entry point —
+        # entry points are SKILL.md and capability.md"), so links in
+        # a capability body that reach into references/ are first-
+        # level under that entry point, not nested under the parent
+        # SKILL.md.  Skip the recursion in that case.
+        is_capability_entry = (
+            os.path.basename(ref_path) == FILE_CAPABILITY_MD
+        )
+        if not allow_nested_refs and not is_capability_entry:
             # Strip fenced code blocks from referenced content so example
             # links inside ``` don't trigger false nested-reference WARNs.
             ref_stripped = re.sub(

--- a/tests/test_router_table.py
+++ b/tests/test_router_table.py
@@ -20,6 +20,7 @@ from lib.constants import LEVEL_FAIL, LEVEL_WARN
 from lib.router_table import (
     audit_router_table,
     expected_path,
+    extract_capability_paths,
     parse_router_table,
 )
 
@@ -759,6 +760,54 @@ class StripFencedRegionsTests(unittest.TestCase):
             + "   ```\n"
         )
         self.assertIsNone(parse_router_table(body))
+
+
+class ExtractCapabilityPathsTests(unittest.TestCase):
+    """Tests for the public ``extract_capability_paths`` helper.
+
+    Stats (and any future load-graph tooling) consumes router-table
+    capability paths through this helper rather than reimplementing the
+    strict + recovery cascade owned by this module.
+    """
+
+    def test_no_router_table_returns_empty(self) -> None:
+        body = "# Skill\n\nNo router table here.\n"
+        self.assertEqual(extract_capability_paths(body), [])
+
+    def test_canonical_rows_yield_canonical_paths(self) -> None:
+        body = "# Skill\n\n" + CANONICAL_TABLE
+        self.assertEqual(
+            extract_capability_paths(body),
+            [
+                "capabilities/alpha/capability.md",
+                "capabilities/beta/capability.md",
+            ],
+        )
+
+    def test_decorated_path_cell_recovered_via_audit_helper(self) -> None:
+        """Backtick-wrapped path cells fall through to the recovery
+        cascade and still produce the canonical path."""
+        body = (
+            "# Skill\n\n"
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| design | when | `capabilities/design/capability.md` |\n"
+        )
+        self.assertEqual(
+            extract_capability_paths(body),
+            ["capabilities/design/capability.md"],
+        )
+
+    def test_unrecoverable_path_cell_dropped(self) -> None:
+        """A path cell that does not match the canonical shape and
+        cannot be recovered is silently dropped."""
+        body = (
+            "# Skill\n\n"
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| design | when | totally-wrong-path |\n"
+        )
+        self.assertEqual(extract_capability_paths(body), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,521 @@
+"""Tests for skill-system-foundry/scripts/lib/stats.py.
+
+Covers byte counting, frontmatter discovery boundaries, the load
+graph traversal (capabilities + references), the scripts/assets load
+filter, alphabetical sort order, multi-parent ``reachable_from``
+aggregation, broken-reference findings, cycle handling, and external
+reference handling.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+from helpers import write_text, write_skill_md
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__), "..", "skill-system-foundry", "scripts",
+    )
+)
+
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.stats import (
+    category_of,
+    compute_stats,
+    discovery_bytes_for_skill_md,
+    extract_body_references,
+    is_excluded_from_load,
+    read_bytes_count,
+)
+from lib.constants import LEVEL_FAIL, LEVEL_INFO, LEVEL_WARN
+
+
+# ============================================================
+# Byte counting primitives
+# ============================================================
+
+
+class ReadBytesCountTests(unittest.TestCase):
+    """Tests for ``read_bytes_count``."""
+
+    def test_counts_raw_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "file.md")
+            with open(path, "wb") as f:
+                f.write(b"hello\n")
+            self.assertEqual(read_bytes_count(path), 6)
+
+    def test_crlf_counted_as_two_bytes(self) -> None:
+        """CRLF preserved on disk → byte count is higher than LF-only."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "file.md")
+            with open(path, "wb") as f:
+                f.write(b"hello\r\nworld\r\n")
+            self.assertEqual(read_bytes_count(path), 14)
+
+    def test_utf8_multibyte_chars_counted_as_bytes_not_codepoints(self) -> None:
+        """A 4-byte UTF-8 emoji counts as 4, not 1."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "file.md")
+            with open(path, "wb") as f:
+                f.write("\U0001f600".encode("utf-8"))
+            self.assertEqual(read_bytes_count(path), 4)
+
+
+# ============================================================
+# Discovery bytes (frontmatter block)
+# ============================================================
+
+
+class DiscoveryBytesTests(unittest.TestCase):
+    """Tests for ``discovery_bytes_for_skill_md``."""
+
+    def test_inclusive_of_both_fences(self) -> None:
+        """Block runs from opening --- to closing --- inclusive."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "SKILL.md")
+            content = "---\nname: x\ndescription: y\n---\n# Body\n"
+            with open(path, "wb") as f:
+                f.write(content.encode("utf-8"))
+            # "---\n" (4) + "name: x\n" (8) + "description: y\n" (15)
+            # + "---\n" (4) = 31
+            self.assertEqual(discovery_bytes_for_skill_md(path), 31)
+
+    def test_no_frontmatter_returns_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "SKILL.md")
+            with open(path, "wb") as f:
+                f.write(b"# Just a body\n")
+            self.assertEqual(discovery_bytes_for_skill_md(path), 0)
+
+    def test_unclosed_frontmatter_returns_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "SKILL.md")
+            with open(path, "wb") as f:
+                f.write(b"---\nname: x\nno closer here\n")
+            self.assertEqual(discovery_bytes_for_skill_md(path), 0)
+
+    def test_crlf_frontmatter_counted_with_carriage_returns(self) -> None:
+        """CRLF terminators contribute to the byte count."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "SKILL.md")
+            with open(path, "wb") as f:
+                f.write(b"---\r\nname: x\r\n---\r\n# Body\r\n")
+            # Each line gets +1 byte for the CR.  4 lines in the
+            # frontmatter block → +3 bytes vs. the LF-only count
+            # (the body's \r\n is excluded).
+            # LF-only count for the same content would be 18:
+            # "---\n" (4) + "name: x\n" (8) + "---\n" (4) + "...".
+            # Actually the LF-only block is 4+8+4 = 16; +3 CRs = 19.
+            self.assertEqual(discovery_bytes_for_skill_md(path), 19)
+
+
+# ============================================================
+# Reference extraction helpers
+# ============================================================
+
+
+class ExtractBodyReferencesTests(unittest.TestCase):
+    """Tests for ``extract_body_references``."""
+
+    def test_capability_link_detected(self) -> None:
+        body = "[design](capabilities/design/capability.md)"
+        self.assertIn(
+            "capabilities/design/capability.md",
+            extract_body_references(body),
+        )
+
+    def test_reference_link_detected(self) -> None:
+        body = "[guide](references/guide.md)"
+        self.assertIn("references/guide.md", extract_body_references(body))
+
+    def test_backtick_reference_detected(self) -> None:
+        body = "see `references/guide.md` for details"
+        self.assertIn("references/guide.md", extract_body_references(body))
+
+    def test_fenced_block_refs_ignored(self) -> None:
+        body = (
+            "Real: [g](references/real.md)\n"
+            "```markdown\n"
+            "[fake](references/fake.md)\n"
+            "```\n"
+        )
+        refs = extract_body_references(body)
+        self.assertIn("references/real.md", refs)
+        self.assertNotIn("references/fake.md", refs)
+
+    def test_template_placeholders_dropped(self) -> None:
+        body = "[x](references/<placeholder>.md) and [y](references/real.md)"
+        refs = extract_body_references(body)
+        self.assertNotIn("references/<placeholder>.md", refs)
+        self.assertIn("references/real.md", refs)
+
+    def test_anchor_fragments_stripped(self) -> None:
+        body = "[g](references/guide.md#section)"
+        self.assertEqual(
+            extract_body_references(body), ["references/guide.md"]
+        )
+
+    def test_duplicates_removed_in_first_seen_order(self) -> None:
+        body = (
+            "[a](references/a.md)\n"
+            "[b](references/b.md)\n"
+            "`references/a.md`\n"
+        )
+        self.assertEqual(
+            extract_body_references(body),
+            ["references/a.md", "references/b.md"],
+        )
+
+    def test_external_path_not_matched_by_patterns(self) -> None:
+        """README.md and similar top-level files are not in scope."""
+        body = "[r](README.md) [g](references/guide.md)"
+        refs = extract_body_references(body)
+        self.assertNotIn("README.md", refs)
+        self.assertIn("references/guide.md", refs)
+
+    def test_router_table_capability_paths_extracted(self) -> None:
+        """Bare capability paths in a router-table cell are picked up."""
+        body = (
+            "# Skill\n\n"
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| design | when designing | "
+            "capabilities/design/capability.md |\n"
+            "| validation | when validating | "
+            "capabilities/validation/capability.md |\n"
+        )
+        refs = extract_body_references(body)
+        self.assertIn("capabilities/design/capability.md", refs)
+        self.assertIn("capabilities/validation/capability.md", refs)
+
+    def test_router_table_decorated_path_cell_recovered(self) -> None:
+        """Backtick-wrapped router-table path cells are still recovered."""
+        body = (
+            "# Skill\n\n"
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| design | when | `capabilities/design/capability.md` |\n"
+        )
+        refs = extract_body_references(body)
+        self.assertIn("capabilities/design/capability.md", refs)
+
+
+class CategoryHelpersTests(unittest.TestCase):
+    """Tests for ``category_of`` and ``is_excluded_from_load``."""
+
+    def test_top_level_file_returns_basename(self) -> None:
+        self.assertEqual(category_of("SKILL.md"), "SKILL.md")
+
+    def test_subdirectory_returns_first_segment(self) -> None:
+        self.assertEqual(
+            category_of("capabilities/design/capability.md"), "capabilities",
+        )
+        self.assertEqual(
+            category_of("references/guide.md"), "references",
+        )
+
+    def test_scripts_excluded_from_load(self) -> None:
+        self.assertTrue(is_excluded_from_load("scripts/foo.py"))
+
+    def test_assets_excluded_from_load(self) -> None:
+        self.assertTrue(is_excluded_from_load("assets/template.md"))
+
+    def test_skill_md_not_excluded(self) -> None:
+        self.assertFalse(is_excluded_from_load("SKILL.md"))
+
+    def test_capabilities_not_excluded(self) -> None:
+        self.assertFalse(
+            is_excluded_from_load("capabilities/design/capability.md")
+        )
+
+    def test_references_not_excluded(self) -> None:
+        self.assertFalse(is_excluded_from_load("references/guide.md"))
+
+
+# ============================================================
+# compute_stats end-to-end
+# ============================================================
+
+
+class ComputeStatsBasicTests(unittest.TestCase):
+    """Tests for the basic happy path of ``compute_stats``."""
+
+    def test_missing_skill_md_returns_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = compute_stats(tmpdir)
+        self.assertEqual(result["discovery_bytes"], 0)
+        self.assertEqual(result["load_bytes"], 0)
+        self.assertEqual(result["files"], [])
+        fails = [e for e in result["errors"] if e.startswith(LEVEL_FAIL)]
+        self.assertEqual(len(fails), 1)
+        self.assertIn("No SKILL.md", fails[0])
+
+    def test_skill_md_only_no_refs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(tmpdir, body="# Skill body\n")
+            result = compute_stats(tmpdir)
+            skill_md_bytes = read_bytes_count(
+                os.path.join(tmpdir, "SKILL.md")
+            )
+        self.assertEqual(result["metric"], "bytes")
+        self.assertEqual(result["skill"], "demo-skill")
+        self.assertEqual(len(result["files"]), 1)
+        self.assertEqual(result["files"][0]["path"], "SKILL.md")
+        self.assertEqual(result["files"][0]["reachable_from"], [])
+        self.assertEqual(result["load_bytes"], skill_md_bytes)
+        # discovery_bytes is non-zero (frontmatter present)
+        self.assertGreater(result["discovery_bytes"], 0)
+        # No findings — clean run
+        self.assertEqual(result["errors"], [])
+
+    def test_skill_name_from_directory_when_frontmatter_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_dir = os.path.join(tmpdir, "my-skill")
+            write_text(
+                os.path.join(skill_dir, "SKILL.md"),
+                "# Skill without frontmatter\n",
+            )
+            result = compute_stats(skill_dir)
+        self.assertEqual(result["skill"], "my-skill")
+        # discovery WARN since no frontmatter
+        warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
+        self.assertTrue(any("frontmatter" in w for w in warns))
+
+
+class ComputeStatsGraphTests(unittest.TestCase):
+    """Tests for transitive load-graph traversal."""
+
+    def test_capability_and_reference_files_included(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body=(
+                    "# Skill\n\n"
+                    "See [design](capabilities/design/capability.md) "
+                    "and [guide](references/guide.md).\n"
+                ),
+            )
+            write_text(
+                os.path.join(tmpdir, "capabilities", "design", "capability.md"),
+                "# Design\n\nCapability body.\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "guide.md"),
+                "# Guide\n\nReference body.\n",
+            )
+            result = compute_stats(tmpdir)
+            paths = [entry["path"] for entry in result["files"]]
+            expected_load = sum(
+                read_bytes_count(os.path.join(tmpdir, p)) for p in paths
+            )
+        self.assertIn("SKILL.md", paths)
+        self.assertIn("capabilities/design/capability.md", paths)
+        self.assertIn("references/guide.md", paths)
+        # Sorted alphabetically by POSIX path
+        self.assertEqual(paths, sorted(paths))
+        # Reachable-from points back to SKILL.md for both children
+        for entry in result["files"]:
+            if entry["path"] == "SKILL.md":
+                self.assertEqual(entry["reachable_from"], [])
+            else:
+                self.assertEqual(entry["reachable_from"], ["SKILL.md"])
+        self.assertEqual(result["load_bytes"], expected_load)
+
+    def test_transitive_reference_followed(self) -> None:
+        """Reference files that link to other reference files are followed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body="# Skill\n\nSee [a](references/a.md).\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "a.md"),
+                "# A\n\nSee [b](references/b.md).\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "b.md"),
+                "# B\n\nLeaf.\n",
+            )
+            result = compute_stats(tmpdir)
+        paths = [entry["path"] for entry in result["files"]]
+        self.assertIn("references/b.md", paths)
+        b_entry = next(
+            entry for entry in result["files"]
+            if entry["path"] == "references/b.md"
+        )
+        self.assertEqual(b_entry["reachable_from"], ["references/a.md"])
+
+    def test_scripts_and_assets_excluded_from_load(self) -> None:
+        """A scripts/ or assets/ link does not contribute to load_bytes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body=(
+                    "# Skill\n\n"
+                    "Run `scripts/runner.py` and use "
+                    "[tmpl](assets/template.md).\n"
+                ),
+            )
+            write_text(
+                os.path.join(tmpdir, "scripts", "runner.py"),
+                "print('hi')\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "assets", "template.md"),
+                "# Template body.\n",
+            )
+            result = compute_stats(tmpdir)
+            skill_bytes = read_bytes_count(os.path.join(tmpdir, "SKILL.md"))
+        paths = [entry["path"] for entry in result["files"]]
+        self.assertNotIn("scripts/runner.py", paths)
+        self.assertNotIn("assets/template.md", paths)
+        self.assertEqual(paths, ["SKILL.md"])
+        self.assertEqual(result["load_bytes"], skill_bytes)
+
+    def test_multiple_parents_aggregated_and_sorted(self) -> None:
+        """A file referenced from two parents lists both, sorted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body=(
+                    "# Skill\n\n"
+                    "See [a](capabilities/a/capability.md) "
+                    "and [b](capabilities/b/capability.md).\n"
+                ),
+            )
+            shared = "shared body\nlink to [s](references/shared.md)\n"
+            write_text(
+                os.path.join(tmpdir, "capabilities", "a", "capability.md"),
+                shared,
+            )
+            write_text(
+                os.path.join(tmpdir, "capabilities", "b", "capability.md"),
+                shared,
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "shared.md"),
+                "shared\n",
+            )
+            result = compute_stats(tmpdir)
+        shared_entry = next(
+            entry for entry in result["files"]
+            if entry["path"] == "references/shared.md"
+        )
+        self.assertEqual(
+            shared_entry["reachable_from"],
+            [
+                "capabilities/a/capability.md",
+                "capabilities/b/capability.md",
+            ],
+        )
+
+    def test_cycle_short_circuits_without_infinite_recursion(self) -> None:
+        """A back-edge to an already-visited file just records the parent."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body="# Skill\n\nSee [a](references/a.md).\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "a.md"),
+                "# A\n\nSee [b](references/b.md).\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "b.md"),
+                "# B\n\nSee [a](references/a.md).\n",
+            )
+            result = compute_stats(tmpdir)
+        a_entry = next(
+            entry for entry in result["files"]
+            if entry["path"] == "references/a.md"
+        )
+        self.assertEqual(
+            a_entry["reachable_from"],
+            ["SKILL.md", "references/b.md"],
+        )
+
+    def test_broken_reference_emits_warn_and_continues(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body=(
+                    "# Skill\n\n"
+                    "See [missing](references/missing.md) "
+                    "and [present](references/present.md).\n"
+                ),
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "present.md"),
+                "# Present\n",
+            )
+            result = compute_stats(tmpdir)
+        warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
+        self.assertTrue(
+            any("references/missing.md" in w for w in warns),
+            f"expected missing-ref WARN, got: {warns}",
+        )
+        # The present file is still counted
+        paths = [entry["path"] for entry in result["files"]]
+        self.assertIn("references/present.md", paths)
+        self.assertNotIn("references/missing.md", paths)
+
+    def test_parent_traversal_skipped_with_warn(self) -> None:
+        """A `../` in a body reference is rejected as a WARN."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Build the body with a parent-traversal capabilities link
+            # so the body regex still matches it.
+            write_text(
+                os.path.join(tmpdir, "SKILL.md"),
+                "---\nname: x\ndescription: triggers when invoked\n---\n"
+                "# Skill\n\n[bad](capabilities/../escape.md)\n",
+            )
+            result = compute_stats(tmpdir)
+        warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
+        self.assertTrue(
+            any("parent traversal" in w for w in warns),
+            f"expected parent-traversal WARN, got: {warns}",
+        )
+
+
+# ============================================================
+# Schema shape
+# ============================================================
+
+
+class ComputeStatsSchemaTests(unittest.TestCase):
+    """Verify the returned dict matches the documented schema."""
+
+    def test_top_level_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(tmpdir)
+            result = compute_stats(tmpdir)
+        self.assertEqual(
+            set(result.keys()),
+            {"skill", "metric", "discovery_bytes", "load_bytes",
+             "files", "errors"},
+        )
+        self.assertEqual(result["metric"], "bytes")
+        self.assertIsInstance(result["discovery_bytes"], int)
+        self.assertIsInstance(result["load_bytes"], int)
+        self.assertIsInstance(result["files"], list)
+        self.assertIsInstance(result["errors"], list)
+
+    def test_file_entry_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(tmpdir)
+            result = compute_stats(tmpdir)
+        for entry in result["files"]:
+            self.assertEqual(
+                set(entry.keys()), {"path", "bytes", "reachable_from"},
+            )
+            self.assertIsInstance(entry["bytes"], int)
+            self.assertIsInstance(entry["reachable_from"], list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -667,6 +667,35 @@ class ComputeStatsGraphTests(unittest.TestCase):
         warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
         self.assertFalse(any("ghost" in w for w in warns))
 
+    def test_frontmatter_strings_not_treated_as_load_edges(self) -> None:
+        """A path-shaped string inside SKILL.md frontmatter (e.g. a
+        description that mentions ``references/foo.md``) must NOT be
+        followed as a live load edge — the body regex is applied to
+        the body only, not the frontmatter block."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write SKILL.md with a frontmatter description that
+            # contains a path-shaped string.  No real link in the body.
+            write_text(
+                os.path.join(tmpdir, "SKILL.md"),
+                "---\n"
+                "name: x\n"
+                "description: triggers when the references/ghost.md "
+                "thing happens\n"
+                "---\n"
+                "# Skill\n\nNo body links here.\n",
+            )
+            # Place the ghost file on disk to confirm we don't follow it.
+            write_text(
+                os.path.join(tmpdir, "references", "ghost.md"),
+                "# Ghost reference — should NOT appear in load_bytes\n",
+            )
+            result = compute_stats(tmpdir)
+        paths = [entry["path"] for entry in result["files"]]
+        self.assertEqual(paths, ["SKILL.md"])
+        self.assertNotIn("references/ghost.md", paths)
+        # No findings either — the ghost is invisible to stats
+        self.assertEqual(result["errors"], [])
+
     def test_undecodable_referenced_md_excluded_from_load_bytes(self) -> None:
         """A referenced .md file that exists but is not valid UTF-8
         is excluded from files[] and load_bytes — only the WARN

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -644,6 +644,38 @@ class ComputeStatsGraphTests(unittest.TestCase):
         warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
         self.assertFalse(any("ghost" in w for w in warns))
 
+    def test_undecodable_referenced_md_excluded_from_load_bytes(self) -> None:
+        """A referenced .md file that exists but is not valid UTF-8
+        is excluded from files[] and load_bytes — only the WARN
+        finding remains.  Pins the documented recovery boundary that
+        unreadable referenced files do not contribute to load_bytes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body="# Skill\n\n[broken](references/broken.md)\n",
+            )
+            ref_path = os.path.join(tmpdir, "references", "broken.md")
+            os.makedirs(os.path.dirname(ref_path), exist_ok=True)
+            # Bytes that aren't valid UTF-8.
+            with open(ref_path, "wb") as f:
+                f.write(b"# Heading\n\xff\xfe broken bytes\n")
+            result = compute_stats(tmpdir)
+            skill_md_size = os.path.getsize(
+                os.path.join(tmpdir, "SKILL.md")
+            )
+        paths = [entry["path"] for entry in result["files"]]
+        self.assertNotIn("references/broken.md", paths)
+        warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
+        self.assertTrue(
+            any(
+                "references/broken.md" in w and "cannot decode" in w
+                for w in warns
+            ),
+            f"expected decode-error WARN for references/broken.md, got: {warns}",
+        )
+        # load_bytes is just SKILL.md
+        self.assertEqual(result["load_bytes"], skill_md_size)
+
     def test_unreadable_skill_md_emits_fail_not_traceback(self) -> None:
         """A SKILL.md that exists but cannot be decoded as UTF-8
         produces a structured FAIL finding, not a traceback."""

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -26,7 +26,7 @@ if SCRIPTS_DIR not in sys.path:
 from lib.stats import (
     category_of,
     compute_stats,
-    discovery_bytes_for_skill_md,
+    discovery_bytes_of,
     extract_body_references,
     is_excluded_from_load,
     read_bytes_count,
@@ -72,7 +72,7 @@ class ReadBytesCountTests(unittest.TestCase):
 
 
 class DiscoveryBytesTests(unittest.TestCase):
-    """Tests for ``discovery_bytes_for_skill_md``."""
+    """Tests for ``discovery_bytes_of``."""
 
     def test_inclusive_of_both_fences(self) -> None:
         """Block runs from opening --- to closing --- inclusive."""
@@ -83,21 +83,21 @@ class DiscoveryBytesTests(unittest.TestCase):
                 f.write(content.encode("utf-8"))
             # "---\n" (4) + "name: x\n" (8) + "description: y\n" (15)
             # + "---\n" (4) = 31
-            self.assertEqual(discovery_bytes_for_skill_md(path), 31)
+            self.assertEqual(discovery_bytes_of(path), 31)
 
     def test_no_frontmatter_returns_zero(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "SKILL.md")
             with open(path, "wb") as f:
                 f.write(b"# Just a body\n")
-            self.assertEqual(discovery_bytes_for_skill_md(path), 0)
+            self.assertEqual(discovery_bytes_of(path), 0)
 
     def test_unclosed_frontmatter_returns_zero(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "SKILL.md")
             with open(path, "wb") as f:
                 f.write(b"---\nname: x\nno closer here\n")
-            self.assertEqual(discovery_bytes_for_skill_md(path), 0)
+            self.assertEqual(discovery_bytes_of(path), 0)
 
     def test_crlf_frontmatter_counted_with_carriage_returns(self) -> None:
         """CRLF terminators contribute to the byte count."""
@@ -111,7 +111,80 @@ class DiscoveryBytesTests(unittest.TestCase):
             # LF-only count for the same content would be 18:
             # "---\n" (4) + "name: x\n" (8) + "---\n" (4) + "...".
             # Actually the LF-only block is 4+8+4 = 16; +3 CRs = 19.
-            self.assertEqual(discovery_bytes_for_skill_md(path), 19)
+            self.assertEqual(discovery_bytes_of(path), 19)
+
+
+# ============================================================
+# Boundary agreement with frontmatter.split_frontmatter
+# ============================================================
+
+
+class DiscoveryBoundaryAgreementTests(unittest.TestCase):
+    """Pin ``discovery_bytes_of`` to ``frontmatter.split_frontmatter``.
+
+    The two implementations exist for legitimate reasons (raw on-disk
+    bytes vs LF-normalized parser view), but on LF-only content they
+    must agree on where the frontmatter block ends.  Without this
+    test, a future refactor of either side could silently disagree
+    and the only symptom would be wrong byte counts.
+    """
+
+    def _expected_bytes(self, lf_content: str) -> int:
+        """Return the boundary the parser sees, expressed in bytes.
+
+        On LF-only input, ``split_frontmatter`` returns the body
+        starting after the closing ``---`` line; the bytes before
+        that point are the discovery block.
+        """
+        from lib.frontmatter import split_frontmatter
+
+        frontmatter_text, body_text = split_frontmatter(lf_content)
+        if frontmatter_text is None or body_text is None:
+            return 0
+        # The block is everything in lf_content except body_text (the
+        # parser strips the trailing closing ``---\n``).
+        return len(lf_content.encode("utf-8")) - len(
+            body_text.encode("utf-8")
+        )
+
+    def test_agrees_on_minimal_frontmatter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "SKILL.md")
+            content = "---\nname: x\n---\n# Body\n"
+            with open(path, "wb") as f:
+                f.write(content.encode("utf-8"))
+            self.assertEqual(
+                discovery_bytes_of(path), self._expected_bytes(content)
+            )
+
+    def test_agrees_on_multi_field_frontmatter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "SKILL.md")
+            content = (
+                "---\n"
+                "name: x\n"
+                "description: triggers when invoked\n"
+                "license: MIT\n"
+                "---\n"
+                "# Body line one.\n"
+                "Body line two.\n"
+            )
+            with open(path, "wb") as f:
+                f.write(content.encode("utf-8"))
+            self.assertEqual(
+                discovery_bytes_of(path), self._expected_bytes(content)
+            )
+
+    def test_agrees_when_body_immediately_follows_closer(self) -> None:
+        """No blank line between closing fence and body content."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "SKILL.md")
+            content = "---\nname: x\n---\nBody.\n"
+            with open(path, "wb") as f:
+                f.write(content.encode("utf-8"))
+            self.assertEqual(
+                discovery_bytes_of(path), self._expected_bytes(content)
+            )
 
 
 # ============================================================
@@ -544,6 +617,48 @@ class ComputeStatsGraphTests(unittest.TestCase):
         # And no broken-link WARN should be raised for the ghost path.
         warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
         self.assertFalse(any("ghost" in w for w in warns))
+
+    def test_external_symlink_classified_as_info(self) -> None:
+        """A symlink whose target lies outside the skill root is
+        classified as external (INFO) and excluded from load_bytes.
+
+        This pins the ``is_within_directory`` defense — a future
+        regression to a lexical relpath check would silently pass the
+        rest of the suite while over-counting load_bytes for any
+        skill that uses symlinks for shared resources.
+        """
+        if not hasattr(os, "symlink"):
+            self.skipTest("symlink unavailable on this platform")
+        with tempfile.TemporaryDirectory() as outer:
+            skill_dir = os.path.join(outer, "skill")
+            external = os.path.join(outer, "elsewhere", "external.md")
+            write_text(external, "# External body\n")
+            write_skill_md(
+                skill_dir,
+                body="# Skill\n\n[ext](references/external.md)\n",
+            )
+            os.makedirs(os.path.join(skill_dir, "references"))
+            link_path = os.path.join(
+                skill_dir, "references", "external.md",
+            )
+            try:
+                os.symlink(external, link_path)
+            except (OSError, NotImplementedError):
+                self.skipTest("symlink creation not permitted")
+            result = compute_stats(skill_dir)
+        paths = [entry["path"] for entry in result["files"]]
+        # The symlink target lives outside the skill — must not be
+        # counted toward load_bytes or appear in files[].
+        self.assertNotIn("references/external.md", paths)
+        infos = [e for e in result["errors"] if e.startswith(LEVEL_INFO)]
+        self.assertTrue(
+            any(
+                "outside the skill directory" in i
+                and "references/external.md" in i
+                for i in infos
+            ),
+            f"expected external-ref INFO finding, got: {infos}",
+        )
 
     def test_parent_traversal_skipped_with_warn(self) -> None:
         """A `../` in a body reference is rejected as a WARN."""

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -214,6 +214,29 @@ class ExtractBodyReferencesTests(unittest.TestCase):
             extract_body_references(body),
         )
 
+    def test_capability_link_filtered_with_anchor_fragment(self) -> None:
+        """Anchored capability links (``capabilities/foo/capability.md#section``)
+        in non-entry bodies are still recognized as entry-point edges
+        and filtered out — strip_fragment is applied before the
+        canonical-shape check."""
+        body = (
+            "# Capability A\n\n"
+            "See [foo](capabilities/foo/capability.md#triggers) "
+            "and [bar](capabilities/bar/capability.md?v=1).\n"
+        )
+        refs = extract_body_references(body)
+        self.assertNotIn("capabilities/foo/capability.md", refs)
+        self.assertNotIn("capabilities/bar/capability.md", refs)
+        # Also ensure no anchored or queried form survived
+        self.assertFalse(
+            any(r.startswith("capabilities/foo/") for r in refs),
+            f"anchored capability link survived filter: {refs}",
+        )
+        self.assertFalse(
+            any(r.startswith("capabilities/bar/") for r in refs),
+            f"queried capability link survived filter: {refs}",
+        )
+
     def test_nested_capability_resource_kept_in_non_entry_body(self) -> None:
         """A capability that links into its OWN nested resources via
         the skill-root-relative path (``capabilities/<name>/references/foo.md``)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -195,12 +195,38 @@ class DiscoveryBoundaryAgreementTests(unittest.TestCase):
 class ExtractBodyReferencesTests(unittest.TestCase):
     """Tests for ``extract_body_references``."""
 
-    def test_capability_link_detected(self) -> None:
+    def test_capability_link_detected_when_entry(self) -> None:
+        """A markdown link to a capability.md is picked up by the
+        body regex when the caller is processing the entry SKILL.md."""
         body = "[design](capabilities/design/capability.md)"
         self.assertIn(
             "capabilities/design/capability.md",
+            extract_body_references(body, include_router_table=True),
+        )
+
+    def test_capability_link_filtered_when_not_entry(self) -> None:
+        """A markdown link to a capability.md inside a non-entry body
+        (capability or reference doc) is NOT returned — capability
+        paths are entry-point-only edges, even when written as links."""
+        body = "[design](capabilities/design/capability.md)"
+        self.assertNotIn(
+            "capabilities/design/capability.md",
             extract_body_references(body),
         )
+
+    def test_nested_capability_resource_kept_in_non_entry_body(self) -> None:
+        """A capability that links into its OWN nested resources via
+        the skill-root-relative path (``capabilities/<name>/references/foo.md``)
+        is a legitimate intra-capability reference and must stay in the
+        load graph — only ``capabilities/<name>/capability.md`` itself
+        is filtered as an entry-point-only edge."""
+        body = (
+            "# Design\n\n"
+            "See [setup](capabilities/design/references/setup.md) "
+            "for details.\n"
+        )
+        refs = extract_body_references(body)
+        self.assertIn("capabilities/design/references/setup.md", refs)
 
     def test_reference_link_detected(self) -> None:
         body = "[guide](references/guide.md)"
@@ -617,6 +643,81 @@ class ComputeStatsGraphTests(unittest.TestCase):
         # And no broken-link WARN should be raised for the ghost path.
         warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
         self.assertFalse(any("ghost" in w for w in warns))
+
+    def test_unreadable_skill_md_emits_fail_not_traceback(self) -> None:
+        """A SKILL.md that exists but cannot be decoded as UTF-8
+        produces a structured FAIL finding, not a traceback."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_md = os.path.join(tmpdir, "SKILL.md")
+            # Write bytes that are not valid UTF-8.
+            with open(skill_md, "wb") as f:
+                f.write(b"---\nname: x\n\xff\xfe invalid utf-8\n---\n# Body\n")
+            result = compute_stats(tmpdir)
+        fails = [e for e in result["errors"] if e.startswith(LEVEL_FAIL)]
+        self.assertEqual(len(fails), 1)
+        self.assertIn("cannot read", fails[0])
+        # No metrics computed beyond the early exit
+        self.assertEqual(result["files"], [])
+
+    def test_capability_path_in_non_entry_body_not_followed(self) -> None:
+        """A capability or reference body that mentions
+        ``capabilities/<name>/capability.md`` in backticks or markdown
+        links is NOT treated as a live load edge — that's an entry-
+        point-only edge.  Pins the non-entry capability-path filter."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body=(
+                    "# Skill\n\n"
+                    "[a](capabilities/a/capability.md)\n"
+                ),
+            )
+            # Capability A's body mentions capability B in backticks
+            # as a documentation example.  B is NOT linked from
+            # SKILL.md and must NOT be added to the load graph.
+            write_text(
+                os.path.join(tmpdir, "capabilities", "a", "capability.md"),
+                "# A\n\nFor a similar pattern see "
+                "`capabilities/b/capability.md`.\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "capabilities", "b", "capability.md"),
+                "# B\n\nUnrelated capability that is not linked.\n",
+            )
+            result = compute_stats(tmpdir)
+        paths = [entry["path"] for entry in result["files"]]
+        self.assertIn("capabilities/a/capability.md", paths)
+        self.assertNotIn("capabilities/b/capability.md", paths)
+        # No broken-ref WARN for capability B either.
+        warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
+        self.assertFalse(any("capabilities/b" in w for w in warns))
+
+    def test_missing_excluded_category_ref_does_not_warn(self) -> None:
+        """A missing scripts/foo.py or assets/template.md reference
+        is silently excluded from load_bytes — no broken-ref WARN
+        because the category is excluded at the gate."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body=(
+                    "# Skill\n\n"
+                    "Run `scripts/missing.py` and use "
+                    "[tmpl](assets/missing.md).\n"
+                ),
+            )
+            result = compute_stats(tmpdir)
+        warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
+        self.assertFalse(
+            any(
+                "scripts/missing.py" in w or "assets/missing.md" in w
+                for w in warns
+            ),
+            f"expected no WARN for excluded categories, got: {warns}",
+        )
+        # And neither path is in files[]
+        paths = [entry["path"] for entry in result["files"]]
+        self.assertNotIn("scripts/missing.py", paths)
+        self.assertNotIn("assets/missing.md", paths)
 
     def test_external_symlink_classified_as_info(self) -> None:
         """A symlink whose target lies outside the skill root is

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -728,6 +728,29 @@ class ComputeStatsGraphTests(unittest.TestCase):
         # load_bytes is just SKILL.md
         self.assertEqual(result["load_bytes"], skill_md_size)
 
+    def test_malformed_frontmatter_emits_warn(self) -> None:
+        """A SKILL.md whose YAML frontmatter fails to parse is not
+        discoverable as-is; the metric is still computed but a WARN
+        signals that the numbers shouldn't be read as a clean
+        result.  Uses an indent-indicator block-scalar header — one
+        of the foundry's pinned ``_parse_error`` triggers."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_text(
+                os.path.join(tmpdir, "SKILL.md"),
+                "---\n"
+                "name: x\n"
+                "description: |2\n"
+                "  body line\n"
+                "---\n"
+                "# Body\n",
+            )
+            result = compute_stats(tmpdir)
+        warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
+        self.assertTrue(
+            any("parse error" in w for w in warns),
+            f"expected frontmatter parse-error WARN, got: {warns}",
+        )
+
     def test_unreadable_skill_md_emits_fail_not_traceback(self) -> None:
         """A SKILL.md that exists but cannot be decoded as UTF-8
         produces a structured FAIL finding, not a traceback."""

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -178,8 +178,9 @@ class ExtractBodyReferencesTests(unittest.TestCase):
         self.assertNotIn("README.md", refs)
         self.assertIn("references/guide.md", refs)
 
-    def test_router_table_capability_paths_extracted(self) -> None:
-        """Bare capability paths in a router-table cell are picked up."""
+    def test_router_table_capability_paths_extracted_when_entry(self) -> None:
+        """Bare capability paths in a router-table cell are picked up
+        when ``include_router_table`` is True (entry SKILL.md only)."""
         body = (
             "# Skill\n\n"
             "| Capability | Trigger | Path |\n"
@@ -189,9 +190,21 @@ class ExtractBodyReferencesTests(unittest.TestCase):
             "| validation | when validating | "
             "capabilities/validation/capability.md |\n"
         )
-        refs = extract_body_references(body)
+        refs = extract_body_references(body, include_router_table=True)
         self.assertIn("capabilities/design/capability.md", refs)
         self.assertIn("capabilities/validation/capability.md", refs)
+
+    def test_router_table_skipped_when_not_entry(self) -> None:
+        """Default (non-entry) calls do NOT pick up router-table paths."""
+        body = (
+            "# Skill\n\n"
+            "| Capability | Trigger | Path |\n"
+            "|---|---|---|\n"
+            "| design | when designing | "
+            "capabilities/design/capability.md |\n"
+        )
+        refs = extract_body_references(body)
+        self.assertNotIn("capabilities/design/capability.md", refs)
 
     def test_router_table_decorated_path_cell_recovered(self) -> None:
         """Backtick-wrapped router-table path cells are still recovered."""
@@ -201,7 +214,7 @@ class ExtractBodyReferencesTests(unittest.TestCase):
             "|---|---|---|\n"
             "| design | when | `capabilities/design/capability.md` |\n"
         )
-        refs = extract_body_references(body)
+        refs = extract_body_references(body, include_router_table=True)
         self.assertIn("capabilities/design/capability.md", refs)
 
 
@@ -463,6 +476,74 @@ class ComputeStatsGraphTests(unittest.TestCase):
         paths = [entry["path"] for entry in result["files"]]
         self.assertIn("references/present.md", paths)
         self.assertNotIn("references/missing.md", paths)
+
+    def test_router_table_capabilities_walked_and_counted(self) -> None:
+        """End-to-end: a capability declared only in the SKILL.md router
+        table (no markdown link) is walked and contributes to load_bytes
+        with reachable_from == ['SKILL.md']."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_text(
+                os.path.join(tmpdir, "SKILL.md"),
+                "---\nname: x\ndescription: triggers when invoked\n---\n"
+                "# Skill\n\n"
+                "| Capability | Trigger | Path |\n"
+                "|---|---|---|\n"
+                "| design | when designing | "
+                "capabilities/design/capability.md |\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "capabilities", "design", "capability.md"),
+                "# Design\n\nBody.\n",
+            )
+            result = compute_stats(tmpdir)
+            cap_bytes = read_bytes_count(
+                os.path.join(
+                    tmpdir, "capabilities", "design", "capability.md",
+                )
+            )
+            skill_bytes = read_bytes_count(os.path.join(tmpdir, "SKILL.md"))
+        paths = [entry["path"] for entry in result["files"]]
+        self.assertIn("capabilities/design/capability.md", paths)
+        cap = next(
+            entry for entry in result["files"]
+            if entry["path"] == "capabilities/design/capability.md"
+        )
+        self.assertEqual(cap["reachable_from"], ["SKILL.md"])
+        self.assertEqual(cap["bytes"], cap_bytes)
+        # load_bytes is the sum of SKILL.md + the router-table-discovered cap
+        self.assertEqual(result["load_bytes"], skill_bytes + cap_bytes)
+
+    def test_router_table_only_runs_on_entry_not_capability(self) -> None:
+        """A router-shaped table inside a capability.md is NOT followed —
+        only the entry SKILL.md scans for router-table capability paths."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body=(
+                    "# Skill\n\n"
+                    "[design](capabilities/design/capability.md)\n"
+                ),
+            )
+            # The capability body contains a doc-example router table
+            # that mentions a non-existent ghost capability.  Without
+            # the entry-only guard, stats would chase it.
+            write_text(
+                os.path.join(tmpdir, "capabilities", "design", "capability.md"),
+                "# Design\n\n"
+                "Documentation example below:\n\n"
+                "| Capability | Trigger | Path |\n"
+                "|---|---|---|\n"
+                "| ghost | example only | "
+                "capabilities/ghost/capability.md |\n",
+            )
+            result = compute_stats(tmpdir)
+        paths = [entry["path"] for entry in result["files"]]
+        self.assertIn("capabilities/design/capability.md", paths)
+        # The ghost capability is doc-example only — must not be chased.
+        self.assertNotIn("capabilities/ghost/capability.md", paths)
+        # And no broken-link WARN should be raised for the ghost path.
+        warns = [e for e in result["errors"] if e.startswith(LEVEL_WARN)]
+        self.assertFalse(any("ghost" in w for w in warns))
 
     def test_parent_traversal_skipped_with_warn(self) -> None:
         """A `../` in a body reference is rejected as a WARN."""

--- a/tests/test_stats_cli.py
+++ b/tests/test_stats_cli.py
@@ -1,0 +1,184 @@
+"""Tests for skill-system-foundry/scripts/stats.py (CLI entry point).
+
+Covers argument parsing, exit codes, JSON schema, error paths
+(missing directory, missing SKILL.md), human-readable output shape,
+and the --verbose parent-list expansion.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+from helpers import write_text, write_skill_md
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__), "..", "skill-system-foundry", "scripts",
+    )
+)
+STATS_SCRIPT = os.path.join(SCRIPTS_DIR, "stats.py")
+
+
+def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, STATS_SCRIPT] + args,
+        capture_output=True,
+        text=True,
+    )
+
+
+class StatsCLIBasicTests(unittest.TestCase):
+    """Argument parsing and top-level exit-code behavior."""
+
+    def test_no_args_prints_docstring_and_exits_one(self) -> None:
+        result = _run([])
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Usage", result.stdout)
+
+    def test_nonexistent_path_exits_one(self) -> None:
+        result = _run(["/tmp/__definitely_does_not_exist__/skill"])
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("not a directory", result.stdout)
+
+    def test_nonexistent_path_json_emits_error_field(self) -> None:
+        result = _run(["/tmp/__nope__", "--json"])
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["tool"], "stats")
+        self.assertFalse(payload["success"])
+        self.assertIn("not a directory", payload["error"])
+
+    def test_missing_skill_md_exits_one(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _run([tmpdir])
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("No SKILL.md", result.stdout)
+
+    def test_missing_skill_md_json_returns_failures_list(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _run([tmpdir, "--json"])
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["tool"], "stats")
+        self.assertFalse(payload["success"])
+        self.assertEqual(payload["summary"]["failures"], 1)
+        self.assertTrue(
+            any("No SKILL.md" in m for m in payload["errors"]["failures"])
+        )
+
+    def test_unknown_flag_exits_one_via_json_aware_handler(self) -> None:
+        result = _run(["--bogus", "--json"])
+        self.assertEqual(result.returncode, 1)
+        payload = json.loads(result.stdout)
+        self.assertFalse(payload["success"])
+
+
+class StatsCLIHappyPathTests(unittest.TestCase):
+    """Successful runs against synthesized skill fixtures."""
+
+    def test_clean_skill_exits_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(tmpdir)
+            result = _run([tmpdir])
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Skill:", result.stdout)
+        self.assertIn("Discovery:", result.stdout)
+        self.assertIn("Load:", result.stdout)
+        self.assertIn("SKILL.md", result.stdout)
+
+    def test_json_schema_top_level_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(tmpdir)
+            result = _run([tmpdir, "--json"])
+        self.assertEqual(result.returncode, 0)
+        payload = json.loads(result.stdout)
+        for key in (
+            "tool", "version", "path", "success",
+            "skill", "metric", "discovery_bytes", "load_bytes",
+            "files", "summary", "errors",
+        ):
+            self.assertIn(key, payload, f"missing key {key}")
+        self.assertEqual(payload["tool"], "stats")
+        self.assertEqual(payload["metric"], "bytes")
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["summary"]["files"], len(payload["files"]))
+
+    def test_json_files_sorted_alphabetically(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body=(
+                    "# Skill\n\n"
+                    "[z](references/z.md) [a](references/a.md)\n"
+                ),
+            )
+            write_text(os.path.join(tmpdir, "references", "a.md"), "a\n")
+            write_text(os.path.join(tmpdir, "references", "z.md"), "z\n")
+            result = _run([tmpdir, "--json"])
+        payload = json.loads(result.stdout)
+        paths = [entry["path"] for entry in payload["files"]]
+        self.assertEqual(paths, sorted(paths))
+
+    def test_human_output_shows_arrow_for_children(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir, body="# Skill\n\n[g](references/g.md)\n",
+            )
+            write_text(os.path.join(tmpdir, "references", "g.md"), "g\n")
+            result = _run([tmpdir])
+        self.assertEqual(result.returncode, 0)
+        # Each child line shows the parent via the ← arrow.
+        self.assertIn("← SKILL.md", result.stdout)
+
+    def test_verbose_expands_multi_parent_arrow(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body=(
+                    "# Skill\n\n"
+                    "[a](capabilities/a/capability.md) "
+                    "[b](capabilities/b/capability.md)\n"
+                ),
+            )
+            shared_body = "see [s](references/shared.md)\n"
+            write_text(
+                os.path.join(tmpdir, "capabilities", "a", "capability.md"),
+                shared_body,
+            )
+            write_text(
+                os.path.join(tmpdir, "capabilities", "b", "capability.md"),
+                shared_body,
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "shared.md"), "s\n",
+            )
+            terse = _run([tmpdir])
+            verbose = _run([tmpdir, "--verbose"])
+        # Terse mode shows "(+1 more)" suffix on the shared file
+        self.assertIn("(+1 more)", terse.stdout)
+        # Verbose mode lists both parents inline, no "more" suffix
+        self.assertNotIn("(+1 more)", verbose.stdout)
+        self.assertIn(
+            "capabilities/a/capability.md, capabilities/b/capability.md",
+            verbose.stdout,
+        )
+
+    def test_broken_ref_exits_zero_with_warning(self) -> None:
+        """A broken ref is a WARN, not a FAIL — exit 0."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body="# Skill\n\n[m](references/missing.md)\n",
+            )
+            result = _run([tmpdir, "--json"])
+        self.assertEqual(result.returncode, 0)
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["summary"]["warnings"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stats_cli.py
+++ b/tests/test_stats_cli.py
@@ -3,14 +3,21 @@
 Covers argument parsing, exit codes, JSON schema, error paths
 (missing directory, missing SKILL.md), human-readable output shape,
 and the --verbose parent-list expansion.
+
+The in-process ``_run_main`` helper exercises the same code paths
+under coverage; subprocess-based tests cannot contribute to coverage
+because the coverage session does not span child Python processes.
 """
 
+import contextlib
+import io
 import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 from helpers import write_text, write_skill_md
 
@@ -21,6 +28,9 @@ SCRIPTS_DIR = os.path.abspath(
 )
 STATS_SCRIPT = os.path.join(SCRIPTS_DIR, "stats.py")
 
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
 
 def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
@@ -28,6 +38,30 @@ def _run(args: list[str]) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
     )
+
+
+def _run_main(argv: list[str]) -> tuple[int, str, str]:
+    """Invoke stats.main() in-process and capture streams."""
+    import stats as st
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    code = 0
+    with (
+        mock.patch.object(sys, "argv", argv),
+        contextlib.redirect_stdout(stdout),
+        contextlib.redirect_stderr(stderr),
+    ):
+        try:
+            st.main()
+        except SystemExit as exc:
+            if exc.code is None:
+                code = 0
+            elif isinstance(exc.code, int):
+                code = exc.code
+            else:
+                code = 1
+    return code, stdout.getvalue(), stderr.getvalue()
 
 
 class StatsCLIBasicTests(unittest.TestCase):
@@ -178,6 +212,98 @@ class StatsCLIHappyPathTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertTrue(payload["success"])
         self.assertEqual(payload["summary"]["warnings"], 1)
+
+
+class StatsCLIInProcessTests(unittest.TestCase):
+    """In-process coverage for ``main()``.  Same scenarios as the
+    subprocess tests above, run through ``_run_main`` so coverage
+    can observe the entry point."""
+
+    def test_no_args_prints_docstring_and_exits_one(self) -> None:
+        code, out, _err = _run_main(["stats.py"])
+        self.assertEqual(code, 1)
+        self.assertIn("Usage", out)
+
+    def test_nonexistent_path_text_mode(self) -> None:
+        code, out, _err = _run_main(["stats.py", "/tmp/__nope_in_proc__"])
+        self.assertEqual(code, 1)
+        self.assertIn("not a directory", out)
+
+    def test_nonexistent_path_json_mode(self) -> None:
+        code, out, _err = _run_main(
+            ["stats.py", "/tmp/__nope_in_proc__", "--json"]
+        )
+        self.assertEqual(code, 1)
+        payload = json.loads(out)
+        self.assertFalse(payload["success"])
+        self.assertIn("not a directory", payload["error"])
+
+    def test_missing_skill_md_text_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            code, out, _err = _run_main(["stats.py", tmpdir])
+        self.assertEqual(code, 1)
+        self.assertIn("No SKILL.md", out)
+
+    def test_missing_skill_md_json_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            code, out, _err = _run_main(["stats.py", tmpdir, "--json"])
+        self.assertEqual(code, 1)
+        payload = json.loads(out)
+        self.assertFalse(payload["success"])
+        self.assertEqual(payload["summary"]["failures"], 1)
+
+    def test_clean_skill_text_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(tmpdir)
+            code, out, _err = _run_main(["stats.py", tmpdir])
+        self.assertEqual(code, 0)
+        self.assertIn("Skill:", out)
+        self.assertIn("Discovery:", out)
+
+    def test_clean_skill_json_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(tmpdir)
+            code, out, _err = _run_main(["stats.py", tmpdir, "--json"])
+        self.assertEqual(code, 0)
+        payload = json.loads(out)
+        self.assertEqual(payload["tool"], "stats")
+        self.assertTrue(payload["success"])
+
+    def test_verbose_text_mode_with_multi_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(
+                tmpdir,
+                body=(
+                    "# Skill\n\n"
+                    "[a](capabilities/a/capability.md) "
+                    "[b](capabilities/b/capability.md)\n"
+                ),
+            )
+            shared = "[s](references/shared.md)\n"
+            write_text(
+                os.path.join(tmpdir, "capabilities", "a", "capability.md"),
+                shared,
+            )
+            write_text(
+                os.path.join(tmpdir, "capabilities", "b", "capability.md"),
+                shared,
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "shared.md"), "x\n",
+            )
+            code, out, _err = _run_main(["stats.py", tmpdir, "--verbose"])
+        self.assertEqual(code, 0)
+        self.assertIn(
+            "capabilities/a/capability.md, capabilities/b/capability.md", out
+        )
+
+    def test_unknown_flag_text_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_skill_md(tmpdir)
+            code, out, err = _run_main(["stats.py", tmpdir, "--bogus"])
+        self.assertEqual(code, 1)
+        # argparse error goes to stderr in text mode
+        self.assertIn("unrecognized", err.lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_stats_cli.py
+++ b/tests/test_stats_cli.py
@@ -73,12 +73,16 @@ class StatsCLIBasicTests(unittest.TestCase):
         self.assertIn("Usage", result.stdout)
 
     def test_nonexistent_path_exits_one(self) -> None:
-        result = _run(["/tmp/__definitely_does_not_exist__/skill"])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = os.path.join(tmpdir, "__nope__", "skill")
+            result = _run([missing])
         self.assertEqual(result.returncode, 1)
         self.assertIn("not a directory", result.stdout)
 
     def test_nonexistent_path_json_emits_error_field(self) -> None:
-        result = _run(["/tmp/__nope__", "--json"])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = os.path.join(tmpdir, "__nope__")
+            result = _run([missing, "--json"])
         self.assertEqual(result.returncode, 1)
         payload = json.loads(result.stdout)
         self.assertEqual(payload["tool"], "stats")
@@ -225,14 +229,16 @@ class StatsCLIInProcessTests(unittest.TestCase):
         self.assertIn("Usage", out)
 
     def test_nonexistent_path_text_mode(self) -> None:
-        code, out, _err = _run_main(["stats.py", "/tmp/__nope_in_proc__"])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = os.path.join(tmpdir, "__nope_in_proc__")
+            code, out, _err = _run_main(["stats.py", missing])
         self.assertEqual(code, 1)
         self.assertIn("not a directory", out)
 
     def test_nonexistent_path_json_mode(self) -> None:
-        code, out, _err = _run_main(
-            ["stats.py", "/tmp/__nope_in_proc__", "--json"]
-        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = os.path.join(tmpdir, "__nope_in_proc__")
+            code, out, _err = _run_main(["stats.py", missing, "--json"])
         self.assertEqual(code, 1)
         payload = json.loads(out)
         self.assertFalse(payload["success"])

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -423,6 +423,81 @@ class ValidateBodyTests(unittest.TestCase):
         broken_warns = [e for e in errors if "does not exist" in e]
         self.assertEqual(broken_warns, [])
 
+    def test_capability_chain_warns_when_capability_refs_have_nested_refs(self) -> None:
+        """SKILL.md → capability.md → references/a.md → references/b.md
+        must produce a nested-ref WARN attributed to the capability.
+        capability.md is treated as its own entry-point boundary, so
+        its referenced files are checked for nesting just as SKILL.md's
+        are.  Pins the gap that opened when we exempted capability
+        targets from the parent's own check."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # capability.md links to references/a.md
+            write_text(
+                os.path.join(
+                    tmpdir, "capabilities", "design", "capability.md"
+                ),
+                "# Design\n\n"
+                "See [primer](references/a.md) for details.\n",
+            )
+            # references/a.md links to references/b.md (nested)
+            write_text(
+                os.path.join(tmpdir, "references", "a.md"),
+                "# A\n\n"
+                "Then see [more](references/b.md) for follow-up.\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "b.md"),
+                "# B\n\nLeaf.\n",
+            )
+            skill_md = os.path.join(tmpdir, "SKILL.md")
+            write_text(
+                skill_md,
+                "# Skill\n\n"
+                "See [design](capabilities/design/capability.md).\n",
+            )
+            errors, _passes = validate_skill_references(
+                tmpdir, tmpdir, skill_md, allow_nested_refs=False,
+            )
+        nested_warns = [e for e in errors if "nested references" in e]
+        self.assertEqual(
+            len(nested_warns), 1,
+            "capability.md's body refs must be checked for nesting "
+            f"because capability.md is itself an entry point; got: {nested_warns}",
+        )
+        self.assertIn("capabilities/design/capability.md", nested_warns[0])
+
+    def test_capability_chain_silent_with_allow_nested_refs(self) -> None:
+        """When --allow-nested-references is on, the capability-as-
+        entry-point check is suppressed too — pins the existing
+        opt-out semantics so the meta-skill's own self-check (which
+        uses --allow-nested-references) keeps working."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            write_text(
+                os.path.join(
+                    tmpdir, "capabilities", "design", "capability.md"
+                ),
+                "# Design\n\nSee [primer](references/a.md).\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "a.md"),
+                "# A\n\nThen see [more](references/b.md).\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "b.md"),
+                "# B\n",
+            )
+            skill_md = os.path.join(tmpdir, "SKILL.md")
+            write_text(
+                skill_md,
+                "# Skill\n\n"
+                "See [design](capabilities/design/capability.md).\n",
+            )
+            errors, _passes = validate_skill_references(
+                tmpdir, tmpdir, skill_md, allow_nested_refs=True,
+            )
+        nested_warns = [e for e in errors if "nested references" in e]
+        self.assertEqual(nested_warns, [])
+
     def test_unrelated_file_named_capability_md_still_nested_checked(self) -> None:
         """An unrelated reference file that happens to be named
         capability.md (e.g., references/capability.md) is NOT a spec

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -423,6 +423,40 @@ class ValidateBodyTests(unittest.TestCase):
         broken_warns = [e for e in errors if "does not exist" in e]
         self.assertEqual(broken_warns, [])
 
+    def test_unrelated_file_named_capability_md_still_nested_checked(self) -> None:
+        """An unrelated reference file that happens to be named
+        capability.md (e.g., references/capability.md) is NOT a spec
+        entry point — its own links must still be checked for nesting.
+        Pins the canonical-shape narrowing of the entry-point
+        exemption."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_md = os.path.join(tmpdir, "SKILL.md")
+            write_text(
+                os.path.join(tmpdir, "references", "capability.md"),
+                "# Misnamed reference\n\n"
+                "See [deeper](references/deeper.md) for more.\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "deeper.md"),
+                "# Deeper\n",
+            )
+            body = (
+                "# Skill\n\n"
+                "See [misnamed](references/capability.md).\n"
+            )
+            write_text(skill_md, body)
+            errors, _passes = validate_body(
+                body, skill_md, os.path.dirname(skill_md),
+            )
+        nested_warns = [e for e in errors if "nested references" in e]
+        self.assertEqual(
+            len(nested_warns), 1,
+            "references/capability.md is not a spec entry point; its "
+            "nested references must still be flagged when "
+            "--allow-nested-references is off",
+        )
+        self.assertIn("references/capability.md", nested_warns[0])
+
     def test_capability_link_not_treated_as_nested_ref(self) -> None:
         """capability.md is its own entry point per the spec — links
         from a capability into references/ are first-level under that

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -423,6 +423,40 @@ class ValidateBodyTests(unittest.TestCase):
         broken_warns = [e for e in errors if "does not exist" in e]
         self.assertEqual(broken_warns, [])
 
+    def test_capability_link_not_treated_as_nested_ref(self) -> None:
+        """capability.md is its own entry point per the spec — links
+        from a capability into references/ are first-level under that
+        entry point, not nested under the parent SKILL.md.  When
+        --allow-nested-references is OFF, a SKILL.md → capability.md →
+        references/foo.md chain must NOT trigger a nested-ref WARN."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_md = os.path.join(tmpdir, "SKILL.md")
+            write_text(
+                os.path.join(
+                    tmpdir, "capabilities", "design", "capability.md"
+                ),
+                "# Design\n\n"
+                "See [guide](references/authoring.md) for details.\n",
+            )
+            write_text(
+                os.path.join(tmpdir, "references", "authoring.md"),
+                "# Authoring\n",
+            )
+            body = (
+                "# Skill\n\n"
+                "See [design](capabilities/design/capability.md).\n"
+            )
+            write_text(skill_md, body)
+            errors, _passes = validate_body(
+                body, skill_md, os.path.dirname(skill_md),
+            )
+        nested_warns = [e for e in errors if "nested references" in e]
+        self.assertEqual(
+            nested_warns, [],
+            "capability.md is its own entry point and must not trigger "
+            "the nested-references WARN when its body links to references/",
+        )
+
     def test_broken_capability_ref_detected(self) -> None:
         """A broken capabilities/ link produces a WARN like other categories."""
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -406,6 +406,36 @@ class ValidateBodyTests(unittest.TestCase):
         nested_warns = [e for e in errors if "nested" in e.lower()]
         self.assertEqual(nested_warns, [])
 
+    def test_capability_ref_in_body_detected(self) -> None:
+        """References to capabilities/<name>/capability.md are detected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_md = os.path.join(tmpdir, "SKILL.md")
+            cap_file = os.path.join(
+                tmpdir, "capabilities", "design", "capability.md"
+            )
+            write_text(cap_file, "# Design\n\nCapability body.\n")
+            body = (
+                "# Skill\n\nSee [design](capabilities/design/capability.md).\n"
+            )
+            write_text(skill_md, body)
+            errors, passes = validate_body(body, skill_md, os.path.dirname(skill_md))
+        # Capability ref must resolve — no broken-link WARN
+        broken_warns = [e for e in errors if "does not exist" in e]
+        self.assertEqual(broken_warns, [])
+
+    def test_broken_capability_ref_detected(self) -> None:
+        """A broken capabilities/ link produces a WARN like other categories."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            skill_md = os.path.join(tmpdir, "SKILL.md")
+            body = (
+                "# Skill\n\nSee [missing](capabilities/missing/capability.md).\n"
+            )
+            write_text(skill_md, body)
+            errors, passes = validate_body(body, skill_md, os.path.dirname(skill_md))
+        broken_warns = [e for e in errors if "does not exist" in e]
+        self.assertEqual(len(broken_warns), 1)
+        self.assertIn("capabilities/missing/capability.md", broken_warns[0])
+
     def test_body_with_nested_refs_returns_warn(self) -> None:
         """A body with nested references (ref file contains refs) produces a WARN."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

Closes #97. Adds a new `stats` entry point that quantifies a skill's discovery and load token-budget cost in raw on-disk bytes, so authors can see what each capability and reference adds. The foundry documents a "token economy" principle but until now gave authors no measurement; `stats` makes the cost of each authoring decision concrete.

The PR also extends body `reference_patterns` in `configuration.yaml` to recognize `capabilities/` (broken capability links from `SKILL.md` were silently skipped before) and adds a public `extract_capability_paths` helper to `router_table.py` so the load-graph traversal can walk router-table cells without tunneling private API.

## Metrics

Two byte-based proxies, both taken from raw on-disk UTF-8 bytes (CRLF preserved — Windows checkouts will report higher than POSIX checkouts of the same content). Bytes are not tokens and are not comparable across models or tokenizers; the docstring states the proxy explicitly.

- **`discovery_bytes`** — the SKILL.md YAML frontmatter block, fences inclusive. This is what the harness reads at startup to decide whether to surface the skill.
- **`load_bytes`** — SKILL.md plus every transitively reachable `capabilities/**/capability.md` and `references/**/*` file. `scripts/` and `assets/` are excluded because they are not loaded into the model's context during skill use.

The graph traversal harvests three reference sources: configuration-driven markdown-link patterns, backtick patterns, and bare router-table path cells (recovered through the new `extract_capability_paths` helper, which owns the strict + recovery cascade and is also consumed by the existing audit). Capability paths in a router table are bare cells — not markdown links — so the body regexes alone would miss them and produce a misleading count on real router skills.

## Schema

Documented in the issue and unchanged from the locked-in design. The lib returns:

```json
{
  "skill": "skill-name",
  "metric": "bytes",
  "discovery_bytes": 412,
  "load_bytes": 18234,
  "files": [
    {"path": "SKILL.md", "bytes": 6104, "reachable_from": []},
    {"path": "capabilities/foo/capability.md", "bytes": 3210, "reachable_from": ["SKILL.md"]}
  ],
  "errors": ["WARN: ..."]
}
```

The CLI wraps this with `tool`, `version`, `path`, `success`, `summary`, and a structured `errors` block (failures/warnings/info) matching the format `validate_skill --json` and `audit_skill_system --json` already emit, so consumers that already parse those entry points see stats output without new code paths. `metric: "bytes"` is the forward-compatibility discriminator — a future tokens-based metric would land alongside without breaking the schema.

## Output

Two byte-based proxies for the foundry's own meta-skill (smoke run from this branch):

```
Skill: skill-system-foundry
Metric: bytes
Discovery: 494 B
Load:      107,781 B (17 files)
```

Human-readable mode prints a header (skill name, metric, discovery total, load total, file count) followed by an alphabetically sorted table with right-aligned byte counts and a parent-link arrow. `--verbose` lists every `reachable_from` parent inline; terse mode collapses extras into a `(+N more)` suffix to keep lines scannable. Findings — broken refs, parent-traversal attempts, external references — print after the table in the same format the other entry points use.

## Behavior boundary

Only a missing `SKILL.md` is a FAIL with early exit; everything else recovers and the run still emits a usable metric.

- Broken or unreadable referenced file → WARN, excluded from `load_bytes`, traversal continues from any other parents
- Reference using parent traversal (`../`) → WARN, skipped
- Reference resolving outside the skill via a symlink → INFO via `is_within_directory` (handles realpath + commonpath)
- Reference to a `scripts/` or `assets/` path → silently excluded from `load_bytes` (declared at the `_visit` boundary, no I/O cost)
- Cycle in the reference graph → naturally short-circuited by the `visited` check; the back-edge just records the extra parent

## Test plan

- [x] 2115 unit tests pass under coverage (was 2045 on `main`)
- [x] 96% total branch coverage (`lib/stats.py` 87%, `scripts/stats.py` 84%, `lib/router_table.py` 97%) — well above the 70% threshold
- [x] `validate_skill.py` and `audit_skill_system.py` clean on the meta-skill (skill-root mode and distribution-repo mode)
- [x] Smoke run on the meta-skill: 494 / 107,781 / 17 files / 0 errors
- [x] Both subprocess and in-process CLI tests, including a `--verbose` parent-list expansion check, an unknown-flag JSON-aware error path, and exit-code coverage
- [x] End-to-end regression test for router-table → capability walking, plus a guard test confirming router tables inside `capability.md` files are NOT followed
- [x] Symlink test pinning the `is_within_directory` external-ref defense (skipped on platforms without symlink support)
- [x] Boundary-agreement tests pinning `discovery_bytes_of` to `frontmatter.split_frontmatter` on LF-only content

## Out of scope (tracked separately)

- **#124** — extend `discovery_bytes` to include capability frontmatter once #120 (capability frontmatter) lands. The lib helper is already filename-agnostic (`discovery_bytes_of`); the `files[]` schema is already a dict and can carry a per-row `discovery_bytes` field as a non-breaking addition
- A token-based metric. The `metric: "bytes"` discriminator is the forward-compatibility hook; a future `--metric tokens-<model>` flag is a separate issue

## Files

| File | Description |
|---|---|
| `AGENTS.md` | Adds entry-point row for `stats.py` and a Measuring-the-Meta-Skill's-Token-Budget section under "Validating the Meta-Skill" |
| `skill-system-foundry/SKILL.md` | Updates `scripts/` inventory paragraph to include `stats.py` |
| `skill-system-foundry/scripts/lib/configuration.yaml` | Adds `capabilities` to body reference-pattern alternation |
| `skill-system-foundry/scripts/lib/router_table.py` | Adds public `extract_capability_paths(body)` helper consolidating the strict + recovery cascade |
| `skill-system-foundry/scripts/lib/stats.py` | New counting module: byte counters, frontmatter-block extractor, reference graph traversal with symlink-safe external-ref classification, exclusion filter, router-table harvest gated to entry SKILL.md |
| `skill-system-foundry/scripts/stats.py` | New CLI entry point: argparse, JSON-aware error path, human-readable table, exit codes |
| `tests/test_router_table.py` | Tests for `extract_capability_paths` (4 cases) |
| `tests/test_stats.py` | Library tests (43 cases) |
| `tests/test_stats_cli.py` | CLI tests (subprocess + in-process for coverage) |
| `tests/test_validate_skill.py` | Two cases for the extended `capabilities/` body regex |