### PR TITLE
Move catalog provenance to top-level catalog_provenance key

### DIFF
--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -282,6 +282,67 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
     """
     lines = yaml_text.splitlines()
 
+    # Locate ``catalogs.<harness>`` first so the migration-mistake
+    # checks (legacy ``provenance:`` and misplaced
+    # ``catalog_provenance:`` directly under the harness bucket) can
+    # fire BEFORE the top-level ``catalog_provenance`` lookup.  A user
+    # who put the new key in the wrong place would otherwise hit the
+    # generic "missing top-level catalog_provenance" message and miss
+    # the actionable wrong-path/right-path guidance below.
+    catalogs_index = _find_key_line(
+        lines, "catalogs:", parents=("skill:", "allowed_tools:")
+    )
+    if catalogs_index < 0:
+        raise ParseError(
+            "configuration.yaml has no `catalogs:` block under "
+            "`skill.allowed_tools` — schema mismatch"
+        )
+
+    harness_index = _find_child_key(
+        lines, catalogs_index, f"{harness}:"
+    )
+    if harness_index < 0:
+        raise ParseError(
+            f"configuration.yaml has no `{harness}:` bucket under "
+            "`skill.allowed_tools.catalogs` — add the bucket or "
+            "update the harness list in this helper"
+        )
+
+    # Reject a leftover legacy ``provenance:`` child even when the new
+    # ``catalog_provenance.<harness>`` key is also present.  A
+    # partial-migration YAML carrying both shapes would otherwise parse
+    # cleanly and silently re-introduce the non-list child this schema
+    # move is meant to make impossible under ``catalogs.<harness>``.
+    legacy_provenance_index = _find_child_key(
+        lines, harness_index, "provenance:"
+    )
+    if legacy_provenance_index >= 0:
+        raise ParseError(
+            f"configuration.yaml still has a legacy `provenance:` child "
+            f"under `skill.allowed_tools.catalogs.{harness}` — remove "
+            "it; provenance now lives at "
+            f"`skill.allowed_tools.catalog_provenance.{harness}`"
+        )
+
+    # Also reject a misplaced ``catalog_provenance:`` *under* the
+    # harness bucket — the new schema requires it to live as a sibling
+    # of ``catalogs:`` at ``skill.allowed_tools.catalog_provenance``,
+    # not nested under any ``catalogs.<harness>``.  This check runs
+    # before the top-level lookup below so a single-mistake migration
+    # (only the misplaced version, no top-level one) still produces
+    # the actionable wrong-path/right-path guidance instead of the
+    # generic "missing top-level catalog_provenance" error.
+    misplaced_provenance_index = _find_child_key(
+        lines, harness_index, "catalog_provenance:"
+    )
+    if misplaced_provenance_index >= 0:
+        raise ParseError(
+            f"configuration.yaml has a misplaced `catalog_provenance:` "
+            f"child under `skill.allowed_tools.catalogs.{harness}` — "
+            "move it to the sibling top-level key "
+            f"`skill.allowed_tools.catalog_provenance.{harness}`"
+        )
+
     # Provenance lives under a sibling top-level key
     # ``skill.allowed_tools.catalog_provenance.<harness>`` so
     # ``catalogs.<harness>`` stays a pure tool-name source (every
@@ -357,59 +418,6 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
             f"under `skill.allowed_tools.catalog_provenance.{harness}`: "
             f"{last_checked!r} — expected ISO-8601 `YYYY-MM-DD`"
         ) from exc
-
-    catalogs_index = _find_key_line(
-        lines, "catalogs:", parents=("skill:", "allowed_tools:")
-    )
-    if catalogs_index < 0:
-        raise ParseError(
-            "configuration.yaml has no `catalogs:` block under "
-            "`skill.allowed_tools` — schema mismatch"
-        )
-
-    harness_index = _find_child_key(
-        lines, catalogs_index, f"{harness}:"
-    )
-    if harness_index < 0:
-        raise ParseError(
-            f"configuration.yaml has no `{harness}:` bucket under "
-            "`skill.allowed_tools.catalogs` — add the bucket or "
-            "update the harness list in this helper"
-        )
-
-    # Reject a leftover legacy ``provenance:`` child even when the new
-    # ``catalog_provenance.<harness>`` key is also present.  A
-    # partial-migration YAML carrying both shapes would otherwise parse
-    # cleanly and silently re-introduce the non-list child this schema
-    # move is meant to make impossible under ``catalogs.<harness>``.
-    legacy_provenance_index = _find_child_key(
-        lines, harness_index, "provenance:"
-    )
-    if legacy_provenance_index >= 0:
-        raise ParseError(
-            f"configuration.yaml still has a legacy `provenance:` child "
-            f"under `skill.allowed_tools.catalogs.{harness}` — remove "
-            "it; provenance now lives at "
-            f"`skill.allowed_tools.catalog_provenance.{harness}`"
-        )
-
-    # Also reject a misplaced ``catalog_provenance:`` *under* the
-    # harness bucket — the new schema requires it to live as a sibling
-    # of ``catalogs:`` at ``skill.allowed_tools.catalog_provenance``,
-    # not nested under any ``catalogs.<harness>``.  Without this guard
-    # a misapplied migration would still satisfy the legacy-rejection
-    # check above and silently leave a non-list child in the catalog
-    # bucket, defeating the schema move's invariant.
-    misplaced_provenance_index = _find_child_key(
-        lines, harness_index, "catalog_provenance:"
-    )
-    if misplaced_provenance_index >= 0:
-        raise ParseError(
-            f"configuration.yaml has a misplaced `catalog_provenance:` "
-            f"child under `skill.allowed_tools.catalogs.{harness}` — "
-            "move it to the sibling top-level key "
-            f"`skill.allowed_tools.catalog_provenance.{harness}`"
-        )
 
     harness_tools_index = _find_child_key(
         lines, harness_index, "harness_tools:"

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -466,47 +466,23 @@ def _find_key_line(
     """Find *key* as a direct child of the chain of *parents*.
 
     Walks forward, descending into each parent in order, then looks
-    for *key* at the direct-child indent of the deepest parent.  A
-    future nested key with the same name deeper in the subtree is
-    skipped — the schema move is specifically about a sibling
-    top-level key, so the lookup must not bind to a same-named
-    descendant by accident.  Returns the line index or -1.
+    for *key* at the direct-child indent of the deepest parent.  Both
+    the parent descent and the final lookup enforce direct-child
+    semantics — a same-named key nested deeper in the subtree (or
+    embedded in a block scalar that happens to look like YAML) cannot
+    bind by accident.  Returns the line index or -1.
     """
     cursor = 0
     parent_indent = -1
     for parent in parents:
-        cursor = _find_key_at_or_after(lines, parent, cursor, parent_indent)
+        cursor = _find_direct_child_at_or_after(
+            lines, parent, cursor, parent_indent
+        )
         if cursor < 0:
             return -1
         parent_indent = _line_indent(lines[cursor])
         cursor += 1
     return _find_direct_child_at_or_after(lines, key, cursor, parent_indent)
-
-
-def _find_key_at_or_after(
-    lines: list[str], key: str, start: int, parent_indent: int
-) -> int:
-    """Find *key* starting at line *start*, deeper than *parent_indent*.
-
-    A negative *parent_indent* means "any indent" (used at the
-    top-level scan).  This helper does not enforce direct-child
-    semantics — it returns the first match at any depth deeper than
-    the parent.  Use :func:`_find_direct_child_at_or_after` (or
-    :func:`_find_child_key`) when the lookup must reject same-named
-    descendants.
-    """
-    for index in range(start, len(lines)):
-        line = lines[index]
-        stripped = line.strip()
-        if stripped == "" or stripped.startswith("#"):
-            continue
-        indent = _line_indent(line)
-        if parent_indent >= 0 and indent <= parent_indent:
-            # Left the parent block — key not found inside it.
-            return -1
-        if stripped.startswith(key):
-            return index
-    return -1
 
 
 def _find_direct_child_at_or_after(

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -274,11 +274,11 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
         immediately after the last existing harness-tool item.  The
         writer inserts new items there.
       * ``last_checked_line`` — int, the line index of
-        ``catalog_provenance.<harness>.last_checked``.
+        ``provenance.last_checked``.
 
-    Hard-fails (:class:`ParseError`) when the catalog_provenance
-    block, the harness bucket, or the harness_tools list is missing
-    or malformed.
+    Hard-fails (:class:`ParseError`) when the harness bucket, the
+    provenance block, or the harness_tools list is missing or
+    malformed.
     """
     lines = yaml_text.splitlines()
 

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -336,6 +336,19 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
             "no-drift / removals-only run cannot leave the catalog "
             "in an unprovenanced state"
         )
+    # ``datetime.date.fromisoformat`` alone accepts the compact ISO
+    # form (e.g. ``20260501``) since Python 3.11.  Pre-check the
+    # exact ``YYYY-MM-DD`` shape so the helper enforces the format it
+    # documents — otherwise a hyphen-less value would round-trip into
+    # ``configuration.yaml`` even though the canary and the workflow
+    # both assume canonical extended-form dates.
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", last_checked):
+        raise ParseError(
+            f"configuration.yaml has an invalid `last_checked` value "
+            f"under `skill.allowed_tools.catalog_provenance.{harness}`: "
+            f"{last_checked!r} — expected ISO-8601 `YYYY-MM-DD` "
+            "(extended form with hyphen separators)"
+        )
     try:
         datetime.date.fromisoformat(last_checked)
     except ValueError as exc:

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -463,10 +463,14 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
 def _find_key_line(
     lines: list[str], key: str, parents: tuple[str, ...]
 ) -> int:
-    """Find *key* under the chain of *parents*.
+    """Find *key* as a direct child of the chain of *parents*.
 
-    Walks forward, descending into each parent in order.  Returns the
-    index of the matching line or -1.
+    Walks forward, descending into each parent in order, then looks
+    for *key* at the direct-child indent of the deepest parent.  A
+    future nested key with the same name deeper in the subtree is
+    skipped — the schema move is specifically about a sibling
+    top-level key, so the lookup must not bind to a same-named
+    descendant by accident.  Returns the line index or -1.
     """
     cursor = 0
     parent_indent = -1
@@ -476,7 +480,7 @@ def _find_key_line(
             return -1
         parent_indent = _line_indent(lines[cursor])
         cursor += 1
-    return _find_key_at_or_after(lines, key, cursor, parent_indent)
+    return _find_direct_child_at_or_after(lines, key, cursor, parent_indent)
 
 
 def _find_key_at_or_after(
@@ -485,7 +489,11 @@ def _find_key_at_or_after(
     """Find *key* starting at line *start*, deeper than *parent_indent*.
 
     A negative *parent_indent* means "any indent" (used at the
-    top-level scan).
+    top-level scan).  This helper does not enforce direct-child
+    semantics — it returns the first match at any depth deeper than
+    the parent.  Use :func:`_find_direct_child_at_or_after` (or
+    :func:`_find_child_key`) when the lookup must reject same-named
+    descendants.
     """
     for index in range(start, len(lines)):
         line = lines[index]
@@ -501,17 +509,52 @@ def _find_key_at_or_after(
     return -1
 
 
+def _find_direct_child_at_or_after(
+    lines: list[str], key: str, start: int, parent_indent: int
+) -> int:
+    """Find *key* as a direct child starting at line *start*.
+
+    A direct child is a key at the first non-blank/non-comment indent
+    encountered deeper than *parent_indent*.  Lines at greater depth
+    (descendants) are skipped so a future nested key with the same
+    name cannot bind by accident.  Returns the line index or -1 if
+    the parent block ends before finding *key*.
+
+    A negative *parent_indent* means "no parent" — the first key
+    encountered sets the direct-child indent (matches top-level keys).
+    """
+    direct_child_indent: int | None = None
+    for index in range(start, len(lines)):
+        line = lines[index]
+        stripped = line.strip()
+        if stripped == "" or stripped.startswith("#"):
+            continue
+        indent = _line_indent(line)
+        if parent_indent >= 0 and indent <= parent_indent:
+            return -1
+        if direct_child_indent is None:
+            direct_child_indent = indent
+        elif indent != direct_child_indent:
+            continue
+        if stripped.startswith(key):
+            return index
+    return -1
+
+
 def _find_child_key(
     lines: list[str], parent_line: int, key: str
 ) -> int:
     """Find *key* as a direct child of the mapping declared at *parent_line*.
 
-    A direct child is the first key found at indent strictly greater
-    than the parent's indent, before any line at indent <= parent's.
+    A direct child is a key at the first non-blank/non-comment indent
+    deeper than the parent's indent.  Descendants at greater depth are
+    skipped so a same-named nested key cannot bind by accident.
     Returns the line index or -1.
     """
     parent_indent = _line_indent(lines[parent_line])
-    return _find_key_at_or_after(lines, key, parent_line + 1, parent_indent)
+    return _find_direct_child_at_or_after(
+        lines, key, parent_line + 1, parent_indent
+    )
 
 
 def _scalar_value(line: str, key: str) -> str:

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -274,13 +274,76 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
         immediately after the last existing harness-tool item.  The
         writer inserts new items there.
       * ``last_checked_line`` — int, the line index of
-        ``provenance.last_checked``.
+        ``catalog_provenance.<harness>.last_checked``.
 
-    Hard-fails (:class:`ParseError`) when the harness bucket, the
-    provenance block, or the harness_tools list is missing or
-    malformed.
+    Hard-fails (:class:`ParseError`) when the catalog_provenance
+    block, the harness bucket, or the harness_tools list is missing
+    or malformed.
     """
     lines = yaml_text.splitlines()
+
+    # Provenance lives under a sibling top-level key
+    # ``skill.allowed_tools.catalog_provenance.<harness>`` so
+    # ``catalogs.<harness>`` stays a pure tool-name source (every
+    # direct child is a list of tool names).
+    catalog_prov_index = _find_key_line(
+        lines, "catalog_provenance:", parents=("skill:", "allowed_tools:")
+    )
+    if catalog_prov_index < 0:
+        raise ParseError(
+            "configuration.yaml has no `catalog_provenance:` block "
+            "under `skill.allowed_tools` — schema mismatch"
+        )
+
+    harness_prov_index = _find_child_key(
+        lines, catalog_prov_index, f"{harness}:"
+    )
+    if harness_prov_index < 0:
+        raise ParseError(
+            f"configuration.yaml has no `{harness}:` bucket under "
+            "`skill.allowed_tools.catalog_provenance` — add the "
+            "bucket or update the harness list in this helper"
+        )
+
+    source_url_line = _find_child_key(
+        lines, harness_prov_index, "source_url:"
+    )
+    last_checked_line = _find_child_key(
+        lines, harness_prov_index, "last_checked:"
+    )
+    if source_url_line < 0 or last_checked_line < 0:
+        raise ParseError(
+            "configuration.yaml is missing `source_url` and/or "
+            f"`last_checked` under "
+            f"`skill.allowed_tools.catalog_provenance.{harness}` — "
+            "schema migration incomplete"
+        )
+
+    source_url = _scalar_value(lines[source_url_line], "source_url:")
+    last_checked = _scalar_value(lines[last_checked_line], "last_checked:")
+    if not source_url:
+        raise ParseError(
+            f"configuration.yaml has an empty `source_url` value under "
+            f"`skill.allowed_tools.catalog_provenance.{harness}` — "
+            "provide an explicit URL rather than falling back to a "
+            "default (silent fallback would mask misconfigurations)"
+        )
+    if not last_checked:
+        raise ParseError(
+            f"configuration.yaml has an empty `last_checked` value "
+            f"under `skill.allowed_tools.catalog_provenance.{harness}` — "
+            "provide an explicit ISO-8601 `YYYY-MM-DD` date so a "
+            "no-drift / removals-only run cannot leave the catalog "
+            "in an unprovenanced state"
+        )
+    try:
+        datetime.date.fromisoformat(last_checked)
+    except ValueError as exc:
+        raise ParseError(
+            f"configuration.yaml has an invalid `last_checked` value "
+            f"under `skill.allowed_tools.catalog_provenance.{harness}`: "
+            f"{last_checked!r} — expected ISO-8601 `YYYY-MM-DD`"
+        ) from exc
 
     catalogs_index = _find_key_line(
         lines, "catalogs:", parents=("skill:", "allowed_tools:")
@@ -300,52 +363,6 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
             "`skill.allowed_tools.catalogs` — add the bucket or "
             "update the harness list in this helper"
         )
-
-    provenance_index = _find_child_key(lines, harness_index, "provenance:")
-    if provenance_index < 0:
-        raise ParseError(
-            f"configuration.yaml has no `provenance:` block under "
-            f"`skill.allowed_tools.catalogs.{harness}` — schema "
-            "migration incomplete (see issue #118)"
-        )
-
-    source_url_line = _find_child_key(
-        lines, provenance_index, "source_url:"
-    )
-    last_checked_line = _find_child_key(
-        lines, provenance_index, "last_checked:"
-    )
-    if source_url_line < 0 or last_checked_line < 0:
-        raise ParseError(
-            "configuration.yaml is missing `source_url` and/or "
-            f"`last_checked` under `{harness}.provenance` — schema "
-            "migration incomplete"
-        )
-
-    source_url = _scalar_value(lines[source_url_line], "source_url:")
-    last_checked = _scalar_value(lines[last_checked_line], "last_checked:")
-    if not source_url:
-        raise ParseError(
-            f"configuration.yaml has an empty `source_url` value under "
-            f"`{harness}.provenance` — provide an explicit URL rather "
-            "than falling back to a default (silent fallback would "
-            "mask misconfigurations)"
-        )
-    if not last_checked:
-        raise ParseError(
-            f"configuration.yaml has an empty `last_checked` value "
-            f"under `{harness}.provenance` — provide an explicit "
-            "ISO-8601 `YYYY-MM-DD` date so a no-drift / removals-only "
-            "run cannot leave the catalog in an unprovenanced state"
-        )
-    try:
-        datetime.date.fromisoformat(last_checked)
-    except ValueError as exc:
-        raise ParseError(
-            f"configuration.yaml has an invalid `last_checked` value "
-            f"under `{harness}.provenance`: {last_checked!r} — expected "
-            "ISO-8601 `YYYY-MM-DD`"
-        ) from exc
 
     harness_tools_index = _find_child_key(
         lines, harness_index, "harness_tools:"

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -4,7 +4,7 @@ and the canonical upstream tools reference.
 Reads the catalog at ``skill-system-foundry/scripts/lib/configuration.yaml``
 under ``skill.allowed_tools.catalogs.claude_code``, fetches the
 upstream markdown table at the URL recorded in
-``skill.allowed_tools.catalogs.claude_code.provenance.source_url``,
+``skill.allowed_tools.catalog_provenance.claude_code.source_url``,
 and compares the two sets of tool names.
 
 Outcomes:
@@ -274,11 +274,13 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
         immediately after the last existing harness-tool item.  The
         writer inserts new items there.
       * ``last_checked_line`` — int, the line index of
-        ``provenance.last_checked``.
+        ``catalog_provenance.<harness>.last_checked``.
 
-    Hard-fails (:class:`ParseError`) when the harness bucket, the
-    provenance block, or the harness_tools list is missing or
-    malformed.
+    Hard-fails (:class:`ParseError`) when the catalog harness bucket,
+    the catalog_provenance harness bucket, or the harness_tools list
+    is missing or malformed; also rejects a leftover legacy
+    ``provenance:`` child or a misplaced ``catalog_provenance:`` child
+    under ``catalogs.<harness>``.
     """
     lines = yaml_text.splitlines()
 

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -393,6 +393,24 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
             f"`skill.allowed_tools.catalog_provenance.{harness}`"
         )
 
+    # Also reject a misplaced ``catalog_provenance:`` *under* the
+    # harness bucket — the new schema requires it to live as a sibling
+    # of ``catalogs:`` at ``skill.allowed_tools.catalog_provenance``,
+    # not nested under any ``catalogs.<harness>``.  Without this guard
+    # a misapplied migration would still satisfy the legacy-rejection
+    # check above and silently leave a non-list child in the catalog
+    # bucket, defeating the schema move's invariant.
+    misplaced_provenance_index = _find_child_key(
+        lines, harness_index, "catalog_provenance:"
+    )
+    if misplaced_provenance_index >= 0:
+        raise ParseError(
+            f"configuration.yaml has a misplaced `catalog_provenance:` "
+            f"child under `skill.allowed_tools.catalogs.{harness}` — "
+            "move it to the sibling top-level key "
+            f"`skill.allowed_tools.catalog_provenance.{harness}`"
+        )
+
     harness_tools_index = _find_child_key(
         lines, harness_index, "harness_tools:"
     )

--- a/.github/scripts/tool-catalog-drift.py
+++ b/.github/scripts/tool-catalog-drift.py
@@ -364,6 +364,22 @@ def parse_catalog(yaml_text: str, harness: str = "claude_code") -> dict:
             "update the harness list in this helper"
         )
 
+    # Reject a leftover legacy ``provenance:`` child even when the new
+    # ``catalog_provenance.<harness>`` key is also present.  A
+    # partial-migration YAML carrying both shapes would otherwise parse
+    # cleanly and silently re-introduce the non-list child this schema
+    # move is meant to make impossible under ``catalogs.<harness>``.
+    legacy_provenance_index = _find_child_key(
+        lines, harness_index, "provenance:"
+    )
+    if legacy_provenance_index >= 0:
+        raise ParseError(
+            f"configuration.yaml still has a legacy `provenance:` child "
+            f"under `skill.allowed_tools.catalogs.{harness}` — remove "
+            "it; provenance now lives at "
+            f"`skill.allowed_tools.catalog_provenance.{harness}`"
+        )
+
     harness_tools_index = _find_child_key(
         lines, harness_index, "harness_tools:"
     )

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -370,6 +370,37 @@ class ParseCatalogTests(unittest.TestCase):
         self.assertIn("legacy", message.lower())
         self.assertIn("catalogs.claude_code", message)
 
+    def test_nested_catalog_provenance_does_not_bind(self) -> None:
+        # The schema move makes ``catalog_provenance`` a sibling
+        # top-level key under ``skill.allowed_tools``.  The lookup must
+        # therefore enforce direct-child semantics — a future YAML
+        # that nests a same-named key deeper in the subtree must NOT
+        # bind to the nested copy and read its values.  This test
+        # constructs a YAML where a nested ``catalog_provenance:``
+        # under ``catalogs.<harness>`` carries deliberately wrong
+        # values; the helper must read the top-level (correct) bucket
+        # instead, proving the lookup is direct-child-only.
+        yaml_text = (
+            "skill:\n"
+            "  allowed_tools:\n"
+            "    catalogs:\n"
+            "      claude_code:\n"
+            "        catalog_provenance:\n"
+            "          source_url: https://example.test/WRONG.md\n"
+            "          last_checked: \"1999-01-01\"\n"
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "    catalog_provenance:\n"
+            "      claude_code:\n"
+            "        source_url: https://example.test/correct.md\n"
+            "        last_checked: \"2026-04-26\"\n"
+        )
+        parsed = mod.parse_catalog(yaml_text)
+        self.assertEqual(
+            parsed["source_url"], "https://example.test/correct.md"
+        )
+        self.assertEqual(parsed["last_checked"], "2026-04-26")
+
     def test_missing_harness_tools_raises(self) -> None:
         text = _HAPPY_CATALOG.replace(
             "        harness_tools:\n"

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -417,6 +417,25 @@ class ParseCatalogTests(unittest.TestCase):
         self.assertIn("last_checked", str(ctx.exception))
         self.assertIn("ISO-8601", str(ctx.exception))
 
+    def test_compact_iso_last_checked_value_raises(self) -> None:
+        # ``datetime.date.fromisoformat`` alone accepts the compact ISO
+        # form (no hyphens) since Python 3.11, so the format check has
+        # to pre-validate the canonical ``YYYY-MM-DD`` shape before
+        # parsing.  Without that pre-check, a hyphen-less value would
+        # round-trip into ``configuration.yaml`` and then trip the
+        # canary on the next CI run rather than failing at the helper's
+        # own boundary.
+        text = _HAPPY_CATALOG.replace(
+            'last_checked: "2026-04-26"',
+            'last_checked: "20260426"',
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(text)
+        message = str(ctx.exception)
+        self.assertIn("last_checked", message)
+        self.assertIn("YYYY-MM-DD", message)
+        self.assertIn("20260426", message)
+
     def test_empty_source_url_value_raises(self) -> None:
         # Empty value (``source_url:`` with no scalar after it) must
         # also hard-fail — silent fallback to a default would mask

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -407,16 +407,17 @@ class ParseCatalogTests(unittest.TestCase):
         )
         self.assertEqual(parsed["last_checked"], "2026-04-26")
 
-    def test_nested_catalog_provenance_does_not_bind(self) -> None:
-        # The schema move makes ``catalog_provenance`` a sibling
-        # top-level key under ``skill.allowed_tools``.  The lookup must
-        # therefore enforce direct-child semantics — a future YAML
-        # that nests a same-named key deeper in the subtree must NOT
-        # bind to the nested copy and read its values.  This test
-        # constructs a YAML where a nested ``catalog_provenance:``
-        # under ``catalogs.<harness>`` carries deliberately wrong
-        # values; the helper must read the top-level (correct) bucket
-        # instead, proving the lookup is direct-child-only.
+    def test_misplaced_catalog_provenance_under_harness_raises(self) -> None:
+        # The schema move requires ``catalog_provenance`` to live as a
+        # sibling of ``catalogs:`` at ``skill.allowed_tools``, not
+        # nested under any ``catalogs.<harness>``.  A misapplied
+        # migration that placed it under the harness bucket would
+        # silently leave a non-list child in the catalog bucket — the
+        # exact shape this PR is meant to make impossible — and the
+        # helper would still read provenance from the (correct)
+        # top-level key.  The parser must hard-fail instead, naming
+        # both the wrong location and the right one so the maintainer
+        # can move the block in a single edit.
         yaml_text = (
             "skill:\n"
             "  allowed_tools:\n"
@@ -432,11 +433,12 @@ class ParseCatalogTests(unittest.TestCase):
             "        source_url: https://example.test/correct.md\n"
             "        last_checked: \"2026-04-26\"\n"
         )
-        parsed = mod.parse_catalog(yaml_text)
-        self.assertEqual(
-            parsed["source_url"], "https://example.test/correct.md"
-        )
-        self.assertEqual(parsed["last_checked"], "2026-04-26")
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(yaml_text)
+        message = str(ctx.exception)
+        self.assertIn("misplaced", message.lower())
+        self.assertIn("catalogs.claude_code", message)
+        self.assertIn("catalog_provenance.claude_code", message)
 
     def test_missing_harness_tools_raises(self) -> None:
         text = _HAPPY_CATALOG.replace(

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -321,6 +321,27 @@ class ParseCatalogTests(unittest.TestCase):
             mod.parse_catalog(text)
         self.assertIn("catalog_provenance", str(ctx.exception))
 
+    def test_old_flat_provenance_shape_raises(self) -> None:
+        # A YAML in the legacy shape (``catalogs.<harness>.provenance:``)
+        # must fail loudly so a future revert to the old layout is
+        # caught at parse time rather than silently absorbed.  The
+        # error message names ``catalog_provenance`` so the failure
+        # mode is greppable to the new key.
+        old_shape = (
+            "skill:\n"
+            "  allowed_tools:\n"
+            "    catalogs:\n"
+            "      claude_code:\n"
+            "        provenance:\n"
+            "          source_url: https://example.test/tools.md\n"
+            "          last_checked: \"2026-04-26\"\n"
+            "        harness_tools:\n"
+            "          - Bash\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(old_shape)
+        self.assertIn("catalog_provenance", str(ctx.exception))
+
     def test_missing_harness_tools_raises(self) -> None:
         text = _HAPPY_CATALOG.replace(
             "        harness_tools:\n"

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -341,6 +341,35 @@ class ParseCatalogTests(unittest.TestCase):
             mod.parse_catalog(old_shape)
         self.assertIn("catalog_provenance", str(ctx.exception))
 
+    def test_partial_migration_both_shapes_raises(self) -> None:
+        # A YAML carrying BOTH the legacy ``catalogs.<harness>.provenance``
+        # child AND the new top-level ``catalog_provenance.<harness>`` key
+        # must fail.  Without this guard ``parse_catalog`` would happily
+        # read the new path and ignore the legacy child, silently
+        # re-introducing the non-list catalog child this schema move is
+        # meant to make impossible.  The error names the legacy path so
+        # the maintainer knows exactly which line to delete.
+        partial = (
+            "skill:\n"
+            "  allowed_tools:\n"
+            "    catalogs:\n"
+            "      claude_code:\n"
+            "        provenance:\n"
+            "          source_url: https://example.test/old.md\n"
+            "          last_checked: \"2026-04-01\"\n"
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "    catalog_provenance:\n"
+            "      claude_code:\n"
+            "        source_url: https://example.test/tools.md\n"
+            "        last_checked: \"2026-04-26\"\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(partial)
+        message = str(ctx.exception)
+        self.assertIn("legacy", message.lower())
+        self.assertIn("catalogs.claude_code", message)
+
     def test_missing_harness_tools_raises(self) -> None:
         text = _HAPPY_CATALOG.replace(
             "        harness_tools:\n"

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -6,10 +6,9 @@ Covers:
   * ``extract_tools`` — real upstream fixture, header-row missing,
     no body, no separator row, zero matches, all-caps acronym,
     non-PascalCase row ignored.
-  * ``parse_catalog`` — happy path, missing catalog_provenance,
-    missing harness_tools, missing source_url/last_checked, empty
-    list, inconsistent indent, missing harness bucket under both
-    ``catalogs`` and ``catalog_provenance``.
+  * ``parse_catalog`` — happy path, missing provenance, missing
+    harness_tools, missing source_url/last_checked, empty list,
+    inconsistent indent, missing harness bucket.
   * ``diff`` — set arithmetic.
   * ``apply_additions`` — append at end, alphabetical insert,
     last_checked rewrite, no-op when no additions, idempotent on

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -268,15 +268,16 @@ skill:
   allowed_tools:
     catalogs:
       claude_code:
-        provenance:
-          source_url: https://example.test/tools.md
-          last_checked: "2026-04-26"
         harness_tools:
           - Bash
           - Read
           - Edit
         cli_tools:
           - bash
+    catalog_provenance:
+      claude_code:
+        source_url: https://example.test/tools.md
+        last_checked: "2026-04-26"
 """
 
 
@@ -309,9 +310,10 @@ class ParseCatalogTests(unittest.TestCase):
 
     def test_missing_provenance_raises(self) -> None:
         text = _HAPPY_CATALOG.replace(
-            "        provenance:\n"
-            "          source_url: https://example.test/tools.md\n"
-            "          last_checked: \"2026-04-26\"\n",
+            "    catalog_provenance:\n"
+            "      claude_code:\n"
+            "        source_url: https://example.test/tools.md\n"
+            "        last_checked: \"2026-04-26\"\n",
             "",
         )
         with self.assertRaises(mod.ParseError) as ctx:
@@ -332,7 +334,7 @@ class ParseCatalogTests(unittest.TestCase):
 
     def test_missing_source_url_raises(self) -> None:
         text = _HAPPY_CATALOG.replace(
-            "          source_url: https://example.test/tools.md\n", ""
+            "        source_url: https://example.test/tools.md\n", ""
         )
         with self.assertRaises(mod.ParseError) as ctx:
             mod.parse_catalog(text)
@@ -371,16 +373,34 @@ class ParseCatalogTests(unittest.TestCase):
         # misconfigurations and contradict the helper's hard-fail
         # contract.
         text = _HAPPY_CATALOG.replace(
-            "          source_url: https://example.test/tools.md\n",
-            "          source_url:\n",
+            "        source_url: https://example.test/tools.md\n",
+            "        source_url:\n",
         )
         with self.assertRaises(mod.ParseError) as ctx:
             mod.parse_catalog(text)
         self.assertIn("empty", str(ctx.exception).lower())
         self.assertIn("source_url", str(ctx.exception))
 
-    def test_missing_harness_bucket_raises(self) -> None:
-        text = _HAPPY_CATALOG.replace("claude_code", "fake_harness")
+    def test_missing_harness_bucket_in_catalogs_raises(self) -> None:
+        # Rename only the ``catalogs.<harness>`` occurrence; leave
+        # ``catalog_provenance.<harness>`` intact so the failure is
+        # localized to the harness_tools lookup.
+        text = _HAPPY_CATALOG.replace(
+            "      claude_code:\n        harness_tools:",
+            "      fake_harness:\n        harness_tools:",
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(text)
+        self.assertIn("claude_code", str(ctx.exception))
+
+    def test_missing_harness_bucket_in_catalog_provenance_raises(self) -> None:
+        # Rename only the ``catalog_provenance.<harness>`` occurrence;
+        # leave ``catalogs.<harness>`` intact so the failure is
+        # localized to the provenance lookup.
+        text = _HAPPY_CATALOG.replace(
+            "      claude_code:\n        source_url:",
+            "      fake_harness:\n        source_url:",
+        )
         with self.assertRaises(mod.ParseError) as ctx:
             mod.parse_catalog(text)
         self.assertIn("claude_code", str(ctx.exception))
@@ -391,12 +411,13 @@ class ParseCatalogTests(unittest.TestCase):
             "  allowed_tools:\n"
             "    catalogs:\n"
             "      claude_code:\n"
-            "        provenance:\n"
-            "          source_url: x\n"
-            "          last_checked: \"2026-01-01\"\n"
             "        harness_tools:\n"
             "          - Bash\n"
             "            - Read\n"  # extra indent on second item
+            "    catalog_provenance:\n"
+            "      claude_code:\n"
+            "        source_url: x\n"
+            "        last_checked: \"2026-01-01\"\n"
         )
         with self.assertRaises(mod.ParseError):
             mod.parse_catalog(text)
@@ -501,9 +522,6 @@ class ApplyAdditionsTests(unittest.TestCase):
             "  allowed_tools:\n"
             "    catalogs:\n"
             "      claude_code:\n"
-            "        provenance:\n"
-            "          source_url: https://example.test/tools.md\n"
-            "          last_checked: \"2026-04-26\"\n"
             "        harness_tools:\n"
             "          - Bash\n"
             "          - Read\n"
@@ -511,6 +529,10 @@ class ApplyAdditionsTests(unittest.TestCase):
             "        # NOT harness primitives — typo-detection only.\n"
             "        cli_tools:\n"
             "          - bash\n"
+            "    catalog_provenance:\n"
+            "      claude_code:\n"
+            "        source_url: https://example.test/tools.md\n"
+            "        last_checked: \"2026-04-26\"\n"
         )
         out = mod.apply_additions(
             catalog_with_comment, {"NewTool"}, "2026-05-01"
@@ -534,11 +556,12 @@ class ApplyAdditionsTests(unittest.TestCase):
         eof_catalog = (
             "skill:\n"
             "  allowed_tools:\n"
+            "    catalog_provenance:\n"
+            "      claude_code:\n"
+            "        source_url: https://example.test/tools.md\n"
+            "        last_checked: \"2026-04-26\"\n"
             "    catalogs:\n"
             "      claude_code:\n"
-            "        provenance:\n"
-            "          source_url: https://example.test/tools.md\n"
-            "          last_checked: \"2026-04-26\"\n"
             "        harness_tools:\n"
             "          - Bash\n"
             "          - Read"  # NOTE: no trailing newline
@@ -841,7 +864,7 @@ class MainTests(unittest.TestCase):
                 self.assertIn("HTTP 500", stderr.getvalue())
 
     def test_parse_error_exits_three(self) -> None:
-        broken = _HAPPY_CATALOG.replace("provenance:", "wrong_key:")
+        broken = _HAPPY_CATALOG.replace("catalog_provenance:", "wrong_key:")
         with _CatalogTempFile(broken) as path, _patched_fetch("ignored"):
             stderr = io.StringIO()
             with redirect_stderr(stderr), redirect_stdout(io.StringIO()):

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -417,7 +417,9 @@ class ParseCatalogTests(unittest.TestCase):
         # helper would still read provenance from the (correct)
         # top-level key.  The parser must hard-fail instead, naming
         # both the wrong location and the right one so the maintainer
-        # can move the block in a single edit.
+        # can move the block in a single edit.  This test covers the
+        # duplicate case (both shapes present); the only-misplaced
+        # case is in the test below.
         yaml_text = (
             "skill:\n"
             "  allowed_tools:\n"
@@ -432,6 +434,33 @@ class ParseCatalogTests(unittest.TestCase):
             "      claude_code:\n"
             "        source_url: https://example.test/correct.md\n"
             "        last_checked: \"2026-04-26\"\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.parse_catalog(yaml_text)
+        message = str(ctx.exception)
+        self.assertIn("misplaced", message.lower())
+        self.assertIn("catalogs.claude_code", message)
+        self.assertIn("catalog_provenance.claude_code", message)
+
+    def test_only_misplaced_catalog_provenance_raises_actionable_error(self) -> None:
+        # The more realistic single-mistake migration: the user moved
+        # the block but to the wrong location (under
+        # ``catalogs.<harness>``) and there is no top-level
+        # ``catalog_provenance`` at all.  The misplaced check must run
+        # BEFORE the top-level lookup so the maintainer gets the
+        # actionable wrong-path/right-path guidance instead of the
+        # generic "missing top-level catalog_provenance" message that
+        # they would otherwise hit first.
+        yaml_text = (
+            "skill:\n"
+            "  allowed_tools:\n"
+            "    catalogs:\n"
+            "      claude_code:\n"
+            "        catalog_provenance:\n"
+            "          source_url: https://example.test/wherever.md\n"
+            "          last_checked: \"2026-04-26\"\n"
+            "        harness_tools:\n"
+            "          - Bash\n"
         )
         with self.assertRaises(mod.ParseError) as ctx:
             mod.parse_catalog(yaml_text)

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -370,6 +370,43 @@ class ParseCatalogTests(unittest.TestCase):
         self.assertIn("legacy", message.lower())
         self.assertIn("catalogs.claude_code", message)
 
+    def test_nested_allowed_tools_in_parent_descent_does_not_bind(self) -> None:
+        # The parent descent in ``_find_key_line`` must enforce the
+        # same direct-child semantics as the final lookup, so a
+        # nested ``allowed_tools:`` appearing earlier in the file
+        # (e.g. embedded in a block scalar describing the schema, or
+        # as a key under an unrelated top-level mapping) cannot bind
+        # ahead of the real ``skill.allowed_tools`` block.  This
+        # test constructs a YAML where a deeper-nested
+        # ``allowed_tools:`` carries deliberately wrong values; the
+        # helper must descend through the real ``skill.allowed_tools``
+        # and return the correct top-level provenance.
+        yaml_text = (
+            "decoy:\n"
+            "  description: |\n"
+            "    Embedded YAML excerpt — must not bind:\n"
+            "      allowed_tools:\n"
+            "        catalog_provenance:\n"
+            "          claude_code:\n"
+            "            source_url: https://example.test/WRONG.md\n"
+            "            last_checked: \"1999-01-01\"\n"
+            "skill:\n"
+            "  allowed_tools:\n"
+            "    catalogs:\n"
+            "      claude_code:\n"
+            "        harness_tools:\n"
+            "          - Bash\n"
+            "    catalog_provenance:\n"
+            "      claude_code:\n"
+            "        source_url: https://example.test/correct.md\n"
+            "        last_checked: \"2026-04-26\"\n"
+        )
+        parsed = mod.parse_catalog(yaml_text)
+        self.assertEqual(
+            parsed["source_url"], "https://example.test/correct.md"
+        )
+        self.assertEqual(parsed["last_checked"], "2026-04-26")
+
     def test_nested_catalog_provenance_does_not_bind(self) -> None:
         # The schema move makes ``catalog_provenance`` a sibling
         # top-level key under ``skill.allowed_tools``.  The lookup must

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -6,9 +6,10 @@ Covers:
   * ``extract_tools`` — real upstream fixture, header-row missing,
     no body, no separator row, zero matches, all-caps acronym,
     non-PascalCase row ignored.
-  * ``parse_catalog`` — happy path, missing provenance, missing
-    harness_tools, missing source_url/last_checked, empty list,
-    inconsistent indent, missing harness bucket.
+  * ``parse_catalog`` — happy path, missing catalog_provenance,
+    missing harness_tools, missing source_url/last_checked, empty
+    list, inconsistent indent, missing harness bucket under both
+    ``catalogs`` and ``catalog_provenance``.
   * ``diff`` — set arithmetic.
   * ``apply_additions`` — append at end, alphabetical insert,
     last_checked rewrite, no-op when no additions, idempotent on
@@ -308,7 +309,7 @@ class ParseCatalogTests(unittest.TestCase):
         self.assertRegex(parsed["last_checked"], r"^\d{4}-\d{2}-\d{2}$")
         self.assertIn("Bash", parsed["harness_tools"])
 
-    def test_missing_provenance_raises(self) -> None:
+    def test_missing_catalog_provenance_raises(self) -> None:
         text = _HAPPY_CATALOG.replace(
             "    catalog_provenance:\n"
             "      claude_code:\n"
@@ -318,7 +319,7 @@ class ParseCatalogTests(unittest.TestCase):
         )
         with self.assertRaises(mod.ParseError) as ctx:
             mod.parse_catalog(text)
-        self.assertIn("provenance", str(ctx.exception))
+        self.assertIn("catalog_provenance", str(ctx.exception))
 
     def test_missing_harness_tools_raises(self) -> None:
         text = _HAPPY_CATALOG.replace(
@@ -874,7 +875,7 @@ class MainTests(unittest.TestCase):
                     "--today", "2026-05-01",
                 ])
             self.assertEqual(code, 3)
-            self.assertIn("provenance", stderr.getvalue())
+            self.assertIn("catalog_provenance", stderr.getvalue())
 
     def test_summary_out_writes_file(self) -> None:
         markdown = _load_fixture_markdown()

--- a/.github/workflows/tool-catalog-drift.yaml
+++ b/.github/workflows/tool-catalog-drift.yaml
@@ -4,7 +4,7 @@ name: Tool catalog drift
 # catalog at ``skill-system-foundry/scripts/lib/configuration.yaml``
 # (under ``skill.allowed_tools.catalogs.claude_code``) against the
 # canonical upstream source URL.  The URL itself is read from
-# ``skill.allowed_tools.catalogs.claude_code.provenance.source_url``
+# ``skill.allowed_tools.catalog_provenance.claude_code.source_url``
 # in the catalog YAML — that field is the single source of truth,
 # so updating it is a YAML-only change and does not require editing
 # this workflow.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ A missing or unreadable `SKILL.md` is a FAIL — that includes the file not exis
 
 ### Detecting Tool Catalog Drift
 
-The hand-maintained Claude Code tool catalog at `skill.allowed_tools.catalogs.claude_code` in `skill-system-foundry/scripts/lib/configuration.yaml` drifts as Claude Code adds, renames, or retires tools. A weekly scheduled workflow (`.github/workflows/tool-catalog-drift.yaml`, helper at `.github/scripts/tool-catalog-drift.py`) compares the catalog against the canonical upstream tools reference at the URL recorded in `skill.allowed_tools.catalogs.claude_code.provenance.source_url` and force-pushes a single rolling PR (`chore/tool-catalog-drift`) when drift is detected. Additions are auto-applied; removals are surfaced in the PR body as advisory candidates only — verify each name before deleting.
+The hand-maintained Claude Code tool catalog at `skill.allowed_tools.catalogs.claude_code` in `skill-system-foundry/scripts/lib/configuration.yaml` drifts as Claude Code adds, renames, or retires tools. A weekly scheduled workflow (`.github/workflows/tool-catalog-drift.yaml`, helper at `.github/scripts/tool-catalog-drift.py`) compares the catalog against the canonical upstream tools reference at the URL recorded in `skill.allowed_tools.catalog_provenance.claude_code.source_url` and force-pushes a single rolling PR (`chore/tool-catalog-drift`) when drift is detected. Additions are auto-applied; removals are surfaced in the PR body as advisory candidates only — verify each name before deleting.
 
 To run the sweep locally:
 
@@ -197,7 +197,7 @@ python .github/scripts/tool-catalog-drift.py --dry-run
 python .github/scripts/tool-catalog-drift.py --dry-run --json
 ```
 
-`--dry-run` exits 0 on no drift, 1 on drift detected; default mode mutates `configuration.yaml` and bumps `skill.allowed_tools.catalogs.claude_code.provenance.last_checked` only when there are additions to apply. Removals-only drift leaves the YAML untouched (removals are advisory and never auto-applied); the workflow surfaces them through the PR body via an empty commit.
+`--dry-run` exits 0 on no drift, 1 on drift detected; default mode mutates `configuration.yaml` and bumps `skill.allowed_tools.catalog_provenance.claude_code.last_checked` only when there are additions to apply. Removals-only drift leaves the YAML untouched (removals are advisory and never auto-applied); the workflow surfaces them through the PR body via an empty commit.
 
 The helper tracks the `claude_code` catalog only. The `catalogs.<harness>` YAML structure preserves room for a future second harness, but adding one is not a YAML-only edit — `run` and `parse_catalog` in `.github/scripts/tool-catalog-drift.py` currently process the single default harness, so a future extension requires helper changes (and may need workflow updates for per-harness PR titles or reporting).
 

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -98,23 +98,6 @@ skill:
     # with their own bucket shape when convenient.
     catalogs:
       claude_code:
-        # Provenance for the canonical upstream source of truth.  The
-        # ``source_url`` is the page consumed by the
-        # ``tool-catalog-drift`` workflow at
-        # ``.github/workflows/tool-catalog-drift.yaml`` (helper at
-        # ``.github/scripts/tool-catalog-drift.py``).  ``last_checked``
-        # is rewritten only when the helper auto-applies additions —
-        # the date marks the last actual catalog change, not every
-        # drift-detection run.  Quiet runs and removals-only drift
-        # (advisory only, never applied) both leave the date
-        # untouched, so an unchanged value means no auto-applied
-        # update was recorded; the GitHub Actions run history
-        # provides the "did the sweep run" signal.  These values were
-        # comments before #118 promoted them to structured YAML so
-        # the drift helper has a single source of truth.
-        provenance:
-          source_url: https://code.claude.com/docs/en/tools-reference.md
-          last_checked: "2026-05-01"
         harness_tools:
           - Bash
           - Read
@@ -145,6 +128,24 @@ skill:
           - make
           - cargo
           - go
+    # Provenance for the canonical upstream source of truth.  The
+    # ``source_url`` is the page consumed by the
+    # ``tool-catalog-drift`` workflow at
+    # ``.github/workflows/tool-catalog-drift.yaml`` (helper at
+    # ``.github/scripts/tool-catalog-drift.py``).  ``last_checked``
+    # is rewritten only when the helper auto-applies additions —
+    # the date marks the last actual catalog change, not every
+    # drift-detection run.  Quiet runs and removals-only drift
+    # (advisory only, never applied) both leave the date
+    # untouched, so an unchanged value means no auto-applied
+    # update was recorded; the GitHub Actions run history
+    # provides the "did the sweep run" signal.  These values were
+    # comments before #118 promoted them to structured YAML so
+    # the drift helper has a single source of truth.
+    catalog_provenance:
+      claude_code:
+        source_url: https://code.claude.com/docs/en/tools-reference.md
+        last_checked: "2026-05-01"
     # Fence/script-presence signals for the coherence rule.  Maps a
     # harness-tool name (PascalCase, must appear in
     # ``catalogs.claude_code.harness_tools``) to its body-fence

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -534,6 +534,38 @@ class AllowedToolsCatalogTests(unittest.TestCase):
                     f"{bucket['last_checked']!r} ({exc})"
                 )
 
+    def test_catalogs_and_provenance_harness_sets_match(self) -> None:
+        # Cross-canary check: ``catalogs`` and ``catalog_provenance``
+        # must declare the same set of harness names.  The two earlier
+        # canaries validate each half independently, so a future edit
+        # could add ``catalogs.<harness>`` without the matching
+        # ``catalog_provenance.<harness>`` bucket (or vice versa) and
+        # both per-half canaries would still pass; the mismatch would
+        # only surface at drift-run time when the helper looks up
+        # provenance for the orphaned harness and hard-fails.  This
+        # check pulls that failure forward to the test suite.
+        with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
+            loaded = yaml_parser.parse_yaml_subset(fh.read())
+        catalog_harnesses = set(
+            loaded["skill"]["allowed_tools"]["catalogs"].keys()
+        )
+        provenance_harnesses = set(
+            loaded["skill"]["allowed_tools"]["catalog_provenance"].keys()
+        )
+        self.assertEqual(
+            catalog_harnesses, provenance_harnesses,
+            msg=(
+                f"`catalogs` and `catalog_provenance` must declare the "
+                f"same harness names; catalogs has "
+                f"{sorted(catalog_harnesses)}, catalog_provenance has "
+                f"{sorted(provenance_harnesses)} (missing under "
+                f"catalog_provenance: "
+                f"{sorted(catalog_harnesses - provenance_harnesses)}; "
+                f"missing under catalogs: "
+                f"{sorted(provenance_harnesses - catalog_harnesses)})"
+            ),
+        )
+
 
 class ToolShapeRegexTests(unittest.TestCase):
     """Token-shape regexes used by pattern-fallback recognition."""

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -21,7 +21,7 @@ SCRIPTS_DIR = os.path.abspath(
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
-from lib import constants
+from lib import constants, yaml_parser
 
 
 class ConfigPathTests(unittest.TestCase):
@@ -399,6 +399,37 @@ class AllowedToolsCatalogTests(unittest.TestCase):
 
     def test_known_tools_recognises_pascalcase_bash(self) -> None:
         self.assertIn("Bash", constants.KNOWN_TOOLS)
+
+    def test_catalogs_harness_children_are_tool_lists(self) -> None:
+        # Schema invariant: every direct child of
+        # ``skill.allowed_tools.catalogs.<harness>`` is a list of
+        # tool names.  ``provenance`` lives under a sibling top-level
+        # key ``catalog_provenance.<harness>`` so a future reader
+        # can iterate the catalog bucket's children without
+        # special-casing a non-list child.  This canary fails loudly
+        # if a future YAML edit re-introduces a non-list child or a
+        # ``provenance`` key under any harness bucket.
+        with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
+            loaded = yaml_parser.parse_yaml_subset(fh.read())
+        catalogs = loaded["skill"]["allowed_tools"]["catalogs"]
+        for harness_name, bucket in catalogs.items():
+            for child_key, child_value in bucket.items():
+                self.assertIsInstance(
+                    child_value, list,
+                    msg=(
+                        f"catalogs.{harness_name}.{child_key} must be "
+                        f"a tool-name list under the schema; "
+                        f"got {type(child_value).__name__}"
+                    ),
+                )
+                self.assertNotEqual(
+                    child_key, "provenance",
+                    msg=(
+                        f"`provenance` must not be a child of "
+                        f"catalogs.{harness_name}; use top-level "
+                        "`catalog_provenance.<harness>` instead"
+                    ),
+                )
 
 
 class ToolShapeRegexTests(unittest.TestCase):

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -356,6 +356,17 @@ class DescriptionTriggerExamplePhrasesTests(unittest.TestCase):
 class AllowedToolsCatalogTests(unittest.TestCase):
     """Per-harness catalog constants exposed by ``allowed_tools.catalogs``."""
 
+    # Harnesses currently tracked by the tool-catalog drift helper.
+    # ``configuration.yaml`` documents that future harnesses may use
+    # their own bucket shape under ``catalogs.<harness>``, so the
+    # strict schema canaries below scope to this set rather than
+    # iterating every harness in the loaded YAML.  Today only
+    # ``claude_code`` is drift-managed (the helper at
+    # ``.github/scripts/tool-catalog-drift.py`` hardcodes the harness
+    # rather than iterating ``HARNESS_NAMES``); add new entries here
+    # in lockstep with teaching the drift helper a new harness.
+    _DRIFT_MANAGED_HARNESSES = frozenset({"claude_code"})
+
     def test_harness_tools_includes_canonical_pascalcase_set(self) -> None:
         # Names listed in the Claude Code skills documentation.
         for tool in ("Bash", "Read", "Edit", "Write", "Grep", "Glob",
@@ -402,22 +413,34 @@ class AllowedToolsCatalogTests(unittest.TestCase):
         self.assertIn("Bash", constants.KNOWN_TOOLS)
 
     def test_catalogs_harness_children_are_tool_lists(self) -> None:
-        # Schema invariant: every direct child of
-        # ``skill.allowed_tools.catalogs.<harness>`` is a list of
-        # tool names.  ``provenance`` lives under a sibling top-level
-        # key ``catalog_provenance.<harness>`` so a future reader
-        # can iterate the catalog bucket's children without
-        # special-casing a non-list child.  This canary fails loudly
-        # if a future YAML edit re-introduces a ``provenance`` key
-        # under any harness bucket or any other non-list child.
-        # The provenance-specific check runs first so the most-likely
+        # Schema invariant for drift-managed harnesses: every direct
+        # child of ``skill.allowed_tools.catalogs.<harness>`` is a
+        # list of tool names.  ``provenance`` lives under a sibling
+        # top-level key ``catalog_provenance.<harness>`` so a reader
+        # iterating the catalog bucket does not need to special-case
+        # a non-list child.  This canary scopes to
+        # ``_DRIFT_MANAGED_HARNESSES`` so a future non-drift-managed
+        # harness with its own bucket shape (allowed by the
+        # ``configuration.yaml`` comment under ``catalogs:``) does
+        # not trip the test.  The canary fails loudly if a YAML edit
+        # re-introduces a ``provenance`` key under any drift-managed
+        # harness bucket or any other non-list child.  The
+        # provenance-specific check runs first so the most-likely
         # regression (re-introducing ``provenance``) produces the
         # most-informative error message; an unrelated non-list
         # field trips the second check.
         with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
             loaded = yaml_parser.parse_yaml_subset(fh.read())
         catalogs = loaded["skill"]["allowed_tools"]["catalogs"]
-        for harness_name, bucket in catalogs.items():
+        for harness_name in self._DRIFT_MANAGED_HARNESSES:
+            self.assertIn(
+                harness_name, catalogs,
+                msg=(
+                    f"drift-managed harness {harness_name!r} must "
+                    "have a `catalogs` bucket"
+                ),
+            )
+            bucket = catalogs[harness_name]
             # Defensive: a future YAML edit that turns the harness
             # bucket itself into a scalar or list would otherwise
             # raise ``AttributeError`` at ``bucket.items()`` below
@@ -474,20 +497,30 @@ class AllowedToolsCatalogTests(unittest.TestCase):
     def test_catalog_provenance_harness_shape_is_uniform(self) -> None:
         # Symmetric canary to ``test_catalogs_harness_children_are_tool_lists``:
         # that one protects the catalog half of the schema, this one
-        # protects the provenance half.  Schema invariant: every direct
-        # child of ``skill.allowed_tools.catalog_provenance`` is a
-        # mapping with exactly ``source_url`` and ``last_checked``
-        # non-empty scalar children.  Without this canary, a typo or
-        # extra key under a future second harness would only be caught
-        # at drift-run time (the helper iterates harness names but
-        # only ``claude_code`` is exercised in unit tests today).
+        # protects the provenance half.  Schema invariant for
+        # drift-managed harnesses: every direct child of
+        # ``skill.allowed_tools.catalog_provenance`` is a mapping with
+        # exactly ``source_url`` and ``last_checked`` non-empty scalar
+        # children, with ``last_checked`` in the canonical
+        # ``YYYY-MM-DD`` form.  Without this canary, a typo, extra
+        # key, or wrong date format under a drift-managed harness
+        # bucket would only be caught at drift-run time when the
+        # helper hardcodes the harness lookup and parses the bucket.
         with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
             loaded = yaml_parser.parse_yaml_subset(fh.read())
         catalog_provenance = (
             loaded["skill"]["allowed_tools"]["catalog_provenance"]
         )
         expected_keys = {"source_url", "last_checked"}
-        for harness_name, bucket in catalog_provenance.items():
+        for harness_name in self._DRIFT_MANAGED_HARNESSES:
+            self.assertIn(
+                harness_name, catalog_provenance,
+                msg=(
+                    f"drift-managed harness {harness_name!r} must "
+                    "have a `catalog_provenance` bucket"
+                ),
+            )
+            bucket = catalog_provenance[harness_name]
             self.assertIsInstance(
                 bucket, dict,
                 msg=(
@@ -547,35 +580,39 @@ class AllowedToolsCatalogTests(unittest.TestCase):
                     f"{bucket['last_checked']!r} ({exc})"
                 )
 
-    def test_catalogs_and_provenance_harness_sets_match(self) -> None:
-        # Cross-canary check: ``catalogs`` and ``catalog_provenance``
-        # must declare the same set of harness names.  The two earlier
-        # canaries validate each half independently, so a future edit
-        # could add ``catalogs.<harness>`` without the matching
-        # ``catalog_provenance.<harness>`` bucket (or vice versa) and
-        # both per-half canaries would still pass; the mismatch would
-        # only surface at drift-run time when the helper looks up
-        # provenance for the orphaned harness and hard-fails.  This
-        # check pulls that failure forward to the test suite.
+    def test_drift_managed_harnesses_present_in_both_maps(self) -> None:
+        # Cross-canary check: every drift-managed harness must have a
+        # bucket under both ``catalogs`` and ``catalog_provenance``.
+        # The two earlier canaries validate each half independently,
+        # so a future edit could land a new drift-managed harness in
+        # one map without the matching bucket in the other and both
+        # per-half canaries would still pass; the mismatch would only
+        # surface at drift-run time when the helper hard-fails on the
+        # missing lookup.  Scope is the same drift-managed set as the
+        # per-half canaries — non-drift-managed harnesses (allowed by
+        # the ``configuration.yaml`` comment under ``catalogs:`` to
+        # use their own bucket shape) are not required to appear in
+        # both maps.
         with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
             loaded = yaml_parser.parse_yaml_subset(fh.read())
-        catalog_harnesses = set(
+        catalog_keys = set(
             loaded["skill"]["allowed_tools"]["catalogs"].keys()
         )
-        provenance_harnesses = set(
+        provenance_keys = set(
             loaded["skill"]["allowed_tools"]["catalog_provenance"].keys()
         )
-        self.assertEqual(
-            catalog_harnesses, provenance_harnesses,
+        missing_in_catalogs = self._DRIFT_MANAGED_HARNESSES - catalog_keys
+        missing_in_provenance = (
+            self._DRIFT_MANAGED_HARNESSES - provenance_keys
+        )
+        self.assertFalse(
+            missing_in_catalogs or missing_in_provenance,
             msg=(
-                f"`catalogs` and `catalog_provenance` must declare the "
-                f"same harness names; catalogs has "
-                f"{sorted(catalog_harnesses)}, catalog_provenance has "
-                f"{sorted(provenance_harnesses)} (missing under "
-                f"catalog_provenance: "
-                f"{sorted(catalog_harnesses - provenance_harnesses)}; "
-                f"missing under catalogs: "
-                f"{sorted(provenance_harnesses - catalog_harnesses)})"
+                f"every drift-managed harness must appear in both "
+                f"`catalogs` and `catalog_provenance`; missing from "
+                f"catalogs: {sorted(missing_in_catalogs)}; missing "
+                f"from catalog_provenance: "
+                f"{sorted(missing_in_provenance)}"
             ),
         )
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -9,6 +9,7 @@ re-importing ``lib.constants`` against a synthetic config file with
 the section removed.
 """
 
+import datetime
 import importlib
 import os
 import sys
@@ -504,6 +505,19 @@ class AllowedToolsCatalogTests(unittest.TestCase):
                         f"catalog_provenance.{harness_name}.{key} "
                         "must be non-empty"
                     ),
+                )
+            # ``last_checked`` must parse as ISO-8601 ``YYYY-MM-DD`` —
+            # the same contract ``parse_catalog`` enforces at runtime.
+            # Without this pin a future harness bucket could ship
+            # ``last_checked: yesterday`` and pass the canary even
+            # though the drift helper would reject it.
+            try:
+                datetime.date.fromisoformat(bucket["last_checked"])
+            except ValueError as exc:
+                self.fail(
+                    f"catalog_provenance.{harness_name}.last_checked "
+                    f"must be ISO-8601 YYYY-MM-DD; got "
+                    f"{bucket['last_checked']!r} ({exc})"
                 )
 
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -407,27 +407,31 @@ class AllowedToolsCatalogTests(unittest.TestCase):
         # key ``catalog_provenance.<harness>`` so a future reader
         # can iterate the catalog bucket's children without
         # special-casing a non-list child.  This canary fails loudly
-        # if a future YAML edit re-introduces a non-list child or a
-        # ``provenance`` key under any harness bucket.
+        # if a future YAML edit re-introduces a ``provenance`` key
+        # under any harness bucket or any other non-list child.
+        # The provenance-specific check runs first so the most-likely
+        # regression (re-introducing ``provenance``) produces the
+        # most-informative error message; an unrelated non-list
+        # field trips the second check.
         with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
             loaded = yaml_parser.parse_yaml_subset(fh.read())
         catalogs = loaded["skill"]["allowed_tools"]["catalogs"]
         for harness_name, bucket in catalogs.items():
             for child_key, child_value in bucket.items():
-                self.assertIsInstance(
-                    child_value, list,
-                    msg=(
-                        f"catalogs.{harness_name}.{child_key} must be "
-                        f"a tool-name list under the schema; "
-                        f"got {type(child_value).__name__}"
-                    ),
-                )
                 self.assertNotEqual(
                     child_key, "provenance",
                     msg=(
                         f"`provenance` must not be a child of "
                         f"catalogs.{harness_name}; use top-level "
                         "`catalog_provenance.<harness>` instead"
+                    ),
+                )
+                self.assertIsInstance(
+                    child_value, list,
+                    msg=(
+                        f"catalogs.{harness_name}.{child_key} must be "
+                        f"a tool-name list under the schema; "
+                        f"got {type(child_value).__name__}"
                     ),
                 )
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -417,7 +417,22 @@ class AllowedToolsCatalogTests(unittest.TestCase):
                 f"`skill.allowed_tools.{key}`"
             ),
         )
-        return allowed_tools[key]
+        section = allowed_tools[key]
+        # Validate the returned section is itself a mapping — the two
+        # current callers (``catalogs`` and ``catalog_provenance``)
+        # both iterate ``.items()`` / ``.keys()`` on the result, so a
+        # scalar or list at this level would otherwise produce a raw
+        # ``TypeError`` / ``AttributeError`` in the canary instead of
+        # the targeted assertion message this helper is meant to
+        # provide.
+        self.assertIsInstance(
+            section, dict,
+            msg=(
+                f"configuration.yaml `skill.allowed_tools.{key}` "
+                f"must be a mapping; got {type(section).__name__}"
+            ),
+        )
+        return section
 
     def test_harness_tools_includes_canonical_pascalcase_set(self) -> None:
         # Names listed in the Claude Code skills documentation.

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -418,6 +418,19 @@ class AllowedToolsCatalogTests(unittest.TestCase):
             loaded = yaml_parser.parse_yaml_subset(fh.read())
         catalogs = loaded["skill"]["allowed_tools"]["catalogs"]
         for harness_name, bucket in catalogs.items():
+            # Defensive: a future YAML edit that turns the harness
+            # bucket itself into a scalar or list would otherwise
+            # raise ``AttributeError`` at ``bucket.items()`` below
+            # and produce an opaque traceback instead of an
+            # actionable assertion failure.  Mirrors the
+            # provenance canary's upfront ``dict`` check.
+            self.assertIsInstance(
+                bucket, dict,
+                msg=(
+                    f"catalogs.{harness_name} must be a mapping; "
+                    f"got {type(bucket).__name__}"
+                ),
+            )
             for child_key, child_value in bucket.items():
                 self.assertNotEqual(
                     child_key, "provenance",

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -510,13 +510,27 @@ class AllowedToolsCatalogTests(unittest.TestCase):
             # the same contract ``parse_catalog`` enforces at runtime.
             # Without this pin a future harness bucket could ship
             # ``last_checked: yesterday`` and pass the canary even
-            # though the drift helper would reject it.
+            # though the drift helper would reject it.  The explicit
+            # shape pre-check matters because
+            # ``datetime.date.fromisoformat`` alone accepts the compact
+            # ISO form (e.g. ``20260501``) since Python 3.11; the
+            # helper documents and writes only the extended form, so
+            # the canary pins that form here too.
+            self.assertRegex(
+                bucket["last_checked"], r"^\d{4}-\d{2}-\d{2}$",
+                msg=(
+                    f"catalog_provenance.{harness_name}.last_checked "
+                    f"must be ISO-8601 YYYY-MM-DD (extended form with "
+                    f"hyphen separators); got "
+                    f"{bucket['last_checked']!r}"
+                ),
+            )
             try:
                 datetime.date.fromisoformat(bucket["last_checked"])
             except ValueError as exc:
                 self.fail(
                     f"catalog_provenance.{harness_name}.last_checked "
-                    f"must be ISO-8601 YYYY-MM-DD; got "
+                    f"must be a valid date; got "
                     f"{bucket['last_checked']!r} ({exc})"
                 )
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -434,6 +434,28 @@ class AllowedToolsCatalogTests(unittest.TestCase):
                         f"got {type(child_value).__name__}"
                     ),
                 )
+                # Each item must be a non-empty string.  Without this
+                # check a malformed edit (a stray ``-`` producing a
+                # ``None`` item, an empty quoted string, or a non-string
+                # scalar like a bare integer) would still satisfy the
+                # is-a-list guard above and only fail later in
+                # downstream consumers.
+                for item_index, item in enumerate(child_value):
+                    self.assertIsInstance(
+                        item, str,
+                        msg=(
+                            f"catalogs.{harness_name}.{child_key}"
+                            f"[{item_index}] must be a string; "
+                            f"got {type(item).__name__}"
+                        ),
+                    )
+                    self.assertNotEqual(
+                        item.strip(), "",
+                        msg=(
+                            f"catalogs.{harness_name}.{child_key}"
+                            f"[{item_index}] must be non-empty"
+                        ),
+                    )
 
     def test_catalog_provenance_harness_shape_is_uniform(self) -> None:
         # Symmetric canary to ``test_catalogs_harness_children_are_tool_lists``:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -367,6 +367,35 @@ class AllowedToolsCatalogTests(unittest.TestCase):
     # in lockstep with teaching the drift helper a new harness.
     _DRIFT_MANAGED_HARNESSES = frozenset({"claude_code"})
 
+    def _load_allowed_tools_section(self, key: str) -> dict:
+        """Load ``configuration.yaml`` and return ``allowed_tools.<key>``.
+
+        Asserts presence of every level above ``key`` so a missing or
+        misspelled top-level mapping produces a targeted assertion
+        message instead of a raw ``KeyError`` traceback.  Used by the
+        schema canaries so future regressions stay actionable.
+        """
+        with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
+            loaded = yaml_parser.parse_yaml_subset(fh.read())
+        self.assertIn(
+            "skill", loaded,
+            msg="configuration.yaml must define top-level `skill`",
+        )
+        skill = loaded["skill"]
+        self.assertIn(
+            "allowed_tools", skill,
+            msg="configuration.yaml must define `skill.allowed_tools`",
+        )
+        allowed_tools = skill["allowed_tools"]
+        self.assertIn(
+            key, allowed_tools,
+            msg=(
+                f"configuration.yaml must define "
+                f"`skill.allowed_tools.{key}`"
+            ),
+        )
+        return allowed_tools[key]
+
     def test_harness_tools_includes_canonical_pascalcase_set(self) -> None:
         # Names listed in the Claude Code skills documentation.
         for tool in ("Bash", "Read", "Edit", "Write", "Grep", "Glob",
@@ -429,9 +458,7 @@ class AllowedToolsCatalogTests(unittest.TestCase):
         # regression (re-introducing ``provenance``) produces the
         # most-informative error message; an unrelated non-list
         # field trips the second check.
-        with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
-            loaded = yaml_parser.parse_yaml_subset(fh.read())
-        catalogs = loaded["skill"]["allowed_tools"]["catalogs"]
+        catalogs = self._load_allowed_tools_section("catalogs")
         for harness_name in self._DRIFT_MANAGED_HARNESSES:
             self.assertIn(
                 harness_name, catalogs,
@@ -506,10 +533,8 @@ class AllowedToolsCatalogTests(unittest.TestCase):
         # key, or wrong date format under a drift-managed harness
         # bucket would only be caught at drift-run time when the
         # helper hardcodes the harness lookup and parses the bucket.
-        with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
-            loaded = yaml_parser.parse_yaml_subset(fh.read())
-        catalog_provenance = (
-            loaded["skill"]["allowed_tools"]["catalog_provenance"]
+        catalog_provenance = self._load_allowed_tools_section(
+            "catalog_provenance"
         )
         expected_keys = {"source_url", "last_checked"}
         for harness_name in self._DRIFT_MANAGED_HARNESSES:
@@ -593,13 +618,11 @@ class AllowedToolsCatalogTests(unittest.TestCase):
         # the ``configuration.yaml`` comment under ``catalogs:`` to
         # use their own bucket shape) are not required to appear in
         # both maps.
-        with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
-            loaded = yaml_parser.parse_yaml_subset(fh.read())
         catalog_keys = set(
-            loaded["skill"]["allowed_tools"]["catalogs"].keys()
+            self._load_allowed_tools_section("catalogs").keys()
         )
         provenance_keys = set(
-            loaded["skill"]["allowed_tools"]["catalog_provenance"].keys()
+            self._load_allowed_tools_section("catalog_provenance").keys()
         )
         missing_in_catalogs = self._DRIFT_MANAGED_HARNESSES - catalog_keys
         missing_in_provenance = (

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -370,23 +370,46 @@ class AllowedToolsCatalogTests(unittest.TestCase):
     def _load_allowed_tools_section(self, key: str) -> dict:
         """Load ``configuration.yaml`` and return ``allowed_tools.<key>``.
 
-        Asserts presence of every level above ``key`` so a missing or
-        misspelled top-level mapping produces a targeted assertion
-        message instead of a raw ``KeyError`` traceback.  Used by the
-        schema canaries so future regressions stay actionable.
+        Asserts each level (``skill``, ``allowed_tools``) is a mapping
+        before subscripting and asserts presence of every level above
+        ``key`` so a missing, misspelled, or wrong-typed top-level
+        node produces a targeted assertion message instead of a raw
+        ``KeyError`` or ``TypeError`` traceback.  Used by the schema
+        canaries so future regressions stay actionable.
         """
         with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
             loaded = yaml_parser.parse_yaml_subset(fh.read())
+        self.assertIsInstance(
+            loaded, dict,
+            msg=(
+                "configuration.yaml must parse to a top-level mapping; "
+                f"got {type(loaded).__name__}"
+            ),
+        )
         self.assertIn(
             "skill", loaded,
             msg="configuration.yaml must define top-level `skill`",
         )
         skill = loaded["skill"]
+        self.assertIsInstance(
+            skill, dict,
+            msg=(
+                "configuration.yaml `skill` must be a mapping; "
+                f"got {type(skill).__name__}"
+            ),
+        )
         self.assertIn(
             "allowed_tools", skill,
             msg="configuration.yaml must define `skill.allowed_tools`",
         )
         allowed_tools = skill["allowed_tools"]
+        self.assertIsInstance(
+            allowed_tools, dict,
+            msg=(
+                "configuration.yaml `skill.allowed_tools` must be a "
+                f"mapping; got {type(allowed_tools).__name__}"
+            ),
+        )
         self.assertIn(
             key, allowed_tools,
             msg=(

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -356,16 +356,16 @@ class DescriptionTriggerExamplePhrasesTests(unittest.TestCase):
 class AllowedToolsCatalogTests(unittest.TestCase):
     """Per-harness catalog constants exposed by ``allowed_tools.catalogs``."""
 
-    # Harnesses currently tracked by the tool-catalog drift helper.
-    # ``configuration.yaml`` documents that future harnesses may use
-    # their own bucket shape under ``catalogs.<harness>``, so the
-    # strict schema canaries below scope to this set rather than
-    # iterating every harness in the loaded YAML.  Today only
-    # ``claude_code`` is drift-managed (the helper at
-    # ``.github/scripts/tool-catalog-drift.py`` hardcodes the harness
-    # rather than iterating ``HARNESS_NAMES``); add new entries here
-    # in lockstep with teaching the drift helper a new harness.
-    _DRIFT_MANAGED_HARNESSES = frozenset({"claude_code"})
+    # The schema canaries below derive their drift-managed scope from
+    # ``catalog_provenance.keys()`` in the live YAML rather than from a
+    # hardcoded constant.  A harness's presence under
+    # ``catalog_provenance`` is the natural declaration that it is
+    # drift-managed (the drift helper reads provenance to operate);
+    # ``configuration.yaml`` independently documents that future
+    # harnesses may use their own bucket shape under
+    # ``catalogs.<harness>``.  Deriving from YAML means adding a new
+    # ``catalog_provenance`` entry automatically extends canary
+    # coverage, without coupling YAML edits to a separate constant.
 
     def _load_allowed_tools_section(self, key: str) -> dict:
         """Load ``configuration.yaml`` and return ``allowed_tools.<key>``.
@@ -485,24 +485,36 @@ class AllowedToolsCatalogTests(unittest.TestCase):
         # list of tool names.  ``provenance`` lives under a sibling
         # top-level key ``catalog_provenance.<harness>`` so a reader
         # iterating the catalog bucket does not need to special-case
-        # a non-list child.  This canary scopes to
-        # ``_DRIFT_MANAGED_HARNESSES`` so a future non-drift-managed
-        # harness with its own bucket shape (allowed by the
-        # ``configuration.yaml`` comment under ``catalogs:``) does
-        # not trip the test.  The canary fails loudly if a YAML edit
-        # re-introduces a ``provenance`` key under any drift-managed
-        # harness bucket or any other non-list child.  The
-        # provenance-specific check runs first so the most-likely
-        # regression (re-introducing ``provenance``) produces the
-        # most-informative error message; an unrelated non-list
-        # field trips the second check.
+        # a non-list child.  Drift-managed scope is derived from the
+        # set of harnesses declared under ``catalog_provenance`` in
+        # the live YAML — non-drift-managed harnesses (allowed by the
+        # ``configuration.yaml`` comment under ``catalogs:`` to use
+        # their own bucket shape) are not validated here.  The canary
+        # fails loudly if a YAML edit re-introduces a ``provenance``
+        # key under any drift-managed harness bucket or any other
+        # non-list child.  The provenance-specific check runs first
+        # so the most-likely regression (re-introducing
+        # ``provenance``) produces the most-informative error
+        # message; an unrelated non-list field trips the second check.
         catalogs = self._load_allowed_tools_section("catalogs")
-        for harness_name in self._DRIFT_MANAGED_HARNESSES:
+        catalog_provenance = self._load_allowed_tools_section(
+            "catalog_provenance"
+        )
+        self.assertNotEqual(
+            catalog_provenance, {},
+            msg=(
+                "configuration.yaml `catalog_provenance` must declare "
+                "at least one harness — otherwise this canary "
+                "silently validates nothing"
+            ),
+        )
+        for harness_name in catalog_provenance:
             self.assertIn(
                 harness_name, catalogs,
                 msg=(
-                    f"drift-managed harness {harness_name!r} must "
-                    "have a `catalogs` bucket"
+                    f"drift-managed harness {harness_name!r} (declared "
+                    "under `catalog_provenance`) must have a matching "
+                    "`catalogs` bucket"
                 ),
             )
             bucket = catalogs[harness_name]
@@ -562,28 +574,30 @@ class AllowedToolsCatalogTests(unittest.TestCase):
     def test_catalog_provenance_harness_shape_is_uniform(self) -> None:
         # Symmetric canary to ``test_catalogs_harness_children_are_tool_lists``:
         # that one protects the catalog half of the schema, this one
-        # protects the provenance half.  Schema invariant for
-        # drift-managed harnesses: every direct child of
-        # ``skill.allowed_tools.catalog_provenance`` is a mapping with
-        # exactly ``source_url`` and ``last_checked`` non-empty scalar
-        # children, with ``last_checked`` in the canonical
-        # ``YYYY-MM-DD`` form.  Without this canary, a typo, extra
-        # key, or wrong date format under a drift-managed harness
-        # bucket would only be caught at drift-run time when the
-        # helper hardcodes the harness lookup and parses the bucket.
+        # protects the provenance half.  Schema invariant: every
+        # direct child of ``skill.allowed_tools.catalog_provenance``
+        # is a mapping with exactly ``source_url`` and ``last_checked``
+        # non-empty scalar children, with ``last_checked`` in the
+        # canonical ``YYYY-MM-DD`` form.  Iterates every harness
+        # present under ``catalog_provenance`` — that mapping is the
+        # natural source of truth for which harnesses are
+        # drift-managed.  Without this canary, a typo, extra key, or
+        # wrong date format under a harness bucket would only be
+        # caught at drift-run time when the helper looks the bucket
+        # up and parses it.
         catalog_provenance = self._load_allowed_tools_section(
             "catalog_provenance"
         )
+        self.assertNotEqual(
+            catalog_provenance, {},
+            msg=(
+                "configuration.yaml `catalog_provenance` must declare "
+                "at least one harness — otherwise this canary "
+                "silently validates nothing"
+            ),
+        )
         expected_keys = {"source_url", "last_checked"}
-        for harness_name in self._DRIFT_MANAGED_HARNESSES:
-            self.assertIn(
-                harness_name, catalog_provenance,
-                msg=(
-                    f"drift-managed harness {harness_name!r} must "
-                    "have a `catalog_provenance` bucket"
-                ),
-            )
-            bucket = catalog_provenance[harness_name]
+        for harness_name, bucket in catalog_provenance.items():
             self.assertIsInstance(
                 bucket, dict,
                 msg=(
@@ -643,65 +657,33 @@ class AllowedToolsCatalogTests(unittest.TestCase):
                     f"{bucket['last_checked']!r} ({exc})"
                 )
 
-    def test_drift_managed_set_matches_catalog_provenance_keys(self) -> None:
-        # ``_DRIFT_MANAGED_HARNESSES`` is a duplicated source of truth
-        # next to the live YAML.  Without this guard, a future edit
-        # that adds a harness bucket to ``catalog_provenance`` (the
-        # natural signal that a harness is drift-managed) without
-        # also adding it to the constant would silently lose strict
-        # canary coverage for that harness, and the per-half canaries
-        # below would still pass.  Asserting equality here surfaces
-        # the drift as a single targeted failure that names the
-        # missing-on-each-side delta, so adding a new harness has to
-        # touch both places (or neither).
-        provenance_keys = frozenset(
-            self._load_allowed_tools_section("catalog_provenance").keys()
-        )
-        self.assertEqual(
-            self._DRIFT_MANAGED_HARNESSES, provenance_keys,
-            msg=(
-                "_DRIFT_MANAGED_HARNESSES must match the set of harness "
-                "names declared under `skill.allowed_tools."
-                "catalog_provenance` in configuration.yaml; constant "
-                f"has {sorted(self._DRIFT_MANAGED_HARNESSES)}, YAML has "
-                f"{sorted(provenance_keys)} (missing from constant: "
-                f"{sorted(provenance_keys - self._DRIFT_MANAGED_HARNESSES)}; "
-                f"missing from YAML: "
-                f"{sorted(self._DRIFT_MANAGED_HARNESSES - provenance_keys)})"
-            ),
-        )
-
-    def test_drift_managed_harnesses_present_in_both_maps(self) -> None:
-        # Cross-canary check: every drift-managed harness must have a
-        # bucket under both ``catalogs`` and ``catalog_provenance``.
-        # The two earlier canaries validate each half independently,
-        # so a future edit could land a new drift-managed harness in
-        # one map without the matching bucket in the other and both
-        # per-half canaries would still pass; the mismatch would only
-        # surface at drift-run time when the helper hard-fails on the
-        # missing lookup.  Scope is the same drift-managed set as the
-        # per-half canaries — non-drift-managed harnesses (allowed by
-        # the ``configuration.yaml`` comment under ``catalogs:`` to
-        # use their own bucket shape) are not required to appear in
-        # both maps.
+    def test_provenance_harnesses_have_matching_catalogs_entry(self) -> None:
+        # Cross-canary check: every harness declared under
+        # ``catalog_provenance`` must have a matching ``catalogs``
+        # bucket.  ``catalog_provenance`` is the source of truth for
+        # which harnesses are drift-managed, and the drift helper
+        # needs the catalogs bucket to read tool names — so a
+        # ``catalog_provenance`` entry without the matching catalogs
+        # bucket would only fail at drift-run time when the helper
+        # tries the lookup and hard-fails.  The reverse direction
+        # (a catalogs bucket without provenance) is intentionally
+        # NOT enforced — ``configuration.yaml`` documents that
+        # future non-drift-managed harnesses may use their own bucket
+        # shape under ``catalogs.<harness>`` without provenance
+        # metadata.
         catalog_keys = set(
             self._load_allowed_tools_section("catalogs").keys()
         )
         provenance_keys = set(
             self._load_allowed_tools_section("catalog_provenance").keys()
         )
-        missing_in_catalogs = self._DRIFT_MANAGED_HARNESSES - catalog_keys
-        missing_in_provenance = (
-            self._DRIFT_MANAGED_HARNESSES - provenance_keys
-        )
+        missing_in_catalogs = provenance_keys - catalog_keys
         self.assertFalse(
-            missing_in_catalogs or missing_in_provenance,
+            missing_in_catalogs,
             msg=(
-                f"every drift-managed harness must appear in both "
-                f"`catalogs` and `catalog_provenance`; missing from "
-                f"catalogs: {sorted(missing_in_catalogs)}; missing "
-                f"from catalog_provenance: "
-                f"{sorted(missing_in_provenance)}"
+                f"every harness declared under `catalog_provenance` "
+                f"must have a matching `catalogs` bucket; missing "
+                f"from catalogs: {sorted(missing_in_catalogs)}"
             ),
         )
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -605,6 +605,34 @@ class AllowedToolsCatalogTests(unittest.TestCase):
                     f"{bucket['last_checked']!r} ({exc})"
                 )
 
+    def test_drift_managed_set_matches_catalog_provenance_keys(self) -> None:
+        # ``_DRIFT_MANAGED_HARNESSES`` is a duplicated source of truth
+        # next to the live YAML.  Without this guard, a future edit
+        # that adds a harness bucket to ``catalog_provenance`` (the
+        # natural signal that a harness is drift-managed) without
+        # also adding it to the constant would silently lose strict
+        # canary coverage for that harness, and the per-half canaries
+        # below would still pass.  Asserting equality here surfaces
+        # the drift as a single targeted failure that names the
+        # missing-on-each-side delta, so adding a new harness has to
+        # touch both places (or neither).
+        provenance_keys = frozenset(
+            self._load_allowed_tools_section("catalog_provenance").keys()
+        )
+        self.assertEqual(
+            self._DRIFT_MANAGED_HARNESSES, provenance_keys,
+            msg=(
+                "_DRIFT_MANAGED_HARNESSES must match the set of harness "
+                "names declared under `skill.allowed_tools."
+                "catalog_provenance` in configuration.yaml; constant "
+                f"has {sorted(self._DRIFT_MANAGED_HARNESSES)}, YAML has "
+                f"{sorted(provenance_keys)} (missing from constant: "
+                f"{sorted(provenance_keys - self._DRIFT_MANAGED_HARNESSES)}; "
+                f"missing from YAML: "
+                f"{sorted(self._DRIFT_MANAGED_HARNESSES - provenance_keys)})"
+            ),
+        )
+
     def test_drift_managed_harnesses_present_in_both_maps(self) -> None:
         # Cross-canary check: every drift-managed harness must have a
         # bucket under both ``catalogs`` and ``catalog_provenance``.

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -435,6 +435,55 @@ class AllowedToolsCatalogTests(unittest.TestCase):
                     ),
                 )
 
+    def test_catalog_provenance_harness_shape_is_uniform(self) -> None:
+        # Symmetric canary to ``test_catalogs_harness_children_are_tool_lists``:
+        # that one protects the catalog half of the schema, this one
+        # protects the provenance half.  Schema invariant: every direct
+        # child of ``skill.allowed_tools.catalog_provenance`` is a
+        # mapping with exactly ``source_url`` and ``last_checked``
+        # non-empty scalar children.  Without this canary, a typo or
+        # extra key under a future second harness would only be caught
+        # at drift-run time (the helper iterates harness names but
+        # only ``claude_code`` is exercised in unit tests today).
+        with open(constants.CONFIG_PATH, "r", encoding="utf-8") as fh:
+            loaded = yaml_parser.parse_yaml_subset(fh.read())
+        catalog_provenance = (
+            loaded["skill"]["allowed_tools"]["catalog_provenance"]
+        )
+        expected_keys = {"source_url", "last_checked"}
+        for harness_name, bucket in catalog_provenance.items():
+            self.assertIsInstance(
+                bucket, dict,
+                msg=(
+                    f"catalog_provenance.{harness_name} must be a "
+                    f"mapping; got {type(bucket).__name__}"
+                ),
+            )
+            self.assertEqual(
+                set(bucket.keys()), expected_keys,
+                msg=(
+                    f"catalog_provenance.{harness_name} must have "
+                    f"exactly {sorted(expected_keys)} as children; "
+                    f"got {sorted(bucket.keys())}"
+                ),
+            )
+            for key, value in bucket.items():
+                self.assertIsInstance(
+                    value, str,
+                    msg=(
+                        f"catalog_provenance.{harness_name}.{key} "
+                        f"must be a scalar string; got "
+                        f"{type(value).__name__}"
+                    ),
+                )
+                self.assertNotEqual(
+                    value.strip(), "",
+                    msg=(
+                        f"catalog_provenance.{harness_name}.{key} "
+                        "must be non-empty"
+                    ),
+                )
+
 
 class ToolShapeRegexTests(unittest.TestCase):
     """Token-shape regexes used by pattern-fallback recognition."""


### PR DESCRIPTION
## Summary

Settles the open design question in #129 (finding 13): the `provenance` mapping moves out of `skill.allowed_tools.catalogs.<harness>` and into a sibling top-level key `skill.allowed_tools.catalog_provenance.<harness>`. Every direct child of `catalogs.<harness>` is now uniformly a list of tool names, so a future reader can iterate the catalog bucket without special-casing a non-list child.

## Context

This branch is scoped to the structural schema move alone. Inline documentation is treated in three categories:

- **Docstrings of new functions, or rewritten docstrings on functions whose behavior this PR changes** — updated as part of the structural change. Reverting them would create the same contract-vs-code mismatch the prose deferral is designed to avoid (`_find_direct_child_at_or_after` is new; `_find_key_line` and `_find_child_key` had their direct-child semantics tightened).
- **Stale path references that this schema move directly invalidates** — updated as a one-time exception so operator-facing guidance does not point at a key that no longer exists. Covers `parse_catalog`'s Returns/Raises docs, the helper module docstring header, the workflow header comment, and the AGENTS.md "Detecting Tool Catalog Drift" path references. Closes #129 finding 20a; partially closes findings 17, 20, 22.
- **Other prose drift the schema move did not introduce** (behavior-claim drift, the `configuration.yaml` provenance comments, AGENTS.md's "adding a harness is YAML-only" claim, helper docstrings on functions this PR did not touch) — kept verbatim. Still tracked in #129's prose sweep (findings 17 remainder, 18, 19, 20 remainder, 21, 23–29).

## Changes

- Move the provenance block in `configuration.yaml` to a sibling top-level key.
- Rewrite `parse_catalog` to look up `catalogs.<harness>` first (so legacy `provenance:` and misplaced `catalog_provenance:` migration mistakes both produce actionable wrong-path/right-path errors), then the top-level `catalog_provenance.<harness>` for `source_url` / `last_checked`. Every `ParseError` message names the new key path.
- Tighten the YAML key lookup helpers to direct-child semantics (`_find_direct_child_at_or_after`) so a same-named key nested deeper in the subtree — including text that looks like YAML inside a block scalar — cannot bind by accident.
- Pin canonical `YYYY-MM-DD` shape for `last_checked` (regex pre-check before `fromisoformat`) so the compact ISO form `20260501` is rejected at the helper boundary, matching the format the helper documents and writes.
- Restructure the `_HAPPY_CATALOG` fixture and rename / split tests so the catalog half and provenance half are exercised independently. New regression tests cover legacy-shape rejection, partial-migration rejection (both shapes present), only-misplaced rejection (no top-level), nested-`catalog_provenance` rejection, the parent-descent direct-child contract, the compact-ISO rejection, and the date-format pin.
- Add three structural canaries in `tests/test_constants.py`. One validates every `catalogs.<drift-managed-harness>` child is a non-empty-string list and `provenance` no longer appears as a child. The symmetric one validates every `catalog_provenance.<harness>` bucket has exactly `{source_url, last_checked}` non-empty string children with `last_checked` matching `YYYY-MM-DD`. The cross-canary asserts every `catalog_provenance` harness has a matching `catalogs` bucket. Drift-managed scope is derived from `catalog_provenance.keys()` in the live YAML so adding a new `catalog_provenance` entry automatically extends coverage; non-drift-managed harnesses (still allowed by `configuration.yaml` to use their own bucket shape under `catalogs.<harness>`) are not validated.
- Harden the canary load helper (`_load_allowed_tools_section`) with `assertIsInstance(dict)` checks at every level so a future scalar/list edit produces a targeted assertion instead of `KeyError` / `TypeError` / `AttributeError` traceback.
- Update the four operator-facing path references the schema move directly invalidates (`parse_catalog` docstring, helper module docstring header, workflow header comment, AGENTS.md "Detecting Tool Catalog Drift" path references) so contract and code agree.

## Test plan

- [ ] `python -m coverage run -m unittest discover -s tests -p "test_*.py"` clean (no regression in the meta-skill suite)
- [ ] `python -m unittest discover -s . -p "test_*.py"` from `.github/tests/` clean (drift helper suite, including the round-by-round regression tests added during review)
- [ ] `python -m coverage report` reports total branch coverage above the 70% threshold
- [ ] `cd skill-system-foundry && python scripts/validate_skill.py . --allow-nested-references --foundry-self --json` exits 0 with no failures
- [ ] `python skill-system-foundry/scripts/audit_skill_system.py skill-system-foundry --json` exits 0 with no failures
- [ ] Both YAML key orderings (`catalogs:` before / after `catalog_provenance:`) round-trip through `apply_additions` — covered by the two existing fixtures in the `apply_additions` tests