### PR TITLE
Add scheduled workflow detecting drift between tool catalog and upstream

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,14 +12,16 @@ exclude_lines =
     if __name__ == .__main__
     raise NotImplementedError
 
+# tool-catalog-drift.py is exercised by its own suite under
+# .github/tests/ via the dedicated ci-helper-tests.yaml workflow,
+# not the meta-skill matrix.  Excluded here so
+# check-per-file-coverage.py does not flag it as 0.0% covered in
+# the python-tests.yaml run.  Comments must live OUTSIDE the
+# indented continuation block under ``omit =`` because configparser
+# treats indented lines as additional pattern values, not comments.
 omit =
     tests/test_*.py
     tests/helpers.py
     */__pycache__/*
     .git/*
-    # tool-catalog-drift is exercised by its own suite under
-    # .github/tests/ via the dedicated ci-helper-tests.yaml
-    # workflow, not the meta-skill matrix.  Excluding it here so
-    # check-per-file-coverage.py does not flag it as 0.0% covered
-    # in the python-tests.yaml run.
     .github/scripts/tool-catalog-drift.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -17,3 +17,9 @@ omit =
     tests/helpers.py
     */__pycache__/*
     .git/*
+    # tool-catalog-drift is exercised by its own suite under
+    # .github/tests/ via the dedicated ci-helper-tests.yaml
+    # workflow, not the meta-skill matrix.  Excluding it here so
+    # check-per-file-coverage.py does not flag it as 0.0% covered
+    # in the python-tests.yaml run.
+    .github/scripts/tool-catalog-drift.py

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -168,6 +168,8 @@ def extract_tools(markdown_text: str) -> set[str]:
       * The header row has no following body line (truncated table).
       * The header row is not followed by a ``| :--- | :--- | ...``
         separator (table format may have changed).
+      * A body row inside the tools table has no backticked
+        identifier in the first cell (table-shape drift).
       * Zero tools are extracted from the body rows.
     """
     lines = markdown_text.splitlines()
@@ -206,7 +208,18 @@ def extract_tools(markdown_text: str) -> set[str]:
             break
         match = RE_TABLE_ROW_FIRST_CELL.match(line)
         if match is None:
-            continue
+            # Row is inside the tools table (starts with ``|``) but
+            # its first cell is not a backticked identifier.  Per
+            # the helper's hard-fail-on-shape-change contract, this
+            # is a real format drift — silently skipping would let
+            # an upstream table-format change (e.g. ``| Bash |``
+            # without backticks, or an unbackticked separator row
+            # injected mid-table) drop tools from ``extracted`` and
+            # produce misleading no-drift / advisory-removal output.
+            raise ParseError(
+                "upstream markdown table row does not start with a "
+                f"backticked tool identifier: {line.rstrip()}"
+            )
         identifier = match.group(1).strip()
         if RE_HARNESS_SHAPE.match(identifier):
             tools.add(identifier)

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -36,6 +36,7 @@ keep their shape.
 
 import argparse
 import datetime
+import json
 import os
 import re
 import sys
@@ -582,12 +583,12 @@ def run(
     catalog_path: str,
     today_iso: str,
     dry_run: bool,
-) -> tuple[bool, str]:
+) -> tuple[bool, str, dict]:
     """Run the drift sweep against the catalog at *catalog_path*.
 
-    Returns ``(drift_detected, summary)``.  In default (non-dry-run)
-    mode, additions are applied to the catalog file and
-    ``last_checked`` is updated regardless of drift state.  In dry-run
+    Returns ``(drift_detected, summary, json_payload)``.  In default
+    (non-dry-run) mode, additions are applied to the catalog file and
+    ``last_checked`` is updated when drift is detected.  In dry-run
     mode, no file edits happen.
 
     Raises :class:`FetchError` or :class:`ParseError` on hard-fail
@@ -606,6 +607,15 @@ def run(
 
     summary = render_summary(additions, removals, source_url, today_iso)
     drift_detected = bool(additions or removals)
+    json_payload = {
+        "drift": drift_detected,
+        "source_url": source_url,
+        "checked": today_iso,
+        "additions": sorted(additions),
+        "removals": sorted(removals),
+        "catalog_size": len(catalog),
+        "upstream_size": len(extracted),
+    }
 
     # Only rewrite the file when drift is detected.  ``last_checked``
     # tracks "date the catalog was last changed to reflect upstream",
@@ -618,7 +628,7 @@ def run(
             with open(catalog_path, "w", encoding="utf-8") as fh:
                 fh.write(new_yaml)
 
-    return (drift_detected, summary)
+    return (drift_detected, summary, json_payload)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -664,12 +674,22 @@ def main(argv: list[str] | None = None) -> int:
             "workflow to compose the PR body."
         ),
     )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help=(
+            "Emit the drift result as a JSON object to stdout instead "
+            "of human-readable markdown. Object keys: drift (bool), "
+            "source_url, checked, additions, removals, catalog_size, "
+            "upstream_size. Useful for tooling consumers."
+        ),
+    )
     args = parser.parse_args(argv)
 
     today_iso = args.today or _today_iso()
 
     try:
-        drift_detected, summary = run(
+        drift_detected, summary, json_payload = run(
             catalog_path=args.catalog_path,
             today_iso=today_iso,
             dry_run=args.dry_run,
@@ -684,7 +704,11 @@ def main(argv: list[str] | None = None) -> int:
         print(f"FAIL: I/O error: {exc}", file=sys.stderr)
         return 4
 
-    sys.stdout.write(summary)
+    if args.json:
+        sys.stdout.write(json.dumps(json_payload, indent=2, sort_keys=True))
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(summary)
 
     if args.summary_out:
         with open(args.summary_out, "w", encoding="utf-8") as fh:

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -769,8 +769,17 @@ def main(argv: list[str] | None = None) -> int:
         sys.stdout.write(summary)
 
     if args.summary_out:
-        with open(args.summary_out, "w", encoding="utf-8") as fh:
-            fh.write(summary)
+        # Match the helper's documented hard-fail contract: an I/O
+        # error here (missing parent dir, unwritable path, full disk)
+        # surfaces as exit 4 with a stderr message, not a bare
+        # traceback.  The summary-out write is the workflow's only
+        # path to the PR body, so a clean failure mode matters.
+        try:
+            with open(args.summary_out, "w", encoding="utf-8") as fh:
+                fh.write(summary)
+        except OSError as exc:
+            print(f"FAIL: I/O error writing summary: {exc}", file=sys.stderr)
+            return 4
 
     if args.dry_run:
         return 1 if drift_detected else 0

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -1,0 +1,693 @@
+"""Detect drift between the hand-maintained Claude Code tool catalog
+and the canonical upstream tools reference.
+
+Reads the catalog at ``skill-system-foundry/scripts/lib/configuration.yaml``
+under ``allowed_tools.catalogs.claude_code``, fetches the upstream
+markdown table at ``provenance.source_url`` (default
+``https://code.claude.com/docs/en/tools-reference.md``), and compares
+the two sets of tool names.
+
+Outcomes:
+  * Additions (upstream has, catalog lacks) — auto-applied to the YAML
+    on disk in default mode.
+  * Removals (catalog has, upstream lacks) — surfaced in the rendered
+    summary as advisory; never auto-applied.  A regex miss or a
+    one-version-wide doc edit could falsely propose dropping a real
+    tool, so removals always require a human edit.
+  * No drift — ``last_checked`` is rewritten on every successful run
+    so the YAML diff alone signals when the catalog was last
+    reconciled with upstream.
+
+The helper hard-fails on fetch errors, decoding errors, table-shape
+mismatches, and zero tokens extracted.  Silent green is the worst
+outcome for a drift sweep — every failure mode prints to stderr and
+exits non-zero.
+
+Stdlib only.  No third-party dependencies, no cross-tree imports from
+the meta-skill: the helper is repo infrastructure under
+``.github/scripts/`` and stays isolated from
+``skill-system-foundry/scripts/lib/``.
+
+Adding another tracked harness later (e.g. a future Codex catalog
+that publishes a canonical tool list) is a YAML edit and a one-line
+addition to ``HARNESS_NAMES`` below — the parser, fetcher, and writer
+keep their shape.
+"""
+
+import argparse
+import datetime
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+CATALOG_PATH = os.path.join(
+    REPO_ROOT, "skill-system-foundry", "scripts", "lib", "configuration.yaml"
+)
+
+# Harness names tracked by this sweep.  Today only ``claude_code`` has
+# a canonical upstream catalog; the YAML structure preserves room for
+# future harness buckets but no second harness ships in this PR.  See
+# the design comment on issue #118.
+HARNESS_NAMES: tuple[str, ...] = ("claude_code",)
+
+# PascalCase token shape.  Matches ``Bash``, ``WebFetch``, ``LSP``, and
+# any future PascalCase or all-caps acronym tool name.  Anchored.
+RE_HARNESS_SHAPE = re.compile(r"^[A-Z][A-Za-z0-9]*$")
+
+# Backticked-identifier-only first-cell match.  Tools-reference rows
+# look like ``| `Bash` | Executes shell commands ... |``.  The pattern
+# is anchored against the leading pipe and trailing pipe so prose-only
+# rows do not false-positive.
+RE_TABLE_ROW_FIRST_CELL = re.compile(r"^\|\s*`([^`]+)`\s*\|")
+
+# Header row sanity check.  The tools-reference table has a "Tool"
+# column (first) and a "Description" column (second).  If the header
+# changes shape, hard-fail rather than silently scanning the wrong
+# table.
+RE_TABLE_HEADER = re.compile(
+    r"^\|\s*Tool\s*\|\s*Description\s*\|", re.IGNORECASE
+)
+RE_TABLE_SEPARATOR = re.compile(r"^\|\s*[: -]+\s*\|")
+
+# Default URL when ``provenance.source_url`` is missing from the YAML.
+# Used only as a backstop — normal operation reads the URL from the
+# catalog's own provenance block.
+DEFAULT_SOURCE_URL = "https://code.claude.com/docs/en/tools-reference.md"
+
+# HTTP timeouts.  Generous enough for slow CDNs, tight enough that a
+# hung connection does not stall the workflow indefinitely.
+FETCH_TIMEOUT_SECONDS = 30
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class DriftHelperError(Exception):
+    """Base exception for hard-fail conditions in this helper."""
+
+
+class FetchError(DriftHelperError):
+    """Network or HTTP error while fetching the upstream source."""
+
+
+class ParseError(DriftHelperError):
+    """The catalog YAML or upstream markdown does not have the expected shape."""
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+def fetch(url: str) -> str:
+    """Fetch *url* and return the response body as UTF-8 text.
+
+    Raises :class:`FetchError` on any non-2xx status, network failure,
+    or non-UTF-8 body.  No silent green — every error path is loud.
+    """
+    request = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": "skill-system-foundry-tool-catalog-drift",
+            "Accept": "text/markdown, text/plain, */*",
+        },
+    )
+    try:
+        with urllib.request.urlopen(
+            request, timeout=FETCH_TIMEOUT_SECONDS
+        ) as response:
+            status = response.status
+            if status < 200 or status >= 300:
+                raise FetchError(
+                    f"HTTP {status} fetching {url}"
+                )
+            body = response.read()
+    except urllib.error.HTTPError as exc:
+        raise FetchError(f"HTTP {exc.code} fetching {url}") from exc
+    except urllib.error.URLError as exc:
+        raise FetchError(f"network error fetching {url}: {exc.reason}") from exc
+    except (TimeoutError, OSError) as exc:
+        raise FetchError(f"I/O error fetching {url}: {exc}") from exc
+    try:
+        return body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise FetchError(
+            f"non-UTF-8 response body from {url}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Extract
+# ---------------------------------------------------------------------------
+
+
+def extract_tools(markdown_text: str) -> set[str]:
+    """Extract harness tool names from the upstream tools-reference markdown.
+
+    Strategy: locate the header row whose first two columns are
+    ``Tool`` and ``Description``, skip the separator row, then read
+    the first column of every following row until the table ends (a
+    blank line or a non-table line).  The first cell is expected to
+    be a backticked identifier; rows without one are skipped silently
+    (footers, prose, or row separators).  Identifiers must match the
+    PascalCase shape regex.
+
+    Hard-fails (raises :class:`ParseError`) when:
+      * No header row matching ``Tool | Description | ...`` is found.
+      * Zero tools are extracted.
+    """
+    lines = markdown_text.splitlines()
+    header_index = -1
+    for index, line in enumerate(lines):
+        if RE_TABLE_HEADER.match(line):
+            header_index = index
+            break
+    if header_index < 0:
+        raise ParseError(
+            "upstream markdown has no `| Tool | Description | ...` "
+            "header row — table format may have changed"
+        )
+    if header_index + 1 >= len(lines):
+        raise ParseError(
+            "upstream markdown has a header row but no body — table "
+            "format may have changed"
+        )
+    if not RE_TABLE_SEPARATOR.match(lines[header_index + 1]):
+        raise ParseError(
+            "upstream markdown header row is not followed by a "
+            "separator — table format may have changed"
+        )
+
+    tools: set[str] = set()
+    for line in lines[header_index + 2:]:
+        if not line.startswith("|"):
+            break
+        if line.strip() == "":
+            break
+        match = RE_TABLE_ROW_FIRST_CELL.match(line)
+        if match is None:
+            continue
+        identifier = match.group(1).strip()
+        if RE_HARNESS_SHAPE.match(identifier):
+            tools.add(identifier)
+
+    if not tools:
+        raise ParseError(
+            "upstream markdown produced zero PascalCase tool names — "
+            "table format may have changed"
+        )
+    return tools
+
+
+# ---------------------------------------------------------------------------
+# Parse the catalog (line-based YAML reader for the slice we care about)
+# ---------------------------------------------------------------------------
+
+
+def _line_indent(line: str) -> int:
+    """Number of leading space characters on *line*.  Tabs are
+    intentionally not counted — the foundry's YAML uses spaces only,
+    and a tab anywhere in the slice we read would be a config error
+    that we want to surface (downstream parsers fail on it).
+    """
+    return len(line) - len(line.lstrip(" "))
+
+
+def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
+    """Parse the catalog slice for *harness* from *yaml_text*.
+
+    Returns a mapping with:
+      * ``source_url`` — string, the upstream URL.
+      * ``last_checked`` — string, the previous check date.
+      * ``harness_tools`` — list of strings (insertion order preserved).
+      * ``harness_tools_indent`` — int, the indent of each
+        ``- ToolName`` list item line; the writer uses this to keep
+        added items aligned with existing items.
+      * ``harness_tools_end_line`` — int, the index of the line
+        immediately after the last existing harness-tool item.  The
+        writer inserts new items there.
+      * ``last_checked_line`` — int, the line index of
+        ``provenance.last_checked``.
+
+    Hard-fails (:class:`ParseError`) when the harness bucket, the
+    provenance block, or the harness_tools list is missing or
+    malformed.
+    """
+    lines = yaml_text.splitlines()
+
+    catalogs_index = _find_key_line(
+        lines, "catalogs:", parents=("skill:", "allowed_tools:")
+    )
+    if catalogs_index < 0:
+        raise ParseError(
+            "configuration.yaml has no `catalogs:` block under "
+            "`skill.allowed_tools` — schema mismatch"
+        )
+
+    harness_index = _find_child_key(
+        lines, catalogs_index, f"{harness}:"
+    )
+    if harness_index < 0:
+        raise ParseError(
+            f"configuration.yaml has no `{harness}:` bucket under "
+            "`allowed_tools.catalogs` — add the bucket or update the "
+            "harness list in this helper"
+        )
+
+    provenance_index = _find_child_key(lines, harness_index, "provenance:")
+    if provenance_index < 0:
+        raise ParseError(
+            f"configuration.yaml has no `provenance:` block under "
+            f"`allowed_tools.catalogs.{harness}` — schema migration "
+            "incomplete (see issue #118)"
+        )
+
+    source_url_line = _find_child_key(
+        lines, provenance_index, "source_url:"
+    )
+    last_checked_line = _find_child_key(
+        lines, provenance_index, "last_checked:"
+    )
+    if source_url_line < 0 or last_checked_line < 0:
+        raise ParseError(
+            "configuration.yaml is missing `source_url` and/or "
+            f"`last_checked` under `{harness}.provenance` — schema "
+            "migration incomplete"
+        )
+
+    source_url = _scalar_value(lines[source_url_line], "source_url:")
+    last_checked = _scalar_value(lines[last_checked_line], "last_checked:")
+
+    harness_tools_index = _find_child_key(
+        lines, harness_index, "harness_tools:"
+    )
+    if harness_tools_index < 0:
+        raise ParseError(
+            f"configuration.yaml has no `harness_tools:` list under "
+            f"`{harness}` — schema mismatch"
+        )
+
+    parent_indent = _line_indent(lines[harness_tools_index])
+    item_indent: int | None = None
+    items: list[str] = []
+    end_line = harness_tools_index + 1
+    for index in range(harness_tools_index + 1, len(lines)):
+        line = lines[index]
+        stripped = line.strip()
+        if stripped == "" or stripped.startswith("#"):
+            continue
+        indent = _line_indent(line)
+        if indent <= parent_indent:
+            end_line = index
+            break
+        if not stripped.startswith("- "):
+            end_line = index
+            break
+        if item_indent is None:
+            item_indent = indent
+        elif indent != item_indent:
+            raise ParseError(
+                f"configuration.yaml has inconsistent indentation in "
+                f"`{harness}.harness_tools` at line {index + 1} — "
+                "schema mismatch"
+            )
+        token = stripped[2:].strip()
+        if not token:
+            raise ParseError(
+                f"configuration.yaml has an empty list item in "
+                f"`{harness}.harness_tools` at line {index + 1}"
+            )
+        items.append(token)
+        end_line = index + 1
+
+    if item_indent is None:
+        # Empty list — preserve a sensible insertion indent.  Use
+        # ``parent_indent + 2`` (foundry convention).
+        item_indent = parent_indent + 2
+
+    return {
+        "source_url": source_url,
+        "last_checked": last_checked,
+        "harness_tools": items,
+        "harness_tools_indent": item_indent,
+        "harness_tools_end_line": end_line,
+        "last_checked_line": last_checked_line,
+    }
+
+
+def _find_key_line(
+    lines: list[str], key: str, parents: tuple[str, ...]
+) -> int:
+    """Find *key* under the chain of *parents*.
+
+    Walks forward, descending into each parent in order.  Returns the
+    index of the matching line or -1.
+    """
+    cursor = 0
+    parent_indent = -1
+    for parent in parents:
+        cursor = _find_key_at_or_after(lines, parent, cursor, parent_indent)
+        if cursor < 0:
+            return -1
+        parent_indent = _line_indent(lines[cursor])
+        cursor += 1
+    return _find_key_at_or_after(lines, key, cursor, parent_indent)
+
+
+def _find_key_at_or_after(
+    lines: list[str], key: str, start: int, parent_indent: int
+) -> int:
+    """Find *key* starting at line *start*, deeper than *parent_indent*.
+
+    A negative *parent_indent* means "any indent" (used at the
+    top-level scan).
+    """
+    for index in range(start, len(lines)):
+        line = lines[index]
+        stripped = line.strip()
+        if stripped == "" or stripped.startswith("#"):
+            continue
+        indent = _line_indent(line)
+        if parent_indent >= 0 and indent <= parent_indent:
+            # Left the parent block — key not found inside it.
+            return -1
+        if stripped.startswith(key):
+            return index
+    return -1
+
+
+def _find_child_key(
+    lines: list[str], parent_line: int, key: str
+) -> int:
+    """Find *key* as a direct child of the mapping declared at *parent_line*.
+
+    A direct child is the first key found at indent strictly greater
+    than the parent's indent, before any line at indent <= parent's.
+    Returns the line index or -1.
+    """
+    parent_indent = _line_indent(lines[parent_line])
+    return _find_key_at_or_after(lines, key, parent_line + 1, parent_indent)
+
+
+def _scalar_value(line: str, key: str) -> str:
+    """Return the scalar value following *key* on *line*.
+
+    Strips inline ``# comment`` tails, surrounding whitespace, and
+    matching surrounding quotes (single or double).  Returns ``""`` if
+    the key has no value (a list-introducing scalar).
+    """
+    after_key = line.split(key, 1)[1]
+    # Strip trailing inline comment.  YAML allows a comment after a
+    # space; a literal ``#`` inside a quoted scalar is preserved by
+    # this helper, since the configuration file does not use ``#`` in
+    # scalar values today.
+    hash_index = after_key.find(" #")
+    if hash_index >= 0:
+        after_key = after_key[:hash_index]
+    value = after_key.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        value = value[1:-1]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Diff
+# ---------------------------------------------------------------------------
+
+
+def diff(
+    catalog: set[str], extracted: set[str]
+) -> tuple[set[str], set[str]]:
+    """Return ``(additions, removals)`` between *catalog* and *extracted*.
+
+    Additions are tools in *extracted* not in *catalog* (upstream-led).
+    Removals are tools in *catalog* not in *extracted* (catalog-led).
+    """
+    return (extracted - catalog, catalog - extracted)
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+def apply_additions(
+    yaml_text: str,
+    additions: set[str],
+    today_iso: str,
+    harness: str = "claude_code",
+) -> str:
+    """Return *yaml_text* with *additions* appended to the harness-tools
+    list and ``last_checked`` rewritten to *today_iso*.
+
+    Additions are inserted in alphabetical order at the end of the
+    existing list — preserves the existing order of catalog entries
+    (so the diff stays readable) while keeping new entries
+    deterministic.  Removals are NOT applied here; they are rendered
+    in the human-readable summary for review.
+
+    If *additions* is empty, only ``last_checked`` is updated.
+    """
+    parsed = parse_catalog(yaml_text, harness=harness)
+    lines = yaml_text.splitlines(keepends=True)
+    indent = " " * parsed["harness_tools_indent"]
+
+    new_items = [
+        f"{indent}- {tool}\n"
+        for tool in sorted(additions)
+        if tool not in set(parsed["harness_tools"])
+    ]
+
+    insert_at = parsed["harness_tools_end_line"]
+
+    rebuilt: list[str] = []
+    for index, line in enumerate(lines):
+        if index == insert_at and new_items:
+            rebuilt.extend(new_items)
+        if index == parsed["last_checked_line"]:
+            rebuilt.append(_replace_scalar(line, "last_checked:", today_iso))
+        else:
+            rebuilt.append(line)
+
+    if insert_at >= len(lines) and new_items:
+        # End-of-file insertion — list runs to the very last line.
+        rebuilt.extend(new_items)
+
+    return "".join(rebuilt)
+
+
+def _replace_scalar(line: str, key: str, value: str) -> str:
+    """Rewrite the scalar after *key* on *line* to *value*.
+
+    Preserves leading whitespace, the key, the gap between key and
+    value (a single space), and the trailing newline.  Always
+    double-quotes the value so dates like ``2026-05-01`` survive YAML
+    type coercion (the foundry's parser would otherwise treat an
+    unquoted ISO-8601 date as a plain scalar).
+    """
+    leading_ws = line[: len(line) - len(line.lstrip(" "))]
+    eol = "\n" if line.endswith("\n") else ""
+    return f'{leading_ws}{key} "{value}"{eol}'
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+
+def render_summary(
+    additions: set[str],
+    removals: set[str],
+    source_url: str,
+    today_iso: str,
+) -> str:
+    """Return a human- and PR-body-friendly markdown summary.
+
+    Output is markdown so the same string works for stdout
+    (``--dry-run``) and the GitHub PR body.  Sections are omitted
+    when empty.
+    """
+    lines: list[str] = []
+    if additions or removals:
+        lines.append("# Tool catalog drift detected")
+    else:
+        lines.append("# No drift detected")
+    lines.append("")
+    lines.append(f"- **Source:** {source_url}")
+    lines.append(f"- **Checked:** {today_iso}")
+    lines.append("")
+
+    if additions:
+        lines.append(
+            f"## Additions auto-applied ({len(additions)})"
+        )
+        lines.append("")
+        lines.append(
+            "Tools present in upstream but missing from the catalog. "
+            "Already added to the YAML in this PR."
+        )
+        lines.append("")
+        for tool in sorted(additions):
+            lines.append(f"- `{tool}`")
+        lines.append("")
+
+    if removals:
+        lines.append(
+            f"## Candidate removals — review before deleting ({len(removals)})"
+        )
+        lines.append("")
+        lines.append(
+            "Tools in the catalog but not seen in the upstream tools "
+            "reference table. NOT auto-removed — verify each name "
+            "before deleting. Possible causes: upstream renamed or "
+            "removed the tool, the table format changed, or the "
+            "extraction missed a row."
+        )
+        lines.append("")
+        for tool in sorted(removals):
+            lines.append(f"- `{tool}`")
+        lines.append("")
+
+    if not additions and not removals:
+        lines.append(
+            "All catalog tools match the upstream tools reference. "
+            "`last_checked` updated."
+        )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _today_iso() -> str:
+    return datetime.date.today().isoformat()
+
+
+def run(
+    catalog_path: str,
+    today_iso: str,
+    dry_run: bool,
+) -> tuple[bool, str]:
+    """Run the drift sweep against the catalog at *catalog_path*.
+
+    Returns ``(drift_detected, summary)``.  In default (non-dry-run)
+    mode, additions are applied to the catalog file and
+    ``last_checked`` is updated regardless of drift state.  In dry-run
+    mode, no file edits happen.
+
+    Raises :class:`FetchError` or :class:`ParseError` on hard-fail
+    conditions; the caller maps those to non-zero exit codes.
+    """
+    with open(catalog_path, "r", encoding="utf-8") as fh:
+        yaml_text = fh.read()
+
+    parsed = parse_catalog(yaml_text)
+    source_url = parsed["source_url"] or DEFAULT_SOURCE_URL
+
+    markdown = fetch(source_url)
+    extracted = extract_tools(markdown)
+    catalog = set(parsed["harness_tools"])
+    additions, removals = diff(catalog, extracted)
+
+    summary = render_summary(additions, removals, source_url, today_iso)
+
+    if not dry_run:
+        new_yaml = apply_additions(yaml_text, additions, today_iso)
+        if new_yaml != yaml_text:
+            with open(catalog_path, "w", encoding="utf-8") as fh:
+                fh.write(new_yaml)
+
+    return (bool(additions or removals), summary)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Detect drift between the Claude Code tool catalog in "
+            "configuration.yaml and the canonical upstream tools "
+            "reference. Auto-applies additions; flags removals as "
+            "advisory."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Print the planned diff to stdout without modifying the "
+            "catalog file. Exits 0 when no drift, 1 when drift "
+            "detected, non-zero on errors."
+        ),
+    )
+    parser.add_argument(
+        "--catalog-path",
+        default=CATALOG_PATH,
+        help=(
+            "Path to configuration.yaml. Defaults to the foundry's "
+            "canonical location."
+        ),
+    )
+    parser.add_argument(
+        "--today",
+        default=None,
+        help=(
+            "Override today's date (ISO 8601 YYYY-MM-DD) for "
+            "deterministic test runs. Defaults to the system date."
+        ),
+    )
+    parser.add_argument(
+        "--summary-out",
+        default=None,
+        help=(
+            "If set, write the rendered summary to this path "
+            "(in addition to printing it to stdout). Used by the "
+            "workflow to compose the PR body."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    today_iso = args.today or _today_iso()
+
+    try:
+        drift_detected, summary = run(
+            catalog_path=args.catalog_path,
+            today_iso=today_iso,
+            dry_run=args.dry_run,
+        )
+    except FetchError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 2
+    except ParseError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 3
+    except OSError as exc:
+        print(f"FAIL: I/O error: {exc}", file=sys.stderr)
+        return 4
+
+    sys.stdout.write(summary)
+
+    if args.summary_out:
+        with open(args.summary_out, "w", encoding="utf-8") as fh:
+            fh.write(summary)
+
+    if args.dry_run:
+        return 1 if drift_detected else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -331,6 +331,21 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
             "than falling back to a default (silent fallback would "
             "mask misconfigurations)"
         )
+    if not last_checked:
+        raise ParseError(
+            f"configuration.yaml has an empty `last_checked` value "
+            f"under `{harness}.provenance` — provide an explicit "
+            "ISO-8601 `YYYY-MM-DD` date so a no-drift / removals-only "
+            "run cannot leave the catalog in an unprovenanced state"
+        )
+    try:
+        datetime.date.fromisoformat(last_checked)
+    except ValueError as exc:
+        raise ParseError(
+            f"configuration.yaml has an invalid `last_checked` value "
+            f"under `{harness}.provenance`: {last_checked!r} — expected "
+            "ISO-8601 `YYYY-MM-DD`"
+        ) from exc
 
     harness_tools_index = _find_child_key(
         lines, harness_index, "harness_tools:"

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -2,10 +2,10 @@
 and the canonical upstream tools reference.
 
 Reads the catalog at ``skill-system-foundry/scripts/lib/configuration.yaml``
-under ``allowed_tools.catalogs.claude_code``, fetches the upstream
-markdown table at ``provenance.source_url`` (default
-``https://code.claude.com/docs/en/tools-reference.md``), and compares
-the two sets of tool names.
+under ``skill.allowed_tools.catalogs.claude_code``, fetches the
+upstream markdown table at the URL recorded in
+``skill.allowed_tools.catalogs.claude_code.provenance.source_url``,
+and compares the two sets of tool names.
 
 Outcomes:
   * Additions (upstream has, catalog lacks) — auto-applied to the YAML
@@ -33,10 +33,10 @@ Tracks ``claude_code`` only.  OpenAI Codex has no harness-level tool
 catalog by design (every tool is MCP-server-sourced and
 user-configured) and Cursor has no documented ``allowed-tools``
 dialect, so no second harness ships in this helper.  The
-``catalogs.<harness>`` YAML structure preserves room for a future
-bucket; adding one will require helper changes (``run`` and
-``parse_catalog`` would need to iterate harness names), not just a
-YAML edit.
+``skill.allowed_tools.catalogs.<harness>`` YAML structure preserves
+room for a future bucket; adding one will require helper changes
+(``run`` and ``parse_catalog`` would need to iterate harness
+names), not just a YAML edit.
 """
 
 import argparse
@@ -259,16 +259,16 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
     if harness_index < 0:
         raise ParseError(
             f"configuration.yaml has no `{harness}:` bucket under "
-            "`allowed_tools.catalogs` — add the bucket or update the "
-            "harness list in this helper"
+            "`skill.allowed_tools.catalogs` — add the bucket or "
+            "update the harness list in this helper"
         )
 
     provenance_index = _find_child_key(lines, harness_index, "provenance:")
     if provenance_index < 0:
         raise ParseError(
             f"configuration.yaml has no `provenance:` block under "
-            f"`allowed_tools.catalogs.{harness}` — schema migration "
-            "incomplete (see issue #118)"
+            f"`skill.allowed_tools.catalogs.{harness}` — schema "
+            "migration incomplete (see issue #118)"
         )
 
     source_url_line = _find_child_key(

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -605,14 +605,20 @@ def run(
     additions, removals = diff(catalog, extracted)
 
     summary = render_summary(additions, removals, source_url, today_iso)
+    drift_detected = bool(additions or removals)
 
-    if not dry_run:
+    # Only rewrite the file when drift is detected.  ``last_checked``
+    # tracks "date the catalog was last changed to reflect upstream",
+    # not "date the workflow last ran" — the GitHub Actions run
+    # history already provides the latter signal, and bumping the
+    # date on every quiet run would produce a noisy commit cadence.
+    if not dry_run and drift_detected:
         new_yaml = apply_additions(yaml_text, additions, today_iso)
         if new_yaml != yaml_text:
             with open(catalog_path, "w", encoding="utf-8") as fh:
                 fh.write(new_yaml)
 
-    return (bool(additions or removals), summary)
+    return (drift_detected, summary)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -321,12 +321,22 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
     for index in range(harness_tools_index + 1, len(lines)):
         line = lines[index]
         stripped = line.strip()
-        if stripped == "" or stripped.startswith("#"):
-            continue
+        # Check dedent BEFORE the blank/comment fast-path so a sibling
+        # comment at the same indent as ``harness_tools:`` terminates
+        # the list scan.  Without this, a comment block documenting the
+        # next sibling key (e.g. the ``# Generic CLI names...`` block
+        # in the foundry catalog) is silently skipped, ``end_line`` is
+        # advanced past the comment, and ``apply_additions`` then
+        # inserts new items between the comment and the key it
+        # documents — splitting the doc from its key in the diff.
+        # Blank lines (indent 0) terminate the same way: standard YAML
+        # lists do not contain blank lines between items.
         indent = _line_indent(line)
         if indent <= parent_indent:
             end_line = index
             break
+        if stripped == "" or stripped.startswith("#"):
+            continue
         if not stripped.startswith("- "):
             end_line = index
             break

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -488,6 +488,12 @@ def apply_additions(
 
     if insert_at >= len(lines) and new_items:
         # End-of-file insertion — list runs to the very last line.
+        # If that last line lacks a trailing newline, appending the
+        # first ``- Tool\n`` would concatenate it onto the previous
+        # line and produce invalid YAML.  Repair the previous line
+        # before extending.
+        if rebuilt and not rebuilt[-1].endswith("\n"):
+            rebuilt[-1] += "\n"
         rebuilt.extend(new_items)
 
     return "".join(rebuilt)

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -14,10 +14,15 @@ Outcomes:
     summary as advisory; never auto-applied.  A regex miss or a
     one-version-wide doc edit could falsely propose dropping a real
     tool, so removals always require a human edit.
-  * No drift — no file is rewritten.  ``last_checked`` records the
-    date of the most recent drift-detected reconciliation; quiet
-    runs leave it untouched.  The GitHub Actions run history is the
-    "did the sweep run today" signal.
+  * Removals-only drift — the catalog is left untouched (removals
+    are advisory only, never applied) and the workflow's
+    empty-commit fallback carries the advisory PR.  ``last_checked``
+    records the date of the last *additions-applied* reconciliation,
+    not the date of every drift event, so a removals-only run does
+    not bump it.
+  * No drift — no file is rewritten.  Quiet runs leave
+    ``last_checked`` untouched; the GitHub Actions run history is
+    the "did the sweep run today" signal.
 
 The helper hard-fails on fetch errors, decoding errors, table-shape
 mismatches, and zero tokens extracted.  Silent green is the worst
@@ -628,11 +633,13 @@ def run(
     """Run the drift sweep against the catalog at *catalog_path*.
 
     Returns ``(drift_detected, summary, json_payload)``.  In default
-    (non-dry-run) mode the catalog file is rewritten only when drift
-    is detected — additions are applied and ``last_checked`` is
-    bumped to *today_iso* in the same write.  Quiet (no-drift) runs
-    leave the file untouched.  In dry-run mode no file edits happen
-    regardless.
+    (non-dry-run) mode the catalog file is rewritten only when there
+    are additions to apply — additions are inserted and
+    ``last_checked`` is bumped to *today_iso* in the same write.
+    Removals-only drift leaves the file untouched (removals are
+    advisory and never applied); the workflow surfaces those via the
+    PR body.  Quiet (no-drift) runs also leave the file untouched.
+    In dry-run mode no file edits happen regardless.
 
     Raises :class:`FetchError` or :class:`ParseError` on hard-fail
     conditions; the caller maps those to non-zero exit codes.
@@ -662,12 +669,17 @@ def run(
         "upstream_size": len(extracted),
     }
 
-    # Only rewrite the file when drift is detected.  ``last_checked``
-    # tracks "date the catalog was last changed to reflect upstream",
-    # not "date the workflow last ran" — the GitHub Actions run
-    # history already provides the latter signal, and bumping the
-    # date on every quiet run would produce a noisy commit cadence.
-    if not dry_run and drift_detected:
+    # Rewrite the catalog only when there are additions to apply.
+    # ``last_checked`` records "date the catalog was last changed to
+    # reflect upstream", which means the date of the last
+    # auto-applied additions — not the date of any drift-detection
+    # run.  Removals are advisory only; bumping ``last_checked`` for
+    # a removals-only run would mutate the catalog despite nothing
+    # being applied, producing date-only churn that contradicts the
+    # advisory-only contract.  Quiet runs (no drift) and removals-only
+    # drift therefore both leave the file untouched; the workflow's
+    # empty-commit fallback carries the advisory PR for removals.
+    if not dry_run and additions:
         new_yaml = apply_additions(yaml_text, additions, today_iso)
         if new_yaml != yaml_text:
             with open(catalog_path, "w", encoding="utf-8") as fh:

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -72,12 +72,23 @@ RE_HARNESS_SHAPE = re.compile(r"^[A-Z][A-Za-z0-9]*$")
 # look like ``| `Bash` | Executes shell commands ... |``.  The pattern
 # is anchored against the leading pipe and trailing pipe so prose-only
 # rows do not false-positive.
+#
+# The leading-``|`` requirement is intentional and matches the
+# canonical upstream format at
+# https://code.claude.com/docs/en/tools-reference.md.  GitHub-Flavored
+# Markdown also permits a pipe-less form (``Tool | Description | ...``
+# with no leading or trailing ``|``), but the helper does NOT accept
+# that form: per the documented hard-fail-on-shape-change contract, an
+# upstream switch to pipe-less rendering should surface as a loud
+# ``ParseError`` (and a CI-visible workflow failure) so a maintainer
+# can update the parser deliberately, rather than being silently
+# absorbed at the risk of hiding other simultaneous shape changes.
 RE_TABLE_ROW_FIRST_CELL = re.compile(r"^\|\s*`([^`]+)`\s*\|")
 
 # Header row sanity check.  The tools-reference table has a "Tool"
 # column (first) and a "Description" column (second).  If the header
 # changes shape, hard-fail rather than silently scanning the wrong
-# table.
+# table.  See the leading-pipe rationale above ``RE_TABLE_ROW_FIRST_CELL``.
 RE_TABLE_HEADER = re.compile(
     r"^\|\s*Tool\s*\|\s*Description\s*\|", re.IGNORECASE
 )

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -189,9 +189,15 @@ def extract_tools(markdown_text: str) -> set[str]:
 
     tools: set[str] = set()
     for line in lines[header_index + 2:]:
-        if not line.startswith("|"):
-            break
+        # Two distinct table-end signals.  Check blank-line first so
+        # the ``not line.startswith("|")`` branch handles only the
+        # narrower "non-blank, not a table row" case (e.g. a heading
+        # or paragraph immediately after the table); blank lines are
+        # the more common terminator and reading the strip() check
+        # first makes that intent explicit.
         if line.strip() == "":
+            break
+        if not line.startswith("|"):
             break
         match = RE_TABLE_ROW_FIRST_CELL.match(line)
         if match is None:
@@ -528,12 +534,19 @@ def render_summary(
     removals: set[str],
     source_url: str,
     today_iso: str,
+    applied: bool = True,
 ) -> str:
     """Return a human- and PR-body-friendly markdown summary.
 
     Output is markdown so the same string works for stdout
     (``--dry-run``) and the GitHub PR body.  Sections are omitted
     when empty.
+
+    *applied* controls the verb tense in the additions section:
+    ``True`` (default, for non-dry-run runs and the workflow's
+    PR-body output) renders "auto-applied" / "Already added"; ``False``
+    (for ``--dry-run``) renders "would be applied" / "Would be added"
+    so the output does not falsely claim file mutation.
     """
     lines: list[str] = []
     if additions or removals:
@@ -546,14 +559,25 @@ def render_summary(
     lines.append("")
 
     if additions:
-        lines.append(
-            f"## Additions auto-applied ({len(additions)})"
-        )
-        lines.append("")
-        lines.append(
-            "Tools present in upstream but missing from the catalog. "
-            "Already added to the YAML in this PR."
-        )
+        if applied:
+            lines.append(
+                f"## Additions auto-applied ({len(additions)})"
+            )
+            lines.append("")
+            lines.append(
+                "Tools present in upstream but missing from the "
+                "catalog. Already added to the YAML in this PR."
+            )
+        else:
+            lines.append(
+                f"## Additions that would be applied ({len(additions)})"
+            )
+            lines.append("")
+            lines.append(
+                "Tools present in upstream but missing from the "
+                "catalog. Dry run — no file mutation; running "
+                "without `--dry-run` would add these to the YAML."
+            )
         lines.append("")
         for tool in sorted(additions):
             lines.append(f"- `{tool}`")
@@ -624,7 +648,9 @@ def run(
     catalog = set(parsed["harness_tools"])
     additions, removals = diff(catalog, extracted)
 
-    summary = render_summary(additions, removals, source_url, today_iso)
+    summary = render_summary(
+        additions, removals, source_url, today_iso, applied=not dry_run,
+    )
     drift_detected = bool(additions or removals)
     json_payload = {
         "drift": drift_detected,
@@ -663,9 +689,10 @@ def main(argv: list[str] | None = None) -> int:
         "--dry-run",
         action="store_true",
         help=(
-            "Print the planned diff to stdout without modifying the "
-            "catalog file. Exits 0 when no drift, 1 when drift "
-            "detected, non-zero on errors."
+            "Print the planned summary to stdout (or JSON with "
+            "--json) without modifying the catalog file. Exits 0 "
+            "when no drift, 1 when drift detected, non-zero on "
+            "errors."
         ),
     )
     parser.add_argument(

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -78,11 +78,6 @@ RE_TABLE_HEADER = re.compile(
 )
 RE_TABLE_SEPARATOR = re.compile(r"^\|\s*[: -]+\s*\|")
 
-# Default URL when ``provenance.source_url`` is missing from the YAML.
-# Used only as a backstop — normal operation reads the URL from the
-# catalog's own provenance block.
-DEFAULT_SOURCE_URL = "https://code.claude.com/docs/en/tools-reference.md"
-
 # HTTP timeouts.  Generous enough for slow CDNs, tight enough that a
 # hung connection does not stall the workflow indefinitely.
 FETCH_TIMEOUT_SECONDS = 30
@@ -165,7 +160,10 @@ def extract_tools(markdown_text: str) -> set[str]:
 
     Hard-fails (raises :class:`ParseError`) when:
       * No header row matching ``Tool | Description | ...`` is found.
-      * Zero tools are extracted.
+      * The header row has no following body line (truncated table).
+      * The header row is not followed by a ``| :--- | :--- | ...``
+        separator (table format may have changed).
+      * Zero tools are extracted from the body rows.
     """
     lines = markdown_text.splitlines()
     header_index = -1
@@ -288,6 +286,13 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
 
     source_url = _scalar_value(lines[source_url_line], "source_url:")
     last_checked = _scalar_value(lines[last_checked_line], "last_checked:")
+    if not source_url:
+        raise ParseError(
+            f"configuration.yaml has an empty `source_url` value under "
+            f"`{harness}.provenance` — provide an explicit URL rather "
+            "than falling back to a default (silent fallback would "
+            "mask misconfigurations)"
+        )
 
     harness_tools_index = _find_child_key(
         lines, harness_index, "harness_tools:"
@@ -463,10 +468,11 @@ def apply_additions(
     lines = yaml_text.splitlines(keepends=True)
     indent = " " * parsed["harness_tools_indent"]
 
+    existing = set(parsed["harness_tools"])
     new_items = [
         f"{indent}- {tool}\n"
         for tool in sorted(additions)
-        if tool not in set(parsed["harness_tools"])
+        if tool not in existing
     ]
 
     insert_at = parsed["harness_tools_end_line"]
@@ -492,9 +498,14 @@ def _replace_scalar(line: str, key: str, value: str) -> str:
 
     Preserves leading whitespace, the key, the gap between key and
     value (a single space), and the trailing newline.  Always
-    double-quotes the value so dates like ``2026-05-01`` survive YAML
-    type coercion (the foundry's parser would otherwise treat an
-    unquoted ISO-8601 date as a plain scalar).
+    double-quotes the value for stylistic consistency with the
+    existing ``last_checked: "YYYY-MM-DD"`` form in the catalog and
+    to keep the rewritten value safe under stricter YAML 1.1 readers
+    (PyYAML and friends), which DO coerce unquoted ISO-8601 dates
+    to ``datetime.date``.  The foundry's own subset parser returns
+    every scalar as a string, so for foundry consumers the quoting
+    is purely cosmetic; the defensive form helps third-party tooling
+    that may load this file.
     """
     leading_ws = line[: len(line) - len(line.lstrip(" "))]
     eol = "\n" if line.endswith("\n") else ""
@@ -600,7 +611,7 @@ def run(
         yaml_text = fh.read()
 
     parsed = parse_catalog(yaml_text)
-    source_url = parsed["source_url"] or DEFAULT_SOURCE_URL
+    source_url = parsed["source_url"]
 
     markdown = fetch(source_url)
     extracted = extract_tools(markdown)

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -158,10 +158,13 @@ def extract_tools(markdown_text: str) -> set[str]:
     Strategy: locate the header row whose first two columns are
     ``Tool`` and ``Description``, skip the separator row, then read
     the first column of every following row until the table ends (a
-    blank line or a non-table line).  The first cell is expected to
-    be a backticked identifier; rows without one are skipped silently
-    (footers, prose, or row separators).  Identifiers must match the
-    PascalCase shape regex.
+    blank line or a non-table line).  Each body row inside the table
+    is expected to start with a backticked identifier in the first
+    cell; rows that fail this check are treated as table-shape drift
+    and raise :class:`ParseError`.  Identifiers must match the
+    PascalCase shape regex; well-formed rows whose identifier does
+    not (e.g. ``mcp__server__tool``) are skipped silently and do not
+    contribute to the extracted set.
 
     Hard-fails (raises :class:`ParseError`) when:
       * No header row matching ``Tool | Description | ...`` is found.

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -14,9 +14,10 @@ Outcomes:
     summary as advisory; never auto-applied.  A regex miss or a
     one-version-wide doc edit could falsely propose dropping a real
     tool, so removals always require a human edit.
-  * No drift — ``last_checked`` is rewritten on every successful run
-    so the YAML diff alone signals when the catalog was last
-    reconciled with upstream.
+  * No drift — no file is rewritten.  ``last_checked`` records the
+    date of the most recent drift-detected reconciliation; quiet
+    runs leave it untouched.  The GitHub Actions run history is the
+    "did the sweep run today" signal.
 
 The helper hard-fails on fetch errors, decoding errors, table-shape
 mismatches, and zero tokens extracted.  Silent green is the worst
@@ -28,10 +29,14 @@ the meta-skill: the helper is repo infrastructure under
 ``.github/scripts/`` and stays isolated from
 ``skill-system-foundry/scripts/lib/``.
 
-Adding another tracked harness later (e.g. a future Codex catalog
-that publishes a canonical tool list) is a YAML edit and a one-line
-addition to ``HARNESS_NAMES`` below — the parser, fetcher, and writer
-keep their shape.
+Tracks ``claude_code`` only.  OpenAI Codex has no harness-level tool
+catalog by design (every tool is MCP-server-sourced and
+user-configured) and Cursor has no documented ``allowed-tools``
+dialect, so no second harness ships in this helper.  The
+``catalogs.<harness>`` YAML structure preserves room for a future
+bucket; adding one will require helper changes (``run`` and
+``parse_catalog`` would need to iterate harness names), not just a
+YAML edit.
 """
 
 import argparse
@@ -53,12 +58,6 @@ REPO_ROOT = os.path.abspath(
 CATALOG_PATH = os.path.join(
     REPO_ROOT, "skill-system-foundry", "scripts", "lib", "configuration.yaml"
 )
-
-# Harness names tracked by this sweep.  Today only ``claude_code`` has
-# a canonical upstream catalog; the YAML structure preserves room for
-# future harness buckets but no second harness ships in this PR.  See
-# the design comment on issue #118.
-HARNESS_NAMES: tuple[str, ...] = ("claude_code",)
 
 # PascalCase token shape.  Matches ``Bash``, ``WebFetch``, ``LSP``, and
 # any future PascalCase or all-caps acronym tool name.  Anchored.
@@ -563,7 +562,8 @@ def render_summary(
     if not additions and not removals:
         lines.append(
             "All catalog tools match the upstream tools reference. "
-            "`last_checked` updated."
+            "No catalog changes written — quiet runs leave "
+            "`last_checked` untouched."
         )
         lines.append("")
 
@@ -587,9 +587,11 @@ def run(
     """Run the drift sweep against the catalog at *catalog_path*.
 
     Returns ``(drift_detected, summary, json_payload)``.  In default
-    (non-dry-run) mode, additions are applied to the catalog file and
-    ``last_checked`` is updated when drift is detected.  In dry-run
-    mode, no file edits happen.
+    (non-dry-run) mode the catalog file is rewritten only when drift
+    is detected — additions are applied and ``last_checked`` is
+    bumped to *today_iso* in the same write.  Quiet (no-drift) runs
+    leave the file untouched.  In dry-run mode no file edits happen
+    regardless.
 
     Raises :class:`FetchError` or :class:`ParseError` on hard-fail
     conditions; the caller maps those to non-zero exit codes.

--- a/.github/tests/fixtures/tools-reference.md
+++ b/.github/tests/fixtures/tools-reference.md
@@ -1,149 +1,49 @@
-> ## Documentation Index
-> Fetch the complete documentation index at: https://code.claude.com/docs/llms.txt
-> Use this file to discover all available pages before exploring further.
+# Tools reference (synthetic test fixture)
 
-# Tools reference
+Synthetic markdown fixture for the tool-catalog-drift extractor
+tests. The structure mirrors what the helper expects from
+`code.claude.com/docs/en/tools-reference.md` (Mintlify-rendered
+markdown) — a `Tool | Description | Permission Required` table
+preceded by some prose. Tool names are real (so tests can pin
+canonical entries like `Bash` and `LSP`), but the surrounding prose
+is minimal and synthetic to avoid vendoring upstream documentation
+verbatim. Update this file when the canonical tool list changes
+upstream and rerun the helper test suite.
 
-> Complete reference for the tools Claude Code can use, including permission requirements.
-
-Claude Code has access to a set of built-in tools that help it understand and modify your codebase. The tool names are the exact strings you use in [permission rules](/en/permissions#tool-specific-permission-rules), [subagent tool lists](/en/sub-agents), and [hook matchers](/en/hooks). To disable a tool entirely, add its name to the `deny` array in your [permission settings](/en/permissions#tool-specific-permission-rules).
-
-To add custom tools, connect an [MCP server](/en/mcp). To extend Claude with reusable prompt-based workflows, write a [skill](/en/skills), which runs through the existing `Skill` tool rather than adding a new tool entry.
-
-| Tool                   | Description                                                                                                                                                                                                                                                               | Permission Required |
-| :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------ |
-| `Agent`                | Spawns a [subagent](/en/sub-agents) with its own context window to handle a task                                                                                                                                                                                          | No                  |
-| `AskUserQuestion`      | Asks multiple-choice questions to gather requirements or clarify ambiguity                                                                                                                                                                                                | No                  |
-| `Bash`                 | Executes shell commands in your environment. See [Bash tool behavior](#bash-tool-behavior)                                                                                                                                                                                | Yes                 |
-| `CronCreate`           | Schedules a recurring or one-shot prompt within the current session. Tasks are session-scoped and restored on `--resume` or `--continue` if unexpired. See [scheduled tasks](/en/scheduled-tasks)                                                                         | No                  |
-| `CronDelete`           | Cancels a scheduled task by ID                                                                                                                                                                                                                                            | No                  |
-| `CronList`             | Lists all scheduled tasks in the session                                                                                                                                                                                                                                  | No                  |
-| `Edit`                 | Makes targeted edits to specific files                                                                                                                                                                                                                                    | Yes                 |
-| `EnterPlanMode`        | Switches to plan mode to design an approach before coding                                                                                                                                                                                                                 | No                  |
-| `EnterWorktree`        | Creates an isolated [git worktree](/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees) and switches into it. Pass a `path` to switch into an existing worktree of the current repository instead of creating a new one. Not available to subagents | No                  |
-| `ExitPlanMode`         | Presents a plan for approval and exits plan mode                                                                                                                                                                                                                          | Yes                 |
-| `ExitWorktree`         | Exits a worktree session and returns to the original directory. Not available to subagents                                                                                                                                                                                | No                  |
-| `Glob`                 | Finds files based on pattern matching                                                                                                                                                                                                                                     | No                  |
-| `Grep`                 | Searches for patterns in file contents                                                                                                                                                                                                                                    | No                  |
-| `ListMcpResourcesTool` | Lists resources exposed by connected [MCP servers](/en/mcp)                                                                                                                                                                                                               | No                  |
-| `LSP`                  | Code intelligence via language servers: jump to definitions, find references, report type errors and warnings. See [LSP tool behavior](#lsp-tool-behavior)                                                                                                                | No                  |
-| `Monitor`              | Runs a command in the background and feeds each output line back to Claude, so it can react to log entries, file changes, or polled status mid-conversation. See [Monitor tool](#monitor-tool)                                                                            | Yes                 |
-| `NotebookEdit`         | Modifies Jupyter notebook cells                                                                                                                                                                                                                                           | Yes                 |
-| `PowerShell`           | Executes PowerShell commands natively. See [PowerShell tool](#powershell-tool) for availability                                                                                                                                                                           | Yes                 |
-| `Read`                 | Reads the contents of files                                                                                                                                                                                                                                               | No                  |
-| `ReadMcpResourceTool`  | Reads a specific MCP resource by URI                                                                                                                                                                                                                                      | No                  |
-| `SendMessage`          | Sends a message to an [agent team](/en/agent-teams) teammate, or [resumes a subagent](/en/sub-agents#resume-subagents) by its agent ID. Stopped subagents auto-resume in the background. Only available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set              | No                  |
-| `Skill`                | Executes a [skill](/en/skills#control-who-invokes-a-skill) within the main conversation                                                                                                                                                                                   | Yes                 |
-| `TaskCreate`           | Creates a new task in the task list                                                                                                                                                                                                                                       | No                  |
-| `TaskGet`              | Retrieves full details for a specific task                                                                                                                                                                                                                                | No                  |
-| `TaskList`             | Lists all tasks with their current status                                                                                                                                                                                                                                 | No                  |
-| `TaskOutput`           | (Deprecated) Retrieves output from a background task. Prefer `Read` on the task's output file path                                                                                                                                                                        | No                  |
-| `TaskStop`             | Kills a running background task by ID                                                                                                                                                                                                                                     | No                  |
-| `TaskUpdate`           | Updates task status, dependencies, details, or deletes tasks                                                                                                                                                                                                              | No                  |
-| `TeamCreate`           | Creates an [agent team](/en/agent-teams) with multiple teammates. Only available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set                                                                                                                                     | No                  |
-| `TeamDelete`           | Disbands an agent team and cleans up teammate processes. Only available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set                                                                                                                                              | No                  |
-| `TodoWrite`            | Manages the session task checklist. Available in non-interactive mode and the [Agent SDK](/en/headless); interactive sessions use TaskCreate, TaskGet, TaskList, and TaskUpdate instead                                                                                   | No                  |
-| `ToolSearch`           | Searches for and loads deferred tools when [tool search](/en/mcp#scale-with-mcp-tool-search) is enabled                                                                                                                                                                   | No                  |
-| `WebFetch`             | Fetches content from a specified URL                                                                                                                                                                                                                                      | Yes                 |
-| `WebSearch`            | Performs web searches                                                                                                                                                                                                                                                     | Yes                 |
-| `Write`                | Creates or overwrites files                                                                                                                                                                                                                                               | Yes                 |
-
-Permission rules can be configured using `/permissions` or in [permission settings](/en/settings#available-settings). Also see [Tool-specific permission rules](/en/permissions#tool-specific-permission-rules).
-
-## Bash tool behavior
-
-The Bash tool runs each command in a separate process with the following persistence behavior:
-
-* When Claude runs `cd` in the main session, the new working directory carries over to later Bash commands as long as it stays inside the project directory or an [additional working directory](/en/permissions#working-directories) you added with `--add-dir`, `/add-dir`, or `additionalDirectories` in settings. Subagent sessions never carry over working directory changes.
-  * If `cd` lands outside those directories, Claude Code resets to the project directory and appends `Shell cwd was reset to <dir>` to the tool result.
-  * To disable this carry-over so every Bash command starts in the project directory, set `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1`.
-* Environment variables do not persist. An `export` in one command will not be available in the next.
-
-Activate your virtualenv or conda environment before launching Claude Code. To make environment variables persist across Bash commands, set [`CLAUDE_ENV_FILE`](/en/env-vars) to a shell script before launching Claude Code, or use a [SessionStart hook](/en/hooks#persist-environment-variables) to populate it dynamically.
-
-## LSP tool behavior
-
-The LSP tool gives Claude code intelligence from a running language server. After each file edit, it automatically reports type errors and warnings so Claude can fix issues without a separate build step. Claude can also call it directly to navigate code:
-
-* Jump to a symbol's definition
-* Find all references to a symbol
-* Get type information at a position
-* List symbols in a file or workspace
-* Find implementations of an interface
-* Trace call hierarchies
-
-The tool is inactive until you install a [code intelligence plugin](/en/discover-plugins#code-intelligence) for your language. The plugin bundles the language server configuration, and you install the server binary separately.
-
-## Monitor tool
-
-<Note>
-  The Monitor tool requires Claude Code v2.1.98 or later.
-</Note>
-
-The Monitor tool lets Claude watch something in the background and react when it changes, without pausing the conversation. Ask Claude to:
-
-* Tail a log file and flag errors as they appear
-* Poll a PR or CI job and report when its status changes
-* Watch a directory for file changes
-* Track output from any long-running script you point it at
-
-Claude writes a small script for the watch, runs it in the background, and receives each output line as it arrives. You keep working in the same session and Claude interjects when an event lands. Stop a monitor by asking Claude to cancel it or by ending the session.
-
-Monitor uses the same [permission rules as Bash](/en/permissions#tool-specific-permission-rules), so `allow` and `deny` patterns you have set for Bash apply here too. It is not available on Amazon Bedrock, Google Vertex AI, or Microsoft Foundry. It is also not available when `DISABLE_TELEMETRY` or `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` is set.
-
-Plugins can declare monitors that start automatically when the plugin is active, instead of asking Claude to start them. See [plugin monitors](/en/plugins-reference#monitors).
-
-## PowerShell tool
-
-The PowerShell tool lets Claude run PowerShell commands natively. On Windows, this means commands run in PowerShell instead of routing through Git Bash. On Windows without Git Bash, the tool is enabled automatically. On Windows with Git Bash installed, the tool is rolling out progressively. On Linux, macOS, and WSL, the tool is opt-in.
-
-### Enable the PowerShell tool
-
-Set `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` in your environment or in `settings.json`:
-
-```json theme={null}
-{
-  "env": {
-    "CLAUDE_CODE_USE_POWERSHELL_TOOL": "1"
-  }
-}
-```
-
-On Windows, set the variable to `0` to opt out of the rollout. On Linux, macOS, and WSL, the tool requires PowerShell 7 or later: install `pwsh` and ensure it is on your `PATH`.
-
-On Windows, Claude Code auto-detects `pwsh.exe` for PowerShell 7+ with a fallback to `powershell.exe` for PowerShell 5.1. The Bash tool remains registered alongside the PowerShell tool, so you may need to ask Claude to use PowerShell.
-
-### Shell selection in settings, hooks, and skills
-
-Three additional settings control where PowerShell is used:
-
-* `"defaultShell": "powershell"` in [`settings.json`](/en/settings#available-settings): routes interactive `!` commands through PowerShell. Requires the PowerShell tool to be enabled.
-* `"shell": "powershell"` on individual [command hooks](/en/hooks#command-hook-fields): runs that hook in PowerShell. Hooks spawn PowerShell directly, so this works regardless of `CLAUDE_CODE_USE_POWERSHELL_TOOL`.
-* `shell: powershell` in [skill frontmatter](/en/skills#frontmatter-reference): runs `` !`command` `` blocks in PowerShell. Requires the PowerShell tool to be enabled.
-
-The same main-session working-directory reset behavior described under the Bash tool section applies to PowerShell commands, including the `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR` environment variable.
-
-### Preview limitations
-
-The PowerShell tool has the following known limitations during the preview:
-
-* PowerShell profiles are not loaded
-* On Windows, sandboxing is not supported
-
-## Check which tools are available
-
-Your exact tool set depends on your provider, platform, and settings. To check what's loaded in a running session, ask Claude directly:
-
-```text theme={null}
-What tools do you have access to?
-```
-
-Claude gives a conversational summary. For exact MCP tool names, run `/mcp`.
-
-## See also
-
-* [MCP servers](/en/mcp): add custom tools by connecting external servers
-* [Permissions](/en/permissions): permission system, rule syntax, and tool-specific patterns
-* [Subagents](/en/sub-agents): configure tool access for subagents
-* [Hooks](/en/hooks-guide): run custom commands before or after tool execution
-
+| Tool                   | Description                                                                                                                  | Permission Required |
+| :--------------------- | :--------------------------------------------------------------------------------------------------------------------------- | :------------------ |
+| `Agent`                | Synthetic description for the Agent tool.                                                                                    | No                  |
+| `AskUserQuestion`      | Synthetic description for the AskUserQuestion tool.                                                                          | No                  |
+| `Bash`                 | Synthetic description for the Bash tool.                                                                                     | Yes                 |
+| `CronCreate`           | Synthetic description for the CronCreate tool.                                                                               | No                  |
+| `CronDelete`           | Synthetic description for the CronDelete tool.                                                                               | No                  |
+| `CronList`             | Synthetic description for the CronList tool.                                                                                 | No                  |
+| `Edit`                 | Synthetic description for the Edit tool.                                                                                     | Yes                 |
+| `EnterPlanMode`        | Synthetic description for the EnterPlanMode tool.                                                                            | No                  |
+| `EnterWorktree`        | Synthetic description for the EnterWorktree tool.                                                                            | No                  |
+| `ExitPlanMode`         | Synthetic description for the ExitPlanMode tool.                                                                             | Yes                 |
+| `ExitWorktree`         | Synthetic description for the ExitWorktree tool.                                                                             | No                  |
+| `Glob`                 | Synthetic description for the Glob tool.                                                                                     | No                  |
+| `Grep`                 | Synthetic description for the Grep tool.                                                                                     | No                  |
+| `ListMcpResourcesTool` | Synthetic description for the ListMcpResourcesTool tool.                                                                     | No                  |
+| `LSP`                  | Synthetic description for the LSP tool.                                                                                      | No                  |
+| `Monitor`              | Synthetic description for the Monitor tool.                                                                                  | Yes                 |
+| `NotebookEdit`         | Synthetic description for the NotebookEdit tool.                                                                             | Yes                 |
+| `PowerShell`           | Synthetic description for the PowerShell tool.                                                                               | Yes                 |
+| `Read`                 | Synthetic description for the Read tool.                                                                                     | No                  |
+| `ReadMcpResourceTool`  | Synthetic description for the ReadMcpResourceTool tool.                                                                      | No                  |
+| `SendMessage`          | Synthetic description for the SendMessage tool.                                                                              | No                  |
+| `Skill`                | Synthetic description for the Skill tool.                                                                                    | Yes                 |
+| `TaskCreate`           | Synthetic description for the TaskCreate tool.                                                                               | No                  |
+| `TaskGet`              | Synthetic description for the TaskGet tool.                                                                                  | No                  |
+| `TaskList`             | Synthetic description for the TaskList tool.                                                                                 | No                  |
+| `TaskOutput`           | Synthetic description for the TaskOutput tool.                                                                               | No                  |
+| `TaskStop`             | Synthetic description for the TaskStop tool.                                                                                 | No                  |
+| `TaskUpdate`           | Synthetic description for the TaskUpdate tool.                                                                               | No                  |
+| `TeamCreate`           | Synthetic description for the TeamCreate tool.                                                                               | No                  |
+| `TeamDelete`           | Synthetic description for the TeamDelete tool.                                                                               | No                  |
+| `TodoWrite`            | Synthetic description for the TodoWrite tool.                                                                                | No                  |
+| `ToolSearch`           | Synthetic description for the ToolSearch tool.                                                                               | No                  |
+| `WebFetch`             | Synthetic description for the WebFetch tool.                                                                                 | Yes                 |
+| `WebSearch`            | Synthetic description for the WebSearch tool.                                                                                | Yes                 |
+| `Write`                | Synthetic description for the Write tool.                                                                                    | Yes                 |

--- a/.github/tests/fixtures/tools-reference.md
+++ b/.github/tests/fixtures/tools-reference.md
@@ -1,0 +1,149 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://code.claude.com/docs/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Tools reference
+
+> Complete reference for the tools Claude Code can use, including permission requirements.
+
+Claude Code has access to a set of built-in tools that help it understand and modify your codebase. The tool names are the exact strings you use in [permission rules](/en/permissions#tool-specific-permission-rules), [subagent tool lists](/en/sub-agents), and [hook matchers](/en/hooks). To disable a tool entirely, add its name to the `deny` array in your [permission settings](/en/permissions#tool-specific-permission-rules).
+
+To add custom tools, connect an [MCP server](/en/mcp). To extend Claude with reusable prompt-based workflows, write a [skill](/en/skills), which runs through the existing `Skill` tool rather than adding a new tool entry.
+
+| Tool                   | Description                                                                                                                                                                                                                                                               | Permission Required |
+| :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------ |
+| `Agent`                | Spawns a [subagent](/en/sub-agents) with its own context window to handle a task                                                                                                                                                                                          | No                  |
+| `AskUserQuestion`      | Asks multiple-choice questions to gather requirements or clarify ambiguity                                                                                                                                                                                                | No                  |
+| `Bash`                 | Executes shell commands in your environment. See [Bash tool behavior](#bash-tool-behavior)                                                                                                                                                                                | Yes                 |
+| `CronCreate`           | Schedules a recurring or one-shot prompt within the current session. Tasks are session-scoped and restored on `--resume` or `--continue` if unexpired. See [scheduled tasks](/en/scheduled-tasks)                                                                         | No                  |
+| `CronDelete`           | Cancels a scheduled task by ID                                                                                                                                                                                                                                            | No                  |
+| `CronList`             | Lists all scheduled tasks in the session                                                                                                                                                                                                                                  | No                  |
+| `Edit`                 | Makes targeted edits to specific files                                                                                                                                                                                                                                    | Yes                 |
+| `EnterPlanMode`        | Switches to plan mode to design an approach before coding                                                                                                                                                                                                                 | No                  |
+| `EnterWorktree`        | Creates an isolated [git worktree](/en/common-workflows#run-parallel-claude-code-sessions-with-git-worktrees) and switches into it. Pass a `path` to switch into an existing worktree of the current repository instead of creating a new one. Not available to subagents | No                  |
+| `ExitPlanMode`         | Presents a plan for approval and exits plan mode                                                                                                                                                                                                                          | Yes                 |
+| `ExitWorktree`         | Exits a worktree session and returns to the original directory. Not available to subagents                                                                                                                                                                                | No                  |
+| `Glob`                 | Finds files based on pattern matching                                                                                                                                                                                                                                     | No                  |
+| `Grep`                 | Searches for patterns in file contents                                                                                                                                                                                                                                    | No                  |
+| `ListMcpResourcesTool` | Lists resources exposed by connected [MCP servers](/en/mcp)                                                                                                                                                                                                               | No                  |
+| `LSP`                  | Code intelligence via language servers: jump to definitions, find references, report type errors and warnings. See [LSP tool behavior](#lsp-tool-behavior)                                                                                                                | No                  |
+| `Monitor`              | Runs a command in the background and feeds each output line back to Claude, so it can react to log entries, file changes, or polled status mid-conversation. See [Monitor tool](#monitor-tool)                                                                            | Yes                 |
+| `NotebookEdit`         | Modifies Jupyter notebook cells                                                                                                                                                                                                                                           | Yes                 |
+| `PowerShell`           | Executes PowerShell commands natively. See [PowerShell tool](#powershell-tool) for availability                                                                                                                                                                           | Yes                 |
+| `Read`                 | Reads the contents of files                                                                                                                                                                                                                                               | No                  |
+| `ReadMcpResourceTool`  | Reads a specific MCP resource by URI                                                                                                                                                                                                                                      | No                  |
+| `SendMessage`          | Sends a message to an [agent team](/en/agent-teams) teammate, or [resumes a subagent](/en/sub-agents#resume-subagents) by its agent ID. Stopped subagents auto-resume in the background. Only available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set              | No                  |
+| `Skill`                | Executes a [skill](/en/skills#control-who-invokes-a-skill) within the main conversation                                                                                                                                                                                   | Yes                 |
+| `TaskCreate`           | Creates a new task in the task list                                                                                                                                                                                                                                       | No                  |
+| `TaskGet`              | Retrieves full details for a specific task                                                                                                                                                                                                                                | No                  |
+| `TaskList`             | Lists all tasks with their current status                                                                                                                                                                                                                                 | No                  |
+| `TaskOutput`           | (Deprecated) Retrieves output from a background task. Prefer `Read` on the task's output file path                                                                                                                                                                        | No                  |
+| `TaskStop`             | Kills a running background task by ID                                                                                                                                                                                                                                     | No                  |
+| `TaskUpdate`           | Updates task status, dependencies, details, or deletes tasks                                                                                                                                                                                                              | No                  |
+| `TeamCreate`           | Creates an [agent team](/en/agent-teams) with multiple teammates. Only available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set                                                                                                                                     | No                  |
+| `TeamDelete`           | Disbands an agent team and cleans up teammate processes. Only available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set                                                                                                                                              | No                  |
+| `TodoWrite`            | Manages the session task checklist. Available in non-interactive mode and the [Agent SDK](/en/headless); interactive sessions use TaskCreate, TaskGet, TaskList, and TaskUpdate instead                                                                                   | No                  |
+| `ToolSearch`           | Searches for and loads deferred tools when [tool search](/en/mcp#scale-with-mcp-tool-search) is enabled                                                                                                                                                                   | No                  |
+| `WebFetch`             | Fetches content from a specified URL                                                                                                                                                                                                                                      | Yes                 |
+| `WebSearch`            | Performs web searches                                                                                                                                                                                                                                                     | Yes                 |
+| `Write`                | Creates or overwrites files                                                                                                                                                                                                                                               | Yes                 |
+
+Permission rules can be configured using `/permissions` or in [permission settings](/en/settings#available-settings). Also see [Tool-specific permission rules](/en/permissions#tool-specific-permission-rules).
+
+## Bash tool behavior
+
+The Bash tool runs each command in a separate process with the following persistence behavior:
+
+* When Claude runs `cd` in the main session, the new working directory carries over to later Bash commands as long as it stays inside the project directory or an [additional working directory](/en/permissions#working-directories) you added with `--add-dir`, `/add-dir`, or `additionalDirectories` in settings. Subagent sessions never carry over working directory changes.
+  * If `cd` lands outside those directories, Claude Code resets to the project directory and appends `Shell cwd was reset to <dir>` to the tool result.
+  * To disable this carry-over so every Bash command starts in the project directory, set `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1`.
+* Environment variables do not persist. An `export` in one command will not be available in the next.
+
+Activate your virtualenv or conda environment before launching Claude Code. To make environment variables persist across Bash commands, set [`CLAUDE_ENV_FILE`](/en/env-vars) to a shell script before launching Claude Code, or use a [SessionStart hook](/en/hooks#persist-environment-variables) to populate it dynamically.
+
+## LSP tool behavior
+
+The LSP tool gives Claude code intelligence from a running language server. After each file edit, it automatically reports type errors and warnings so Claude can fix issues without a separate build step. Claude can also call it directly to navigate code:
+
+* Jump to a symbol's definition
+* Find all references to a symbol
+* Get type information at a position
+* List symbols in a file or workspace
+* Find implementations of an interface
+* Trace call hierarchies
+
+The tool is inactive until you install a [code intelligence plugin](/en/discover-plugins#code-intelligence) for your language. The plugin bundles the language server configuration, and you install the server binary separately.
+
+## Monitor tool
+
+<Note>
+  The Monitor tool requires Claude Code v2.1.98 or later.
+</Note>
+
+The Monitor tool lets Claude watch something in the background and react when it changes, without pausing the conversation. Ask Claude to:
+
+* Tail a log file and flag errors as they appear
+* Poll a PR or CI job and report when its status changes
+* Watch a directory for file changes
+* Track output from any long-running script you point it at
+
+Claude writes a small script for the watch, runs it in the background, and receives each output line as it arrives. You keep working in the same session and Claude interjects when an event lands. Stop a monitor by asking Claude to cancel it or by ending the session.
+
+Monitor uses the same [permission rules as Bash](/en/permissions#tool-specific-permission-rules), so `allow` and `deny` patterns you have set for Bash apply here too. It is not available on Amazon Bedrock, Google Vertex AI, or Microsoft Foundry. It is also not available when `DISABLE_TELEMETRY` or `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` is set.
+
+Plugins can declare monitors that start automatically when the plugin is active, instead of asking Claude to start them. See [plugin monitors](/en/plugins-reference#monitors).
+
+## PowerShell tool
+
+The PowerShell tool lets Claude run PowerShell commands natively. On Windows, this means commands run in PowerShell instead of routing through Git Bash. On Windows without Git Bash, the tool is enabled automatically. On Windows with Git Bash installed, the tool is rolling out progressively. On Linux, macOS, and WSL, the tool is opt-in.
+
+### Enable the PowerShell tool
+
+Set `CLAUDE_CODE_USE_POWERSHELL_TOOL=1` in your environment or in `settings.json`:
+
+```json theme={null}
+{
+  "env": {
+    "CLAUDE_CODE_USE_POWERSHELL_TOOL": "1"
+  }
+}
+```
+
+On Windows, set the variable to `0` to opt out of the rollout. On Linux, macOS, and WSL, the tool requires PowerShell 7 or later: install `pwsh` and ensure it is on your `PATH`.
+
+On Windows, Claude Code auto-detects `pwsh.exe` for PowerShell 7+ with a fallback to `powershell.exe` for PowerShell 5.1. The Bash tool remains registered alongside the PowerShell tool, so you may need to ask Claude to use PowerShell.
+
+### Shell selection in settings, hooks, and skills
+
+Three additional settings control where PowerShell is used:
+
+* `"defaultShell": "powershell"` in [`settings.json`](/en/settings#available-settings): routes interactive `!` commands through PowerShell. Requires the PowerShell tool to be enabled.
+* `"shell": "powershell"` on individual [command hooks](/en/hooks#command-hook-fields): runs that hook in PowerShell. Hooks spawn PowerShell directly, so this works regardless of `CLAUDE_CODE_USE_POWERSHELL_TOOL`.
+* `shell: powershell` in [skill frontmatter](/en/skills#frontmatter-reference): runs `` !`command` `` blocks in PowerShell. Requires the PowerShell tool to be enabled.
+
+The same main-session working-directory reset behavior described under the Bash tool section applies to PowerShell commands, including the `CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR` environment variable.
+
+### Preview limitations
+
+The PowerShell tool has the following known limitations during the preview:
+
+* PowerShell profiles are not loaded
+* On Windows, sandboxing is not supported
+
+## Check which tools are available
+
+Your exact tool set depends on your provider, platform, and settings. To check what's loaded in a running session, ask Claude directly:
+
+```text theme={null}
+What tools do you have access to?
+```
+
+Claude gives a conversational summary. For exact MCP tool names, run `/mcp`.
+
+## See also
+
+* [MCP servers](/en/mcp): add custom tools by connecting external servers
+* [Permissions](/en/permissions): permission system, rule syntax, and tool-specific patterns
+* [Subagents](/en/sub-agents): configure tool access for subagents
+* [Hooks](/en/hooks-guide): run custom commands before or after tool execution
+

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -1,0 +1,685 @@
+"""Tests for ``.github/scripts/tool-catalog-drift.py``.
+
+Covers:
+  * ``fetch`` — success, HTTP error, URL error, timeout/OSError,
+    non-UTF-8 body.
+  * ``extract_tools`` — real upstream fixture, header-row missing,
+    no body, no separator row, zero matches, all-caps acronym,
+    non-PascalCase row ignored.
+  * ``parse_catalog`` — happy path, missing provenance, missing
+    harness_tools, missing source_url/last_checked, empty list,
+    inconsistent indent, missing harness bucket.
+  * ``diff`` — set arithmetic.
+  * ``apply_additions`` — append at end, alphabetical insert,
+    last_checked rewrite, no-op when no additions, idempotent on
+    re-run with same data, handles single-quoted and double-quoted
+    last_checked values.
+  * ``_replace_scalar`` — preserves leading whitespace, always
+    double-quotes the new value.
+  * ``render_summary`` — additions only, removals only, both,
+    neither.
+  * ``main`` — dry-run no drift, dry-run with drift, default mode
+    rewrites the file, hard-fail on fetch error, hard-fail on
+    parse error, summary-out file written.
+"""
+
+import datetime
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+import urllib.error
+from contextlib import redirect_stderr, redirect_stdout
+from typing import Any
+from unittest import mock
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..")
+)
+_SCRIPT_PATH = os.path.join(
+    _REPO_ROOT, ".github", "scripts", "tool-catalog-drift.py"
+)
+_FIXTURES_DIR = os.path.join(
+    os.path.dirname(__file__), "fixtures"
+)
+
+_spec = importlib.util.spec_from_file_location(
+    "tool_catalog_drift", _SCRIPT_PATH
+)
+if _spec is None or _spec.loader is None:
+    raise ImportError(f"Could not load module from {_SCRIPT_PATH}")
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _read_fixture(name: str) -> str:
+    """Return the contents of the named fixture file as a string."""
+    with open(
+        os.path.join(_FIXTURES_DIR, name), "r", encoding="utf-8"
+    ) as fh:
+        return fh.read()
+
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+
+class FetchTests(unittest.TestCase):
+    """``fetch`` returns UTF-8 text on success and hard-fails loudly otherwise."""
+
+    def _make_response(self, status: int, body: bytes) -> mock.MagicMock:
+        response = mock.MagicMock()
+        response.status = status
+        response.read.return_value = body
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+        return response
+
+    def test_returns_decoded_body_on_2xx(self) -> None:
+        response = self._make_response(200, b"hello upstream")
+        with mock.patch.object(
+            mod.urllib.request, "urlopen", return_value=response
+        ):
+            self.assertEqual(mod.fetch("https://example.test"), "hello upstream")
+
+    def test_raises_on_non_2xx_status(self) -> None:
+        response = self._make_response(500, b"bad")
+        with mock.patch.object(
+            mod.urllib.request, "urlopen", return_value=response
+        ):
+            with self.assertRaises(mod.FetchError) as ctx:
+                mod.fetch("https://example.test")
+            self.assertIn("500", str(ctx.exception))
+
+    def test_raises_on_http_error(self) -> None:
+        http_error = urllib.error.HTTPError(
+            url="https://example.test",
+            code=404,
+            msg="Not Found",
+            hdrs=None,
+            fp=None,
+        )
+        with mock.patch.object(
+            mod.urllib.request, "urlopen", side_effect=http_error
+        ):
+            with self.assertRaises(mod.FetchError) as ctx:
+                mod.fetch("https://example.test")
+            self.assertIn("404", str(ctx.exception))
+
+    def test_raises_on_url_error(self) -> None:
+        url_error = urllib.error.URLError("DNS lookup failed")
+        with mock.patch.object(
+            mod.urllib.request, "urlopen", side_effect=url_error
+        ):
+            with self.assertRaises(mod.FetchError) as ctx:
+                mod.fetch("https://example.test")
+            self.assertIn("network error", str(ctx.exception))
+
+    def test_raises_on_timeout(self) -> None:
+        with mock.patch.object(
+            mod.urllib.request,
+            "urlopen",
+            side_effect=TimeoutError("read timed out"),
+        ):
+            with self.assertRaises(mod.FetchError) as ctx:
+                mod.fetch("https://example.test")
+            self.assertIn("I/O error", str(ctx.exception))
+
+    def test_raises_on_non_utf8_body(self) -> None:
+        # 0xff is invalid as a UTF-8 leading byte.
+        response = self._make_response(200, b"\xff\xfe\xfd")
+        with mock.patch.object(
+            mod.urllib.request, "urlopen", return_value=response
+        ):
+            with self.assertRaises(mod.FetchError) as ctx:
+                mod.fetch("https://example.test")
+            self.assertIn("non-UTF-8", str(ctx.exception))
+
+
+# ---------------------------------------------------------------------------
+# Extract
+# ---------------------------------------------------------------------------
+
+
+class ExtractToolsTests(unittest.TestCase):
+    """``extract_tools`` parses the upstream tools-reference table."""
+
+    def test_real_fixture_yields_canonical_set(self) -> None:
+        markdown = _read_fixture("tools-reference.md")
+        tools = mod.extract_tools(markdown)
+        # Spot-check against verbatim names from the captured table.
+        for tool in (
+            "Bash", "Read", "Edit", "Write", "Grep", "Glob",
+            "WebFetch", "WebSearch", "Agent", "AskUserQuestion",
+            "NotebookEdit", "Skill", "LSP", "PowerShell", "ToolSearch",
+        ):
+            self.assertIn(tool, tools)
+
+    def test_real_fixture_excludes_stale_task_token(self) -> None:
+        # ``Task`` (singular) is in our catalog but not in the upstream
+        # table — it has been split into ``TaskCreate`` / ``TaskGet`` /
+        # etc. The extractor must not return ``Task``.
+        markdown = _read_fixture("tools-reference.md")
+        tools = mod.extract_tools(markdown)
+        self.assertNotIn("Task", tools)
+        for split_form in (
+            "TaskCreate", "TaskGet", "TaskList",
+            "TaskOutput", "TaskStop", "TaskUpdate",
+        ):
+            self.assertIn(split_form, tools)
+
+    def test_all_caps_acronym_lsp_recognised(self) -> None:
+        # ``LSP`` is all-caps but matches the harness shape regex.
+        markdown = _read_fixture("tools-reference.md")
+        tools = mod.extract_tools(markdown)
+        self.assertIn("LSP", tools)
+
+    def test_no_header_row_raises(self) -> None:
+        markdown = "# Some page\n\nNo table here.\n"
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.extract_tools(markdown)
+        self.assertIn("header row", str(ctx.exception))
+
+    def test_header_without_body_raises(self) -> None:
+        markdown = (
+            "# Tools\n\n"
+            "| Tool | Description | Permission |\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.extract_tools(markdown)
+        self.assertIn("no body", str(ctx.exception).lower())
+
+    def test_header_without_separator_raises(self) -> None:
+        markdown = (
+            "# Tools\n\n"
+            "| Tool | Description | Permission |\n"
+            "| `Bash` | Runs commands | Yes |\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.extract_tools(markdown)
+        self.assertIn("separator", str(ctx.exception))
+
+    def test_zero_matches_raises(self) -> None:
+        markdown = (
+            "| Tool | Description | Permission |\n"
+            "| :--- | :---------- | :--------- |\n"
+            "| (deprecated) | Removed in v2 | No |\n"
+            "\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.extract_tools(markdown)
+        self.assertIn("zero", str(ctx.exception).lower())
+
+    def test_non_pascalcase_row_ignored(self) -> None:
+        markdown = (
+            "| Tool | Description | Permission |\n"
+            "| :--- | :---------- | :--------- |\n"
+            "| `lowercase` | a bad row | No |\n"
+            "| `Bash` | a good row | Yes |\n"
+            "| `mcp__server__tool` | mcp shape | No |\n"
+        )
+        tools = mod.extract_tools(markdown)
+        self.assertEqual(tools, {"Bash"})
+
+    def test_table_terminated_by_blank_line(self) -> None:
+        markdown = (
+            "| Tool | Description | Permission |\n"
+            "| :--- | :---------- | :--------- |\n"
+            "| `Bash` | a good row | Yes |\n"
+            "\n"
+            "| Tool | Description | Permission |\n"
+            "| :--- | :---------- | :--------- |\n"
+            "| `Phantom` | should not be picked up | No |\n"
+        )
+        # First table only — blank line breaks scan.  ``Phantom`` is in
+        # a second table that the extractor never enters.
+        tools = mod.extract_tools(markdown)
+        self.assertEqual(tools, {"Bash"})
+
+
+# ---------------------------------------------------------------------------
+# Parse catalog
+# ---------------------------------------------------------------------------
+
+
+_HAPPY_CATALOG = """\
+skill:
+  allowed_tools:
+    catalogs:
+      claude_code:
+        provenance:
+          source_url: https://example.test/tools.md
+          last_checked: "2026-04-26"
+        harness_tools:
+          - Bash
+          - Read
+          - Edit
+        cli_tools:
+          - bash
+"""
+
+
+class ParseCatalogTests(unittest.TestCase):
+    """``parse_catalog`` reads the harness slice of configuration.yaml."""
+
+    def test_happy_path(self) -> None:
+        parsed = mod.parse_catalog(_HAPPY_CATALOG)
+        self.assertEqual(
+            parsed["source_url"], "https://example.test/tools.md"
+        )
+        self.assertEqual(parsed["last_checked"], "2026-04-26")
+        self.assertEqual(
+            parsed["harness_tools"], ["Bash", "Read", "Edit"]
+        )
+
+    def test_real_configuration_yaml(self) -> None:
+        # The actual repo configuration must parse cleanly under the
+        # current schema.  This test is the canary for "did we break
+        # the production catalog with an edit elsewhere?"
+        path = os.path.join(
+            _REPO_ROOT, "skill-system-foundry", "scripts", "lib",
+            "configuration.yaml",
+        )
+        with open(path, "r", encoding="utf-8") as fh:
+            parsed = mod.parse_catalog(fh.read())
+        self.assertTrue(parsed["source_url"].startswith("https://"))
+        self.assertRegex(parsed["last_checked"], r"^\d{4}-\d{2}-\d{2}$")
+        self.assertIn("Bash", parsed["harness_tools"])
+
+    def test_missing_provenance_raises(self) -> None:
+        text = _HAPPY_CATALOG.replace(
+            "        provenance:\n"
+            "          source_url: https://example.test/tools.md\n"
+            "          last_checked: \"2026-04-26\"\n",
+            "",
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(text)
+        self.assertIn("provenance", str(ctx.exception))
+
+    def test_missing_harness_tools_raises(self) -> None:
+        text = _HAPPY_CATALOG.replace(
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "          - Read\n"
+            "          - Edit\n",
+            "",
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(text)
+        self.assertIn("harness_tools", str(ctx.exception))
+
+    def test_missing_source_url_raises(self) -> None:
+        text = _HAPPY_CATALOG.replace(
+            "          source_url: https://example.test/tools.md\n", ""
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(text)
+        self.assertIn("source_url", str(ctx.exception))
+
+    def test_missing_harness_bucket_raises(self) -> None:
+        text = _HAPPY_CATALOG.replace("claude_code", "fake_harness")
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(text)
+        self.assertIn("claude_code", str(ctx.exception))
+
+    def test_inconsistent_indent_raises(self) -> None:
+        text = (
+            "skill:\n"
+            "  allowed_tools:\n"
+            "    catalogs:\n"
+            "      claude_code:\n"
+            "        provenance:\n"
+            "          source_url: x\n"
+            "          last_checked: \"2026-01-01\"\n"
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "            - Read\n"  # extra indent on second item
+        )
+        with self.assertRaises(mod.ParseError):
+            mod.parse_catalog(text)
+
+    def test_quoted_last_checked_unquoted_correctly(self) -> None:
+        parsed = mod.parse_catalog(_HAPPY_CATALOG)
+        self.assertEqual(parsed["last_checked"], "2026-04-26")
+
+    def test_single_quoted_last_checked_unquoted_correctly(self) -> None:
+        text = _HAPPY_CATALOG.replace(
+            'last_checked: "2026-04-26"',
+            "last_checked: '2026-04-26'",
+        )
+        parsed = mod.parse_catalog(text)
+        self.assertEqual(parsed["last_checked"], "2026-04-26")
+
+
+# ---------------------------------------------------------------------------
+# Diff
+# ---------------------------------------------------------------------------
+
+
+class DiffTests(unittest.TestCase):
+    def test_additions_and_removals(self) -> None:
+        catalog = {"Bash", "Read", "Task"}
+        extracted = {"Bash", "Read", "Edit", "Write"}
+        additions, removals = mod.diff(catalog, extracted)
+        self.assertEqual(additions, {"Edit", "Write"})
+        self.assertEqual(removals, {"Task"})
+
+    def test_no_drift(self) -> None:
+        s = {"Bash", "Read"}
+        additions, removals = mod.diff(s, s)
+        self.assertEqual(additions, set())
+        self.assertEqual(removals, set())
+
+
+# ---------------------------------------------------------------------------
+# Apply additions
+# ---------------------------------------------------------------------------
+
+
+class ApplyAdditionsTests(unittest.TestCase):
+    """``apply_additions`` rewrites the YAML in place via line-level edits."""
+
+    def test_appends_in_alphabetical_order(self) -> None:
+        out = mod.apply_additions(
+            _HAPPY_CATALOG, {"Glob", "WebFetch"}, "2026-05-01"
+        )
+        # New items go between existing list and the next sibling
+        # (``cli_tools:``).
+        self.assertIn("- Glob\n", out)
+        self.assertIn("- WebFetch\n", out)
+        # Alphabetical: Glob before WebFetch in the raw bytes.
+        self.assertLess(out.find("- Glob"), out.find("- WebFetch"))
+        # cli_tools section is preserved after the additions.
+        self.assertIn("cli_tools:\n", out)
+        self.assertLess(out.find("- WebFetch"), out.find("cli_tools:"))
+
+    def test_rewrites_last_checked(self) -> None:
+        out = mod.apply_additions(_HAPPY_CATALOG, set(), "2026-05-01")
+        self.assertIn('last_checked: "2026-05-01"', out)
+        self.assertNotIn('last_checked: "2026-04-26"', out)
+
+    def test_no_additions_only_rewrites_date(self) -> None:
+        out = mod.apply_additions(_HAPPY_CATALOG, set(), "2026-05-01")
+        # All three existing tools survive unchanged.
+        for tool in ("Bash", "Read", "Edit"):
+            self.assertIn(f"- {tool}\n", out)
+
+    def test_skips_already_present_additions(self) -> None:
+        # ``Bash`` is already in the catalog — must not be duplicated.
+        out = mod.apply_additions(
+            _HAPPY_CATALOG, {"Bash", "Glob"}, "2026-05-01"
+        )
+        # Count occurrences of ``- Bash`` lines.
+        self.assertEqual(out.count("- Bash\n"), 1)
+        self.assertEqual(out.count("- Glob\n"), 1)
+
+    def test_idempotent_on_rerun(self) -> None:
+        first = mod.apply_additions(
+            _HAPPY_CATALOG, {"Glob"}, "2026-05-01"
+        )
+        # Re-parse the rewritten YAML and apply the same additions.
+        second = mod.apply_additions(first, {"Glob"}, "2026-05-01")
+        self.assertEqual(first, second)
+
+    def test_preserves_cli_tools_block(self) -> None:
+        out = mod.apply_additions(
+            _HAPPY_CATALOG, {"Glob"}, "2026-05-01"
+        )
+        self.assertIn("cli_tools:\n", out)
+        self.assertIn("- bash\n", out)
+
+
+# ---------------------------------------------------------------------------
+# _replace_scalar
+# ---------------------------------------------------------------------------
+
+
+class ReplaceScalarTests(unittest.TestCase):
+    def test_preserves_indent_and_double_quotes_value(self) -> None:
+        out = mod._replace_scalar(
+            '          last_checked: "2026-04-26"\n',
+            "last_checked:",
+            "2026-05-01",
+        )
+        self.assertEqual(
+            out, '          last_checked: "2026-05-01"\n'
+        )
+
+    def test_handles_unquoted_input(self) -> None:
+        out = mod._replace_scalar(
+            "  last_checked: 2026-04-26\n",
+            "last_checked:",
+            "2026-05-01",
+        )
+        self.assertEqual(out, '  last_checked: "2026-05-01"\n')
+
+    def test_handles_no_trailing_newline(self) -> None:
+        out = mod._replace_scalar(
+            'last_checked: "2026-04-26"',
+            "last_checked:",
+            "2026-05-01",
+        )
+        self.assertEqual(out, 'last_checked: "2026-05-01"')
+
+
+# ---------------------------------------------------------------------------
+# Render summary
+# ---------------------------------------------------------------------------
+
+
+class RenderSummaryTests(unittest.TestCase):
+    def test_no_drift_message(self) -> None:
+        out = mod.render_summary(set(), set(), "https://x", "2026-05-01")
+        self.assertIn("No drift detected", out)
+        self.assertIn("All catalog tools match", out)
+
+    def test_additions_only(self) -> None:
+        out = mod.render_summary(
+            {"Glob", "Edit"}, set(), "https://x", "2026-05-01"
+        )
+        self.assertIn("drift detected", out)
+        self.assertIn("Additions auto-applied (2)", out)
+        self.assertIn("`Edit`", out)
+        self.assertIn("`Glob`", out)
+        self.assertNotIn("Candidate removals", out)
+
+    def test_removals_only(self) -> None:
+        out = mod.render_summary(
+            set(), {"Stale"}, "https://x", "2026-05-01"
+        )
+        self.assertIn("drift detected", out)
+        self.assertIn(
+            "Candidate removals — review before deleting (1)", out
+        )
+        self.assertIn("`Stale`", out)
+        self.assertNotIn("Additions auto-applied", out)
+
+    def test_both_sections(self) -> None:
+        out = mod.render_summary(
+            {"Glob"}, {"Stale"}, "https://x", "2026-05-01"
+        )
+        self.assertIn("Additions auto-applied (1)", out)
+        self.assertIn("Candidate removals — review before deleting (1)", out)
+
+
+# ---------------------------------------------------------------------------
+# Main / CLI
+# ---------------------------------------------------------------------------
+
+
+class _CatalogTempFile:
+    """Context-manager helper: write a temp catalog file, yield its path."""
+
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self._path: str | None = None
+
+    def __enter__(self) -> str:
+        fd, path = tempfile.mkstemp(suffix=".yaml")
+        os.close(fd)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(self._content)
+        self._path = path
+        return path
+
+    def __exit__(self, *args: Any) -> None:
+        if self._path is not None and os.path.exists(self._path):
+            os.unlink(self._path)
+
+
+def _patched_fetch(markdown: str) -> Any:
+    """Return a mock that replaces ``mod.fetch`` with a fixed body."""
+    return mock.patch.object(mod, "fetch", return_value=markdown)
+
+
+_FIXTURE_MARKDOWN: str | None = None
+
+
+def _load_fixture_markdown() -> str:
+    global _FIXTURE_MARKDOWN
+    if _FIXTURE_MARKDOWN is None:
+        _FIXTURE_MARKDOWN = _read_fixture("tools-reference.md")
+    return _FIXTURE_MARKDOWN
+
+
+class MainTests(unittest.TestCase):
+    """End-to-end tests of ``main`` with mocked fetch."""
+
+    def test_dry_run_no_drift_exits_zero(self) -> None:
+        # Build a catalog whose harness_tools matches the fixture exactly.
+        markdown = _load_fixture_markdown()
+        upstream = mod.extract_tools(markdown)
+        catalog_yaml = _HAPPY_CATALOG.replace(
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "          - Read\n"
+            "          - Edit\n",
+            (
+                "        harness_tools:\n"
+                + "".join(f"          - {t}\n" for t in sorted(upstream))
+            ),
+        )
+        with _CatalogTempFile(catalog_yaml) as path, _patched_fetch(markdown):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = mod.main([
+                    "--dry-run",
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                ])
+            self.assertEqual(code, 0)
+            self.assertIn("No drift detected", stdout.getvalue())
+
+    def test_dry_run_drift_exits_one(self) -> None:
+        markdown = _load_fixture_markdown()
+        with _CatalogTempFile(_HAPPY_CATALOG) as path, _patched_fetch(markdown):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = mod.main([
+                    "--dry-run",
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                ])
+            self.assertEqual(code, 1)
+            self.assertIn("drift detected", stdout.getvalue())
+
+    def test_default_mode_rewrites_file(self) -> None:
+        markdown = _load_fixture_markdown()
+        with _CatalogTempFile(_HAPPY_CATALOG) as path, _patched_fetch(markdown):
+            with redirect_stdout(io.StringIO()):
+                code = mod.main([
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                ])
+            self.assertEqual(code, 0)
+            with open(path, "r", encoding="utf-8") as fh:
+                rewritten = fh.read()
+            # last_checked updated, additions inserted.
+            self.assertIn('last_checked: "2026-05-01"', rewritten)
+            self.assertIn("- WebFetch\n", rewritten)
+            self.assertIn("- AskUserQuestion\n", rewritten)
+
+    def test_dry_run_does_not_modify_file(self) -> None:
+        markdown = _load_fixture_markdown()
+        with _CatalogTempFile(_HAPPY_CATALOG) as path, _patched_fetch(markdown):
+            with redirect_stdout(io.StringIO()):
+                mod.main([
+                    "--dry-run",
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                ])
+            with open(path, "r", encoding="utf-8") as fh:
+                rewritten = fh.read()
+            self.assertEqual(rewritten, _HAPPY_CATALOG)
+
+    def test_fetch_error_exits_two(self) -> None:
+        with _CatalogTempFile(_HAPPY_CATALOG) as path:
+            with mock.patch.object(
+                mod,
+                "fetch",
+                side_effect=mod.FetchError("HTTP 500"),
+            ):
+                stderr = io.StringIO()
+                with redirect_stderr(stderr), redirect_stdout(io.StringIO()):
+                    code = mod.main([
+                        "--dry-run",
+                        "--catalog-path", path,
+                        "--today", "2026-05-01",
+                    ])
+                self.assertEqual(code, 2)
+                self.assertIn("HTTP 500", stderr.getvalue())
+
+    def test_parse_error_exits_three(self) -> None:
+        broken = _HAPPY_CATALOG.replace("provenance:", "wrong_key:")
+        with _CatalogTempFile(broken) as path, _patched_fetch("ignored"):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr), redirect_stdout(io.StringIO()):
+                code = mod.main([
+                    "--dry-run",
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                ])
+            self.assertEqual(code, 3)
+            self.assertIn("provenance", stderr.getvalue())
+
+    def test_summary_out_writes_file(self) -> None:
+        markdown = _load_fixture_markdown()
+        fd, summary_path = tempfile.mkstemp(suffix=".md")
+        os.close(fd)
+        try:
+            with _CatalogTempFile(_HAPPY_CATALOG) as path, \
+                 _patched_fetch(markdown):
+                with redirect_stdout(io.StringIO()):
+                    code = mod.main([
+                        "--catalog-path", path,
+                        "--today", "2026-05-01",
+                        "--summary-out", summary_path,
+                    ])
+                self.assertEqual(code, 0)
+                with open(summary_path, "r", encoding="utf-8") as fh:
+                    summary_text = fh.read()
+                self.assertIn("Additions auto-applied", summary_text)
+        finally:
+            if os.path.exists(summary_path):
+                os.unlink(summary_path)
+
+    def test_today_default_uses_system_date(self) -> None:
+        # Smoke-test: run without --today and confirm today's date
+        # appears in the rewritten YAML.
+        markdown = _load_fixture_markdown()
+        today = datetime.date.today().isoformat()
+        with _CatalogTempFile(_HAPPY_CATALOG) as path, _patched_fetch(markdown):
+            with redirect_stdout(io.StringIO()):
+                mod.main([
+                    "--catalog-path", path,
+                ])
+            with open(path, "r", encoding="utf-8") as fh:
+                rewritten = fh.read()
+            self.assertIn(f'last_checked: "{today}"', rewritten)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -338,6 +338,33 @@ class ParseCatalogTests(unittest.TestCase):
             mod.parse_catalog(text)
         self.assertIn("source_url", str(ctx.exception))
 
+    def test_empty_last_checked_value_raises(self) -> None:
+        # Mirror the empty-source_url contract for last_checked: an
+        # explicitly empty value would let a no-drift / removals-only
+        # run leave the catalog in an unprovenanced state, since those
+        # paths never rewrite the file.
+        text = _HAPPY_CATALOG.replace(
+            'last_checked: "2026-04-26"',
+            "last_checked:",
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(text)
+        self.assertIn("empty", str(ctx.exception).lower())
+        self.assertIn("last_checked", str(ctx.exception))
+
+    def test_invalid_last_checked_value_raises(self) -> None:
+        # A non-ISO-8601 last_checked is also rejected so a typo or
+        # accidental free-text edit cannot quietly land in provenance.
+        text = _HAPPY_CATALOG.replace(
+            'last_checked: "2026-04-26"',
+            'last_checked: "yesterday"',
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(text)
+        self.assertIn("invalid", str(ctx.exception).lower())
+        self.assertIn("last_checked", str(ctx.exception))
+        self.assertIn("ISO-8601", str(ctx.exception))
+
     def test_empty_source_url_value_raises(self) -> None:
         # Empty value (``source_url:`` with no scalar after it) must
         # also hard-fail — silent fallback to a default would mask
@@ -926,19 +953,20 @@ class MainTests(unittest.TestCase):
             self.assertEqual(code, 4)
             self.assertIn("I/O error", stderr.getvalue())
 
-    def test_today_default_uses_system_date(self) -> None:
-        # Smoke-test: run without --today and confirm today's date
-        # appears in the rewritten YAML.
+    def test_today_default_uses_module_date_source(self) -> None:
+        # Smoke-test: run without --today and confirm the helper uses
+        # its module-level date source for the rewritten YAML.  The
+        # date source (``mod._today_iso``) is patched to a fixed value
+        # so the test does not race the system clock at midnight.
         markdown = _load_fixture_markdown()
-        today = datetime.date.today().isoformat()
+        fixed_today = "2026-05-01"
         with _CatalogTempFile(_HAPPY_CATALOG) as path, _patched_fetch(markdown):
-            with redirect_stdout(io.StringIO()):
-                mod.main([
-                    "--catalog-path", path,
-                ])
+            with mock.patch.object(mod, "_today_iso", return_value=fixed_today):
+                with redirect_stdout(io.StringIO()):
+                    mod.main(["--catalog-path", path])
             with open(path, "r", encoding="utf-8") as fh:
                 rewritten = fh.read()
-            self.assertIn(f'last_checked: "{today}"', rewritten)
+            self.assertIn(f'last_checked: "{fixed_today}"', rewritten)
 
 
 if __name__ == "__main__":

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -438,6 +438,47 @@ class ApplyAdditionsTests(unittest.TestCase):
         second = mod.apply_additions(first, {"Glob"}, "2026-05-01")
         self.assertEqual(first, second)
 
+    def test_sibling_comment_block_does_not_split_from_next_key(self) -> None:
+        # Regression: a comment block at the same indent as
+        # ``harness_tools:`` (i.e. a sibling comment documenting the
+        # next sibling key, like ``# Generic CLI names...`` followed
+        # by ``cli_tools:`` in the real catalog) used to be silently
+        # skipped during the list scan, which advanced ``end_line``
+        # past the comment and let ``apply_additions`` insert new
+        # items BETWEEN the comment block and the key it documents.
+        # The fix terminates the list scan on dedent before the
+        # blank/comment fast-path, so new items insert right after
+        # the last existing list item — leaving the comment block
+        # attached to its sibling key.
+        catalog_with_comment = (
+            "skill:\n"
+            "  allowed_tools:\n"
+            "    catalogs:\n"
+            "      claude_code:\n"
+            "        provenance:\n"
+            "          source_url: https://example.test/tools.md\n"
+            "          last_checked: \"2026-04-26\"\n"
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "          - Read\n"
+            "        # Generic CLI names sometimes written into allowed-tools.\n"
+            "        # NOT harness primitives — typo-detection only.\n"
+            "        cli_tools:\n"
+            "          - bash\n"
+        )
+        out = mod.apply_additions(
+            catalog_with_comment, {"NewTool"}, "2026-05-01"
+        )
+        # The new tool lands right after the last existing item,
+        # not after the comment block.
+        idx_read = out.index("- Read\n")
+        idx_new = out.index("- NewTool\n")
+        idx_comment = out.index("# Generic CLI names")
+        idx_cli_tools = out.index("cli_tools:")
+        self.assertLess(idx_read, idx_new)
+        self.assertLess(idx_new, idx_comment)
+        self.assertLess(idx_comment, idx_cli_tools)
+
     def test_eof_insertion_repairs_missing_trailing_newline(self) -> None:
         # Regression: when the catalog file ends with the harness_tools
         # list (no trailing sibling), splitlines(keepends=True) yields

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -544,6 +544,23 @@ class RenderSummaryTests(unittest.TestCase):
         self.assertIn("Additions auto-applied (1)", out)
         self.assertIn("Candidate removals — review before deleting (1)", out)
 
+    def test_applied_false_uses_subjunctive_wording(self) -> None:
+        # Dry-run / preview rendering must not falsely claim mutation.
+        out = mod.render_summary(
+            {"Glob"}, set(), "https://x", "2026-05-01", applied=False,
+        )
+        self.assertIn("Additions that would be applied (1)", out)
+        self.assertIn("Dry run", out)
+        self.assertNotIn("auto-applied", out)
+        self.assertNotIn("Already added", out)
+
+    def test_applied_true_default_keeps_auto_applied(self) -> None:
+        # Confirm the default keeps the existing wording so the
+        # workflow's PR body and post-mutation runs read correctly.
+        out = mod.render_summary({"Glob"}, set(), "https://x", "2026-05-01")
+        self.assertIn("auto-applied", out)
+        self.assertNotIn("would be applied", out)
+
 
 # ---------------------------------------------------------------------------
 # Main / CLI

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -605,6 +605,44 @@ def _load_fixture_markdown() -> str:
 class MainTests(unittest.TestCase):
     """End-to-end tests of ``main`` with mocked fetch."""
 
+    def test_default_mode_removals_only_does_not_modify_file(self) -> None:
+        # Removals are advisory only and never auto-applied.  In
+        # particular, ``last_checked`` must not be bumped on a
+        # removals-only run — that would mutate the catalog despite
+        # nothing being applied, contradicting the advisory-only
+        # contract and producing date-only churn.  The workflow
+        # carries the advisory via an --allow-empty commit instead.
+        markdown = _load_fixture_markdown()
+        upstream = mod.extract_tools(markdown)
+        # Build a catalog whose harness_tools is upstream PLUS one
+        # extra "stale" name that the upstream does not have.  Drift
+        # is then exactly one removal, zero additions.
+        tools_with_extra = sorted(upstream | {"GhostTool"})
+        catalog_yaml = _HAPPY_CATALOG.replace(
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "          - Read\n"
+            "          - Edit\n",
+            (
+                "        harness_tools:\n"
+                + "".join(f"          - {t}\n" for t in tools_with_extra)
+            ),
+        )
+        with _CatalogTempFile(catalog_yaml) as path, _patched_fetch(markdown):
+            with redirect_stdout(io.StringIO()):
+                code = mod.main([
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                ])
+            self.assertEqual(code, 0)
+            with open(path, "r", encoding="utf-8") as fh:
+                rewritten = fh.read()
+            # The catalog is byte-identical to the input — the
+            # advisory removal does not bump last_checked, does not
+            # delete the stale tool, and does not touch any other
+            # bytes.
+            self.assertEqual(rewritten, catalog_yaml)
+
     def test_default_mode_no_drift_does_not_modify_file(self) -> None:
         # No-drift runs must leave the YAML untouched so the catalog's
         # commit history is not polluted by weekly date-only bumps.

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -692,6 +692,64 @@ class MainTests(unittest.TestCase):
             if os.path.exists(summary_path):
                 os.unlink(summary_path)
 
+    def test_json_mode_emits_machine_readable_payload(self) -> None:
+        markdown = _load_fixture_markdown()
+        with _CatalogTempFile(_HAPPY_CATALOG) as path, _patched_fetch(markdown):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = mod.main([
+                    "--dry-run",
+                    "--json",
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                ])
+            self.assertEqual(code, 1)
+            import json as _json
+            payload = _json.loads(stdout.getvalue())
+            self.assertEqual(payload["drift"], True)
+            self.assertEqual(payload["checked"], "2026-05-01")
+            self.assertIn("AskUserQuestion", payload["additions"])
+            # ``Edit`` is in the happy catalog already so it must NOT
+            # appear in additions.
+            self.assertNotIn("Edit", payload["additions"])
+            self.assertEqual(payload["catalog_size"], 3)
+            self.assertGreater(payload["upstream_size"], 30)
+            self.assertIsInstance(payload["additions"], list)
+            self.assertIsInstance(payload["removals"], list)
+            # Lists are sorted for stable diffing.
+            self.assertEqual(
+                payload["additions"], sorted(payload["additions"])
+            )
+
+    def test_json_mode_no_drift_returns_empty_lists(self) -> None:
+        markdown = _load_fixture_markdown()
+        upstream = mod.extract_tools(markdown)
+        catalog_yaml = _HAPPY_CATALOG.replace(
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "          - Read\n"
+            "          - Edit\n",
+            (
+                "        harness_tools:\n"
+                + "".join(f"          - {t}\n" for t in sorted(upstream))
+            ),
+        )
+        with _CatalogTempFile(catalog_yaml) as path, _patched_fetch(markdown):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                code = mod.main([
+                    "--dry-run",
+                    "--json",
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                ])
+            self.assertEqual(code, 0)
+            import json as _json
+            payload = _json.loads(stdout.getvalue())
+            self.assertEqual(payload["drift"], False)
+            self.assertEqual(payload["additions"], [])
+            self.assertEqual(payload["removals"], [])
+
     def test_today_default_uses_system_date(self) -> None:
         # Smoke-test: run without --today and confirm today's date
         # appears in the rewritten YAML.

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -548,6 +548,32 @@ def _load_fixture_markdown() -> str:
 class MainTests(unittest.TestCase):
     """End-to-end tests of ``main`` with mocked fetch."""
 
+    def test_default_mode_no_drift_does_not_modify_file(self) -> None:
+        # No-drift runs must leave the YAML untouched so the catalog's
+        # commit history is not polluted by weekly date-only bumps.
+        markdown = _load_fixture_markdown()
+        upstream = mod.extract_tools(markdown)
+        catalog_yaml = _HAPPY_CATALOG.replace(
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "          - Read\n"
+            "          - Edit\n",
+            (
+                "        harness_tools:\n"
+                + "".join(f"          - {t}\n" for t in sorted(upstream))
+            ),
+        )
+        with _CatalogTempFile(catalog_yaml) as path, _patched_fetch(markdown):
+            with redirect_stdout(io.StringIO()):
+                code = mod.main([
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                ])
+            self.assertEqual(code, 0)
+            with open(path, "r", encoding="utf-8") as fh:
+                rewritten = fh.read()
+            self.assertEqual(rewritten, catalog_yaml)
+
     def test_dry_run_no_drift_exits_zero(self) -> None:
         # Build a catalog whose harness_tools matches the fixture exactly.
         markdown = _load_fixture_markdown()

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -845,6 +845,27 @@ class MainTests(unittest.TestCase):
             self.assertEqual(payload["additions"], [])
             self.assertEqual(payload["removals"], [])
 
+    def test_summary_out_unwritable_path_exits_four(self) -> None:
+        # An unwritable summary-out path must surface as the helper's
+        # documented hard-fail (exit 4 + stderr message), not a bare
+        # traceback.  The workflow relies on --summary-out for the PR
+        # body, so a clean failure mode matters when the temp path is
+        # somehow unavailable.
+        markdown = _load_fixture_markdown()
+        unwritable = os.path.join(
+            os.sep, "nonexistent-dir", "no-permission", "summary.md"
+        )
+        with _CatalogTempFile(_HAPPY_CATALOG) as path, _patched_fetch(markdown):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr), redirect_stdout(io.StringIO()):
+                code = mod.main([
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                    "--summary-out", unwritable,
+                ])
+            self.assertEqual(code, 4)
+            self.assertIn("I/O error", stderr.getvalue())
+
     def test_today_default_uses_system_date(self) -> None:
         # Smoke-test: run without --today and confirm today's date
         # appears in the rewritten YAML.

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -201,11 +201,30 @@ class ExtractToolsTests(unittest.TestCase):
             mod.extract_tools(markdown)
         self.assertIn("separator", str(ctx.exception))
 
-    def test_zero_matches_raises(self) -> None:
+    def test_unbackticked_row_raises(self) -> None:
+        # An unbackticked first cell inside the tools table is a
+        # shape-drift signal, not silent noise — the helper now
+        # hard-fails on it.
         markdown = (
             "| Tool | Description | Permission |\n"
             "| :--- | :---------- | :--------- |\n"
             "| (deprecated) | Removed in v2 | No |\n"
+            "\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.extract_tools(markdown)
+        self.assertIn("backticked", str(ctx.exception).lower())
+
+    def test_zero_pascalcase_matches_raises(self) -> None:
+        # Backticked rows whose identifiers are all non-PascalCase
+        # (e.g. all lowercase or all MCP-shaped) still pass the
+        # row-shape guard but produce zero extracted tools, which is
+        # the older "zero matches" failure path.
+        markdown = (
+            "| Tool | Description | Permission |\n"
+            "| :--- | :---------- | :--------- |\n"
+            "| `lowercase` | not pascalcase | No |\n"
+            "| `mcp__server__tool` | mcp shape | No |\n"
             "\n"
         )
         with self.assertRaises(mod.ParseError) as ctx:

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -438,6 +438,32 @@ class ApplyAdditionsTests(unittest.TestCase):
         second = mod.apply_additions(first, {"Glob"}, "2026-05-01")
         self.assertEqual(first, second)
 
+    def test_eof_insertion_repairs_missing_trailing_newline(self) -> None:
+        # Regression: when the catalog file ends with the harness_tools
+        # list (no trailing sibling), splitlines(keepends=True) yields
+        # a final element without ``\n``.  Extending with new ``- Tool\n``
+        # items would concatenate them onto the last existing line and
+        # produce invalid YAML.  Confirm the writer repairs the gap.
+        eof_catalog = (
+            "skill:\n"
+            "  allowed_tools:\n"
+            "    catalogs:\n"
+            "      claude_code:\n"
+            "        provenance:\n"
+            "          source_url: https://example.test/tools.md\n"
+            "          last_checked: \"2026-04-26\"\n"
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "          - Read"  # NOTE: no trailing newline
+        )
+        out = mod.apply_additions(eof_catalog, {"Glob"}, "2026-05-01")
+        # The final existing item is on its own line and the new item
+        # follows it as a separate list entry — no concatenation.
+        self.assertIn("          - Read\n", out)
+        self.assertIn("          - Glob\n", out)
+        # And the new item must not glue onto the previous line.
+        self.assertNotIn("- Read          - Glob", out)
+
     def test_preserves_cli_tools_block(self) -> None:
         out = mod.apply_additions(
             _HAPPY_CATALOG, {"Glob"}, "2026-05-01"

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -319,6 +319,20 @@ class ParseCatalogTests(unittest.TestCase):
             mod.parse_catalog(text)
         self.assertIn("source_url", str(ctx.exception))
 
+    def test_empty_source_url_value_raises(self) -> None:
+        # Empty value (``source_url:`` with no scalar after it) must
+        # also hard-fail — silent fallback to a default would mask
+        # misconfigurations and contradict the helper's hard-fail
+        # contract.
+        text = _HAPPY_CATALOG.replace(
+            "          source_url: https://example.test/tools.md\n",
+            "          source_url:\n",
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(text)
+        self.assertIn("empty", str(ctx.exception).lower())
+        self.assertIn("source_url", str(ctx.exception))
+
     def test_missing_harness_bucket_raises(self) -> None:
         text = _HAPPY_CATALOG.replace("claude_code", "fake_harness")
         with self.assertRaises(mod.ParseError) as ctx:

--- a/.github/workflows/ci-helper-tests.yaml
+++ b/.github/workflows/ci-helper-tests.yaml
@@ -2,9 +2,17 @@ name: CI helper tests
 
 # Runs the unittest suite under ``.github/tests/`` against the helper
 # scripts under ``.github/scripts/``.  Kept separate from
-# ``python-tests.yaml`` (which covers the meta-skill itself) so the
-# meta-skill matrix stays focused and a helper-only change does not
-# trigger the full test suite.
+# ``python-tests.yaml`` (which covers the meta-skill itself) so
+# helper checks stay isolated from the meta-skill matrix and helper
+# failures surface as their own clear signal in PR checks.  Note
+# that ``python-tests.yaml`` runs on every PR with no path filter,
+# so the meta-skill matrix still exercises any change that touches
+# its tree — the isolation here is about scope/clarity, not skipping.
+#
+# The path filter includes ``configuration.yaml`` because the helper
+# test suite has a real-configuration canary that reads the live
+# catalog schema; a PR that edits the catalog without touching the
+# helper or its tests must still run this suite.
 
 on:
   pull_request:
@@ -12,12 +20,14 @@ on:
       - ".github/scripts/**"
       - ".github/tests/**"
       - ".github/workflows/ci-helper-tests.yaml"
+      - "skill-system-foundry/scripts/lib/configuration.yaml"
   push:
     branches: [main]
     paths:
       - ".github/scripts/**"
       - ".github/tests/**"
       - ".github/workflows/ci-helper-tests.yaml"
+      - "skill-system-foundry/scripts/lib/configuration.yaml"
 
 permissions:
   contents: read

--- a/.github/workflows/ci-helper-tests.yaml
+++ b/.github/workflows/ci-helper-tests.yaml
@@ -1,0 +1,38 @@
+name: CI helper tests
+
+# Runs the unittest suite under ``.github/tests/`` against the helper
+# scripts under ``.github/scripts/``.  Kept separate from
+# ``python-tests.yaml`` (which covers the meta-skill itself) so the
+# meta-skill matrix stays focused and a helper-only change does not
+# trigger the full test suite.
+
+on:
+  pull_request:
+    paths:
+      - ".github/scripts/**"
+      - ".github/tests/**"
+      - ".github/workflows/ci-helper-tests.yaml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/scripts/**"
+      - ".github/tests/**"
+      - ".github/workflows/ci-helper-tests.yaml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v5 as 5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Run helper test suite
+        run: python -m unittest discover -s .github/tests -p "test_*.py" -v

--- a/.github/workflows/ci-helper-tests.yaml
+++ b/.github/workflows/ci-helper-tests.yaml
@@ -12,7 +12,11 @@ name: CI helper tests
 # The path filter includes ``configuration.yaml`` because the helper
 # test suite has a real-configuration canary that reads the live
 # catalog schema; a PR that edits the catalog without touching the
-# helper or its tests must still run this suite.
+# helper or its tests must still run this suite.  It also includes
+# ``tool-catalog-drift.yaml`` because that workflow is the only
+# production caller of the helper — it owns the CLI-flag, output
+# file, and JSON-parsing contract — so a change there is part of
+# the integration surface this suite covers.
 
 on:
   pull_request:
@@ -20,6 +24,7 @@ on:
       - ".github/scripts/**"
       - ".github/tests/**"
       - ".github/workflows/ci-helper-tests.yaml"
+      - ".github/workflows/tool-catalog-drift.yaml"
       - "skill-system-foundry/scripts/lib/configuration.yaml"
   push:
     branches: [main]
@@ -27,6 +32,7 @@ on:
       - ".github/scripts/**"
       - ".github/tests/**"
       - ".github/workflows/ci-helper-tests.yaml"
+      - ".github/workflows/tool-catalog-drift.yaml"
       - "skill-system-foundry/scripts/lib/configuration.yaml"
 
 permissions:

--- a/.github/workflows/tool-catalog-drift.yaml
+++ b/.github/workflows/tool-catalog-drift.yaml
@@ -91,7 +91,7 @@ jobs:
         # equals today produces a byte-identical YAML, so a diff-based
         # detection would miss that drift case.
         run: |
-          drift=$(python -c "import json,sys; print(str(json.load(open(sys.argv[1]))['drift']).lower())" "$STATE_PATH")
+          drift=$(python -c "import json,sys; print(str(json.load(open(sys.argv[1], encoding='utf-8'))['drift']).lower())" "$STATE_PATH")
           echo "drift=$drift" >> "$GITHUB_OUTPUT"
 
       - name: Resolve stale drift PR (no drift this run)
@@ -133,7 +133,16 @@ jobs:
         run: |
           git switch -C "$BRANCH"
           git add "$CATALOG_PATH"
-          git commit -m "Sync claude_code tool catalog with upstream tools-reference"
+          # Removals-only drift on a day when ``last_checked`` already
+          # equals today produces a byte-identical YAML — the helper
+          # detected drift but had nothing to write.  Use --allow-empty
+          # so the commit + force-push + PR-open steps still run; the
+          # PR body's "Candidate removals" section carries the advisory.
+          if git diff --cached --quiet; then
+            git commit --allow-empty -m "Report claude_code tool catalog drift (removals-only advisory)"
+          else
+            git commit -m "Sync claude_code tool catalog with upstream tools-reference"
+          fi
           git push --force origin "$BRANCH"
 
       - name: Compose PR body

--- a/.github/workflows/tool-catalog-drift.yaml
+++ b/.github/workflows/tool-catalog-drift.yaml
@@ -2,11 +2,11 @@ name: Tool catalog drift
 
 # Weekly sweep that compares the hand-maintained Claude Code tool
 # catalog at ``skill-system-foundry/scripts/lib/configuration.yaml``
-# (under ``allowed_tools.catalogs.claude_code``) against the canonical
-# upstream source URL.  The URL itself is read from
-# ``allowed_tools.catalogs.claude_code.provenance.source_url`` in
-# the catalog YAML — that field is the single source of truth, so
-# updating it is a YAML-only change and does not require editing
+# (under ``skill.allowed_tools.catalogs.claude_code``) against the
+# canonical upstream source URL.  The URL itself is read from
+# ``skill.allowed_tools.catalogs.claude_code.provenance.source_url``
+# in the catalog YAML — that field is the single source of truth,
+# so updating it is a YAML-only change and does not require editing
 # this workflow.
 #
 # Behavior:

--- a/.github/workflows/tool-catalog-drift.yaml
+++ b/.github/workflows/tool-catalog-drift.yaml
@@ -148,11 +148,11 @@ jobs:
         run: |
           git switch -C "$BRANCH"
           git add "$CATALOG_PATH"
-          # Removals-only drift on a day when ``last_checked`` already
-          # equals today produces a byte-identical YAML — the helper
-          # detected drift but had nothing to write.  Use --allow-empty
-          # so the commit + force-push + PR-open steps still run; the
-          # PR body's "Candidate removals" section carries the advisory.
+          # Removals are advisory and never auto-applied, so a
+          # removals-only drift run leaves the YAML untouched.  Use
+          # --allow-empty so the commit + force-push + PR-open steps
+          # still run; the PR body's "Candidate removals" section
+          # carries the advisory.
           if git diff --cached --quiet; then
             git commit --allow-empty -m "Report claude_code tool catalog drift (removals-only advisory)"
           else

--- a/.github/workflows/tool-catalog-drift.yaml
+++ b/.github/workflows/tool-catalog-drift.yaml
@@ -1,0 +1,166 @@
+name: Tool catalog drift
+
+# Weekly sweep that compares the hand-maintained Claude Code tool
+# catalog at ``skill-system-foundry/scripts/lib/configuration.yaml``
+# (under ``allowed_tools.catalogs.claude_code``) against the canonical
+# upstream tools reference at
+# https://code.claude.com/docs/en/tools-reference.md.
+#
+# Behavior:
+#   * No drift detected — no PR opened.  If a stale drift PR exists on
+#     the rolling branch ``chore/tool-catalog-drift`` it is closed and
+#     the branch deleted (drift was resolved manually since the last
+#     run).
+#   * Drift detected — additions are auto-applied to the catalog,
+#     ``last_checked`` is bumped to today, and a single rolling PR is
+#     opened or force-updated against ``chore/tool-catalog-drift``.
+#     Removals are surfaced in the PR body as advisory candidates;
+#     they are NEVER auto-applied (a regex miss or a one-version-wide
+#     doc edit could falsely propose dropping a real tool).
+#   * Hard-fail on any fetch error, table-shape change, or
+#     parse error — silent green is the worst outcome for a drift
+#     sweep.
+#
+# Adding a second tracked URL (e.g. a future Codex catalog) is a
+# YAML-only edit: add a new harness bucket under
+# ``allowed_tools.catalogs.<harness>`` with its own ``provenance``
+# block, then extend ``HARNESS_NAMES`` in the helper.  Workflow does
+# not need editing.
+
+on:
+  schedule:
+    # Mondays at 12:00 UTC.  Single source-of-truth; do not duplicate
+    # this expression in code reviews — change here only.
+    - cron: "0 12 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A queued ``workflow_dispatch`` must not race the cron — drift PRs
+# are force-pushed to a single rolling branch and concurrent runs
+# would clobber each other.  ``cancel-in-progress: false`` so an
+# in-flight run finishes before the queued one starts.
+concurrency:
+  group: tool-catalog-drift
+  cancel-in-progress: false
+
+jobs:
+  detect-and-pr:
+    runs-on: ubuntu-latest
+    # Needs ``contents: write`` to push the rolling branch and
+    # ``pull-requests: write`` to open / edit / close the rolling PR.
+    # The default workflow-wide ``contents: read`` stays so any future
+    # job that does not need write does not get it implicitly.
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+        with:
+          ref: main
+          # Fetch full history so a force-push to the rolling branch
+          # cleanly supersedes whatever was there before.
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # @v5 as 5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Run drift helper
+        id: helper
+        env:
+          SUMMARY_PATH: ${{ runner.temp }}/drift-summary.md
+        run: |
+          python .github/scripts/tool-catalog-drift.py \
+            --summary-out "$SUMMARY_PATH"
+          echo "summary_path=$SUMMARY_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Detect catalog mutation
+        id: detect
+        env:
+          CATALOG_PATH: skill-system-foundry/scripts/lib/configuration.yaml
+        run: |
+          if git diff --quiet -- "$CATALOG_PATH"; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve stale drift PR (no drift this run)
+        if: steps.detect.outputs.drift == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: chore/tool-catalog-drift
+        run: |
+          # If a previous run opened a PR but the drift was resolved
+          # manually (or upstream recovered), close the PR and delete
+          # the branch so the next genuine drift opens a fresh PR.
+          pr_number=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$pr_number" ]; then
+            gh pr close "$pr_number" \
+              --comment "Drift resolved upstream or manually; closing rolling PR." \
+              --delete-branch
+            echo "Closed rolling PR #$pr_number."
+          else
+            echo "No stale drift PR to close."
+          fi
+
+      - name: Configure git identity
+        if: steps.detect.outputs.drift == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Commit and force-push to rolling branch
+        if: steps.detect.outputs.drift == 'true'
+        env:
+          BRANCH: chore/tool-catalog-drift
+          CATALOG_PATH: skill-system-foundry/scripts/lib/configuration.yaml
+        run: |
+          git switch -C "$BRANCH"
+          git add "$CATALOG_PATH"
+          git commit -m "Sync claude_code tool catalog with upstream tools-reference"
+          git push --force origin "$BRANCH"
+
+      - name: Compose PR body
+        if: steps.detect.outputs.drift == 'true'
+        env:
+          SUMMARY_PATH: ${{ steps.helper.outputs.summary_path }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          {
+            echo "Auto-generated by [tool-catalog-drift run]($RUN_URL)."
+            echo
+            cat "$SUMMARY_PATH"
+            echo
+            echo "## How to handle removals"
+            echo
+            echo "Any \"Candidate removals\" listed above are advisory only — they are NOT applied to the catalog by this workflow. Verify each name against the upstream tools reference before deleting; possible false positives include upstream renames, table-format changes, or extraction misses."
+            echo
+            echo "## CI on this PR"
+            echo
+            echo "PRs opened by the default \`GITHUB_TOKEN\` do not trigger downstream workflow runs. To run the full CI matrix against this branch, close and reopen this PR (a human action) so \`python-tests.yaml\` and the other path-filtered checks fire against the head."
+          } > "$RUNNER_TEMP/pr-body.md"
+
+      - name: Open or update rolling PR
+        if: steps.detect.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: chore/tool-catalog-drift
+        run: |
+          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" \
+              --title "Sync claude_code tool catalog with upstream" \
+              --body-file "$RUNNER_TEMP/pr-body.md"
+            echo "Updated rolling PR #$existing."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "Sync claude_code tool catalog with upstream" \
+              --body-file "$RUNNER_TEMP/pr-body.md"
+          fi

--- a/.github/workflows/tool-catalog-drift.yaml
+++ b/.github/workflows/tool-catalog-drift.yaml
@@ -54,11 +54,17 @@ jobs:
     runs-on: ubuntu-latest
     # Needs ``contents: write`` to push the rolling branch and
     # ``pull-requests: write`` to open / edit / close the rolling PR.
+    # ``issues: write`` is also required because ``gh pr close
+    # --comment`` posts the closing comment via the issues API
+    # (PR comments are issue comments in GitHub's permission
+    # model) — without it the no-drift cleanup path would fail
+    # exactly when a stale rolling PR needs to be closed.
     # The default workflow-wide ``contents: read`` stays so any future
     # job that does not need write does not get it implicitly.
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2

--- a/.github/workflows/tool-catalog-drift.yaml
+++ b/.github/workflows/tool-catalog-drift.yaml
@@ -21,11 +21,12 @@ name: Tool catalog drift
 #     parse error — silent green is the worst outcome for a drift
 #     sweep.
 #
-# Adding a second tracked URL (e.g. a future Codex catalog) is a
-# YAML-only edit: add a new harness bucket under
-# ``allowed_tools.catalogs.<harness>`` with its own ``provenance``
-# block, then extend ``HARNESS_NAMES`` in the helper.  Workflow does
-# not need editing.
+# Tracks the ``claude_code`` catalog only.  Adding a second harness
+# is not a YAML-only edit: ``run`` and ``parse_catalog`` in the
+# helper currently process the single default harness, so a future
+# extension requires helper changes (and may need workflow updates
+# for per-harness PR titles or reporting).  See the design comment
+# on #118.
 
 on:
   schedule:
@@ -73,21 +74,25 @@ jobs:
         id: helper
         env:
           SUMMARY_PATH: ${{ runner.temp }}/drift-summary.md
+          STATE_PATH: ${{ runner.temp }}/drift-state.json
         run: |
           python .github/scripts/tool-catalog-drift.py \
-            --summary-out "$SUMMARY_PATH"
+            --json --summary-out "$SUMMARY_PATH" > "$STATE_PATH"
           echo "summary_path=$SUMMARY_PATH" >> "$GITHUB_OUTPUT"
+          echo "state_path=$STATE_PATH" >> "$GITHUB_OUTPUT"
 
-      - name: Detect catalog mutation
+      - name: Detect drift from helper output
         id: detect
         env:
-          CATALOG_PATH: skill-system-foundry/scripts/lib/configuration.yaml
+          STATE_PATH: ${{ steps.helper.outputs.state_path }}
+        # Read the helper's authoritative drift signal from its JSON
+        # payload rather than inferring from the YAML diff.  A
+        # removals-only run on a day when ``last_checked`` already
+        # equals today produces a byte-identical YAML, so a diff-based
+        # detection would miss that drift case.
         run: |
-          if git diff --quiet -- "$CATALOG_PATH"; then
-            echo "drift=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "drift=true" >> "$GITHUB_OUTPUT"
-          fi
+          drift=$(python -c "import json,sys; print(str(json.load(open(sys.argv[1]))['drift']).lower())" "$STATE_PATH")
+          echo "drift=$drift" >> "$GITHUB_OUTPUT"
 
       - name: Resolve stale drift PR (no drift this run)
         if: steps.detect.outputs.drift == 'false'
@@ -98,14 +103,20 @@ jobs:
           # If a previous run opened a PR but the drift was resolved
           # manually (or upstream recovered), close the PR and delete
           # the branch so the next genuine drift opens a fresh PR.
+          # The branch may also exist without an open PR (e.g. someone
+          # closed the PR manually without ticking "Delete branch") —
+          # delete it here so the rolling-branch lifecycle stays tidy.
           pr_number=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -n "$pr_number" ]; then
             gh pr close "$pr_number" \
               --comment "Drift resolved upstream or manually; closing rolling PR." \
               --delete-branch
             echo "Closed rolling PR #$pr_number."
+          elif git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            git push origin --delete "$BRANCH"
+            echo "Deleted stale rolling branch $BRANCH (no open PR)."
           else
-            echo "No stale drift PR to close."
+            echo "No stale drift PR or rolling branch to clean up."
           fi
 
       - name: Configure git identity

--- a/.github/workflows/tool-catalog-drift.yaml
+++ b/.github/workflows/tool-catalog-drift.yaml
@@ -3,8 +3,11 @@ name: Tool catalog drift
 # Weekly sweep that compares the hand-maintained Claude Code tool
 # catalog at ``skill-system-foundry/scripts/lib/configuration.yaml``
 # (under ``allowed_tools.catalogs.claude_code``) against the canonical
-# upstream tools reference at
-# https://code.claude.com/docs/en/tools-reference.md.
+# upstream source URL.  The URL itself is read from
+# ``allowed_tools.catalogs.claude_code.provenance.source_url`` in
+# the catalog YAML — that field is the single source of truth, so
+# updating it is a YAML-only change and does not require editing
+# this workflow.
 #
 # Behavior:
 #   * No drift detected — no PR opened.  If a stale drift PR exists on
@@ -106,7 +109,10 @@ jobs:
           # The branch may also exist without an open PR (e.g. someone
           # closed the PR manually without ticking "Delete branch") —
           # delete it here so the rolling-branch lifecycle stays tidy.
-          pr_number=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          # Scope the head ref to the current repo's owner so a PR
+          # opened from a fork using the same branch name cannot be
+          # mistakenly matched, closed, or edited.
+          pr_number=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$GITHUB_REPOSITORY_OWNER:$BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -n "$pr_number" ]; then
             gh pr close "$pr_number" \
               --comment "Drift resolved upstream or manually; closing rolling PR." \
@@ -171,7 +177,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: chore/tool-catalog-drift
         run: |
-          existing=$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
+          # Same fork-scoping rationale as in the no-drift cleanup step:
+          # match only PRs opened from this repo's rolling branch.
+          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$GITHUB_REPOSITORY_OWNER:$BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then
             gh pr edit "$existing" \
               --title "Sync claude_code tool catalog with upstream" \

--- a/.github/workflows/tool-catalog-drift.yaml
+++ b/.github/workflows/tool-catalog-drift.yaml
@@ -109,10 +109,13 @@ jobs:
           # The branch may also exist without an open PR (e.g. someone
           # closed the PR manually without ticking "Delete branch") —
           # delete it here so the rolling-branch lifecycle stays tidy.
-          # Scope the head ref to the current repo's owner so a PR
-          # opened from a fork using the same branch name cannot be
-          # mistakenly matched, closed, or edited.
-          pr_number=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$GITHUB_REPOSITORY_OWNER:$BRANCH" --state open --json number --jq '.[0].number // empty')
+          # Filter to PRs whose head repo owner matches this repo's
+          # owner so a PR opened from a fork using the same branch
+          # name cannot be mistakenly matched, closed, or edited.
+          # ``gh pr list --head`` accepts only a bare branch name (the
+          # ``OWNER:BRANCH`` form is unsupported), so the cross-repo
+          # filter has to come from the JSON output via ``--jq``.
+          pr_number=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number,headRepositoryOwner --jq "[.[] | select(.headRepositoryOwner.login == \"$GITHUB_REPOSITORY_OWNER\") | .number][0] // empty")
           if [ -n "$pr_number" ]; then
             gh pr close "$pr_number" \
               --comment "Drift resolved upstream or manually; closing rolling PR." \
@@ -177,9 +180,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: chore/tool-catalog-drift
         run: |
-          # Same fork-scoping rationale as in the no-drift cleanup step:
-          # match only PRs opened from this repo's rolling branch.
-          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$GITHUB_REPOSITORY_OWNER:$BRANCH" --state open --json number --jq '.[0].number // empty')
+          # Same fork-scoping rationale as in the no-drift cleanup
+          # step: match only PRs whose head repo owner is this repo's
+          # owner so a fork PR cannot be mistakenly edited.
+          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number,headRepositoryOwner --jq "[.[] | select(.headRepositoryOwner.login == \"$GITHUB_REPOSITORY_OWNER\") | .number][0] // empty")
           if [ -n "$existing" ]; then
             gh pr edit "$existing" \
               --title "Sync claude_code tool catalog with upstream" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,7 @@ python .github/scripts/tool-catalog-drift.py --dry-run
 python .github/scripts/tool-catalog-drift.py --dry-run --json
 ```
 
-`--dry-run` exits 0 on no drift, 1 on drift detected; default mode mutates `configuration.yaml` and bumps `skill.allowed_tools.catalogs.claude_code.provenance.last_checked` only when drift is detected (the workflow then commits and opens the PR).
+`--dry-run` exits 0 on no drift, 1 on drift detected; default mode mutates `configuration.yaml` and bumps `skill.allowed_tools.catalogs.claude_code.provenance.last_checked` only when there are additions to apply. Removals-only drift leaves the YAML untouched (removals are advisory and never auto-applied); the workflow surfaces them through the PR body via an empty commit.
 
 The helper tracks the `claude_code` catalog only. The `catalogs.<harness>` YAML structure preserves room for a future second harness, but adding one is not a YAML-only edit — `run` and `parse_catalog` in `.github/scripts/tool-catalog-drift.py` currently process the single default harness, so a future extension requires helper changes (and may need workflow updates for per-harness PR titles or reporting).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ A missing or unreadable `SKILL.md` is a FAIL — that includes the file not exis
 
 ### Detecting Tool Catalog Drift
 
-The hand-maintained Claude Code tool catalog at `allowed_tools.catalogs.claude_code` in `skill-system-foundry/scripts/lib/configuration.yaml` drifts as Claude Code adds, renames, or retires tools. A weekly scheduled workflow (`.github/workflows/tool-catalog-drift.yaml`, helper at `.github/scripts/tool-catalog-drift.py`) compares the catalog against the canonical upstream tools reference at the URL recorded in `skill.allowed_tools.catalogs.claude_code.provenance.source_url` and force-pushes a single rolling PR (`chore/tool-catalog-drift`) when drift is detected. Additions are auto-applied; removals are surfaced in the PR body as advisory candidates only — verify each name before deleting.
+The hand-maintained Claude Code tool catalog at `skill.allowed_tools.catalogs.claude_code` in `skill-system-foundry/scripts/lib/configuration.yaml` drifts as Claude Code adds, renames, or retires tools. A weekly scheduled workflow (`.github/workflows/tool-catalog-drift.yaml`, helper at `.github/scripts/tool-catalog-drift.py`) compares the catalog against the canonical upstream tools reference at the URL recorded in `skill.allowed_tools.catalogs.claude_code.provenance.source_url` and force-pushes a single rolling PR (`chore/tool-catalog-drift`) when drift is detected. Additions are auto-applied; removals are surfaced in the PR body as advisory candidates only — verify each name before deleting.
 
 To run the sweep locally:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ python .github/scripts/tool-catalog-drift.py --dry-run --json
 
 `--dry-run` exits 0 on no drift, 1 on drift detected; default mode mutates `configuration.yaml` and bumps `provenance.last_checked` only when drift is detected (the workflow then commits and opens the PR).
 
-To track an additional upstream catalog (e.g., a future Codex tool list), add a new harness bucket under `allowed_tools.catalogs.<harness>` with its own `provenance` block, then add the harness name to `HARNESS_NAMES` in the helper. The workflow itself does not need editing.
+The helper tracks the `claude_code` catalog only. The `catalogs.<harness>` YAML structure preserves room for a future second harness, but adding one is not a YAML-only edit — `run` and `parse_catalog` in `.github/scripts/tool-catalog-drift.py` currently process the single default harness, so a future extension requires helper changes (and may need workflow updates for per-harness PR titles or reporting).
 
 ### Linting Shell Scripts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,6 +186,21 @@ python scripts/stats.py . --json
 
 A missing or unreadable `SKILL.md` is a FAIL — that includes the file not existing, an I/O error during read, or invalid UTF-8 in either the frontmatter scan or the body. Everything else recovers: broken references, parent-traversal attempts, external references, undecodable referenced files, and frontmatter parse errors are surfaced as WARN/INFO findings while the run still emits a usable metric.
 
+### Detecting Tool Catalog Drift
+
+The hand-maintained Claude Code tool catalog at `allowed_tools.catalogs.claude_code` in `skill-system-foundry/scripts/lib/configuration.yaml` drifts as Claude Code adds, renames, or retires tools. A weekly scheduled workflow (`.github/workflows/tool-catalog-drift.yaml`, helper at `.github/scripts/tool-catalog-drift.py`) compares the catalog against the canonical upstream tools reference at `provenance.source_url` and force-pushes a single rolling PR (`chore/tool-catalog-drift`) when drift is detected. Additions are auto-applied; removals are surfaced in the PR body as advisory candidates only — verify each name before deleting.
+
+To run the sweep locally:
+
+```bash
+python .github/scripts/tool-catalog-drift.py --dry-run
+python .github/scripts/tool-catalog-drift.py --dry-run --json
+```
+
+`--dry-run` exits 0 on no drift, 1 on drift detected; default mode mutates `configuration.yaml` and bumps `provenance.last_checked` only when drift is detected (the workflow then commits and opens the PR).
+
+To track an additional upstream catalog (e.g., a future Codex tool list), add a new harness bucket under `allowed_tools.catalogs.<harness>` with its own `provenance` block, then add the harness name to `HARNESS_NAMES` in the helper. The workflow itself does not need editing.
+
 ### Linting Shell Scripts
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ A missing or unreadable `SKILL.md` is a FAIL — that includes the file not exis
 
 ### Detecting Tool Catalog Drift
 
-The hand-maintained Claude Code tool catalog at `allowed_tools.catalogs.claude_code` in `skill-system-foundry/scripts/lib/configuration.yaml` drifts as Claude Code adds, renames, or retires tools. A weekly scheduled workflow (`.github/workflows/tool-catalog-drift.yaml`, helper at `.github/scripts/tool-catalog-drift.py`) compares the catalog against the canonical upstream tools reference at `provenance.source_url` and force-pushes a single rolling PR (`chore/tool-catalog-drift`) when drift is detected. Additions are auto-applied; removals are surfaced in the PR body as advisory candidates only — verify each name before deleting.
+The hand-maintained Claude Code tool catalog at `allowed_tools.catalogs.claude_code` in `skill-system-foundry/scripts/lib/configuration.yaml` drifts as Claude Code adds, renames, or retires tools. A weekly scheduled workflow (`.github/workflows/tool-catalog-drift.yaml`, helper at `.github/scripts/tool-catalog-drift.py`) compares the catalog against the canonical upstream tools reference at the URL recorded in `skill.allowed_tools.catalogs.claude_code.provenance.source_url` and force-pushes a single rolling PR (`chore/tool-catalog-drift`) when drift is detected. Additions are auto-applied; removals are surfaced in the PR body as advisory candidates only — verify each name before deleting.
 
 To run the sweep locally:
 
@@ -197,7 +197,7 @@ python .github/scripts/tool-catalog-drift.py --dry-run
 python .github/scripts/tool-catalog-drift.py --dry-run --json
 ```
 
-`--dry-run` exits 0 on no drift, 1 on drift detected; default mode mutates `configuration.yaml` and bumps `provenance.last_checked` only when drift is detected (the workflow then commits and opens the PR).
+`--dry-run` exits 0 on no drift, 1 on drift detected; default mode mutates `configuration.yaml` and bumps `skill.allowed_tools.catalogs.claude_code.provenance.last_checked` only when drift is detected (the workflow then commits and opens the PR).
 
 The helper tracks the `claude_code` catalog only. The `catalogs.<harness>` YAML structure preserves room for a future second harness, but adding one is not a YAML-only edit — `run` and `parse_catalog` in `.github/scripts/tool-catalog-drift.py` currently process the single default harness, so a future extension requires helper changes (and may need workflow updates for per-harness PR titles or reporting).
 

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -103,13 +103,15 @@ skill:
         # ``tool-catalog-drift`` workflow at
         # ``.github/workflows/tool-catalog-drift.yaml`` (helper at
         # ``.github/scripts/tool-catalog-drift.py``).  ``last_checked``
-        # is rewritten by the helper only when drift is detected, so
-        # quiet scheduled runs do not produce date-only commits.  An
-        # unchanged value means no catalog update was recorded; the
-        # GitHub Actions run history provides the "did the sweep run"
-        # signal.  These values were comments before #118 promoted
-        # them to structured YAML so the drift helper has a single
-        # source of truth.
+        # is rewritten only when the helper auto-applies additions —
+        # the date marks the last actual catalog change, not every
+        # drift-detection run.  Quiet runs and removals-only drift
+        # (advisory only, never applied) both leave the date
+        # untouched, so an unchanged value means no auto-applied
+        # update was recorded; the GitHub Actions run history
+        # provides the "did the sweep run" signal.  These values were
+        # comments before #118 promoted them to structured YAML so
+        # the drift helper has a single source of truth.
         provenance:
           source_url: https://code.claude.com/docs/en/tools-reference.md
           last_checked: "2026-05-01"

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -102,12 +102,14 @@ skill:
         # ``source_url`` is the page consumed by the
         # ``tool-catalog-drift`` workflow at
         # ``.github/workflows/tool-catalog-drift.yaml`` (helper at
-        # ``.github/scripts/tool_catalog_drift.py``).  ``last_checked``
-        # is rewritten by the helper on every successful run, whether
-        # or not drift was detected, so the YAML diff alone tells you
-        # when the catalog was last reconciled with upstream.  These
-        # values were comments before #118 promoted them to structured
-        # YAML so the drift helper has a single source of truth.
+        # ``.github/scripts/tool-catalog-drift.py``).  ``last_checked``
+        # is rewritten by the helper only when drift is detected, so
+        # quiet scheduled runs do not produce date-only commits.  An
+        # unchanged value means no catalog update was recorded; the
+        # GitHub Actions run history provides the "did the sweep run"
+        # signal.  These values were comments before #118 promoted
+        # them to structured YAML so the drift helper has a single
+        # source of truth.
         provenance:
           source_url: https://code.claude.com/docs/en/tools-reference.md
           last_checked: "2026-05-01"

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -98,8 +98,19 @@ skill:
     # with their own bucket shape when convenient.
     catalogs:
       claude_code:
-        # Source: https://code.claude.com/docs/en/skills
-        # Last checked: 2026-04-26
+        # Provenance for the canonical upstream source of truth.  The
+        # ``source_url`` is the page consumed by the
+        # ``tool-catalog-drift`` workflow at
+        # ``.github/workflows/tool-catalog-drift.yaml`` (helper at
+        # ``.github/scripts/tool_catalog_drift.py``).  ``last_checked``
+        # is rewritten by the helper on every successful run, whether
+        # or not drift was detected, so the YAML diff alone tells you
+        # when the catalog was last reconciled with upstream.  These
+        # values were comments before #118 promoted them to structured
+        # YAML so the drift helper has a single source of truth.
+        provenance:
+          source_url: https://code.claude.com/docs/en/tools-reference.md
+          last_checked: "2026-05-01"
         harness_tools:
           - Bash
           - Read

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -376,6 +376,22 @@ class AllowedToolsCatalogTests(unittest.TestCase):
             | constants.CLI_TOOLS_CLAUDE_CODE,
         )
 
+    def test_provenance_metadata_does_not_pollute_catalog_sets(self) -> None:
+        # Defensive regression: ``provenance`` is a sibling mapping
+        # under ``catalogs.claude_code`` (added in #118 to give the
+        # drift helper a single source of truth for the upstream URL
+        # and last-checked date).  The constants loader subscripts
+        # ``harness_tools`` and ``cli_tools`` explicitly rather than
+        # iterating bucket children, but if a future code edit ever
+        # iterates and pollutes these sets, this test catches it.
+        polluters = {
+            "provenance", "source_url", "last_checked",
+        }
+        for polluter in polluters:
+            self.assertNotIn(polluter, constants.HARNESS_TOOLS_CLAUDE_CODE)
+            self.assertNotIn(polluter, constants.CLI_TOOLS_CLAUDE_CODE)
+            self.assertNotIn(polluter, constants.KNOWN_TOOLS)
+
     def test_known_tools_recognises_lowercase_bash(self) -> None:
         # Backwards-compat: existing skills may list lowercase ``bash``.
         # Recognition INFO must continue to treat it as known.


### PR DESCRIPTION
## Summary

Closes #118.

Adds a weekly scheduled workflow (Mondays 12:00 UTC + `workflow_dispatch`) that detects drift between the hand-maintained Claude Code tool catalog at `allowed_tools.catalogs.claude_code` and the canonical upstream tools reference, and force-pushes a single rolling PR (`chore/tool-catalog-drift`) when drift is found.

## What changed (6 commits)

1. **YAML schema** — promotes `provenance` from inline comments to a structured field under `catalogs.claude_code`. Switches the source URL from the skills doc page (only ~3 tools mentioned in `allowed-tools:` examples) to `https://code.claude.com/docs/en/tools-reference.md` (canonical markdown table enumerating every tool).
2. **Helper script** at `.github/scripts/tool-catalog-drift.py` — stdlib-only, layered (`fetch` / `extract_tools` / `parse_catalog` / `diff` / `apply_additions` / `render_summary`). Hard-fails on every error path: non-2xx HTTP, network errors, non-UTF-8 bodies, header-row mismatches, zero tokens extracted.
3. **Tests + fixture** under `.github/tests/` — isolated from the meta-skill's `tests/` per the repo-infrastructure separation. Captured `tools-reference.md` as a deterministic fixture. 50 tests covering every public function, every error path, and the real `configuration.yaml` as a canary.
4. **CI helper-tests workflow** at `.github/workflows/ci-helper-tests.yaml` — path-filtered to `.github/scripts/**` and `.github/tests/**` so the meta-skill matrix in `python-tests.yaml` is unaffected.
5. **Drift workflow** at `.github/workflows/tool-catalog-drift.yaml` — `concurrency: tool-catalog-drift` (no cancel-in-progress), workflow-wide `contents: read` with elevated per-job permissions, default `GITHUB_TOKEN`. Single rolling branch with force-push; opens, edits, or closes the PR depending on drift state. Also gates `last_checked` rewrites on drift detection so quiet weeks do not produce noisy date-only commits.
6. **`--json` output mode** + AGENTS.md "Detecting Tool Catalog Drift" section. JSON mode brings the helper in line with every other `.github/scripts/` helper.

## Drift direction

- **Additions** (upstream has, catalog lacks) — auto-applied to the YAML diff. The PR diff is the proposal.
- **Removals** (catalog has, upstream lacks) — surfaced in the PR body as advisory candidates only. NOT auto-applied. A regex miss or one-version-wide doc edit could falsely propose dropping a real tool, so removals always require a human edit.

## First-run cleanup PR (expected)

The first scheduled run after this lands will propose **adding ~25 tools and flagging `Task` as a candidate removal** — the catalog is roughly 30% accurate today against the upstream tools-reference table. That's the feature, not a bug; the workflow proves itself by surfacing the staleness immediately. Subsequent runs should be quiet most weeks.

Out of scope: I deliberately did **not** preemptively reconcile the catalog in this PR — the workflow's first run should produce that diff itself.

## Scope decisions documented in commits

- **Claude Code only.** OpenAI Codex has no `allowed-tools` field (every tool is MCP-sourced and user-configured), Cursor has no documented dialect, agentskills.io leaves tool names host-defined. The `catalogs.<harness>` YAML structure preserves room for a future second harness; no second bucket ships in this PR.
- **No version bump / CHANGELOG entry.** Release-prep handles those when the next minor cuts.
- **Per-MCP-server drift via `tools/list`.** A different engineering shape (JSON-RPC against running servers, not HTTP fetcher); belongs to a separate discovery issue if pursued.

## Workflow shape (from commit messages)

| Aspect | Decision |
|---|---|
| Cadence | Mondays 12:00 UTC (`0 12 * * 1`) + `workflow_dispatch` |
| Branch strategy | Single rolling `chore/tool-catalog-drift`, force-push on each drift, auto-close + branch-delete when drift resolves |
| Token | Default `GITHUB_TOKEN`, attributed to `github-actions[bot]` |
| CI on the auto-PR | Will not fire automatically (GitHub limitation). PR body documents the close-and-reopen workaround, mirroring `release-prep.yml` |
| Concurrency | `tool-catalog-drift` group, `cancel-in-progress: false` so a queued `workflow_dispatch` waits rather than races the cron |
| Hard-fail conditions | Fetch errors, table-shape mismatches, zero tokens extracted, parse errors |

## Test plan

- [x] `python -m unittest discover -s .github/tests -p "test_*.py"` — 50 tests passing locally
- [x] `python -m unittest discover -s tests -p "test_*.py"` — 2240 meta-skill tests still passing
- [x] `python .github/scripts/verify-action-pins.py` — clean
- [x] `python .github/scripts/tool-catalog-drift.py --dry-run` — finds 25 additions and 1 removal against live upstream
- [x] `python .github/scripts/tool-catalog-drift.py --dry-run --json` — emits sorted machine-readable payload
- [ ] First scheduled or `workflow_dispatch` run after merge — produces the cleanup PR
- [ ] Manual close-and-reopen of the auto-PR fires `python-tests.yaml` and `ci-helper-tests.yaml` against the head

## Related issues

- Implements #118.
- Partially answers #119 (discovery: is vendoring upstream catalogs feasible?) — Claude Code publishes a structured table at a stable URL; Codex and Cursor do not. The vendoring scope reduces to "do we want to vendor `tools-reference.md` verbatim with checksum verification" — a smaller follow-up than originally framed.
- Builds on #100 (per-harness tool catalog).
