### PR TITLE
Add retain-findings inputs to Codex review workflow

### DIFF
--- a/.github/workflows/codex-code-review.yaml
+++ b/.github/workflows/codex-code-review.yaml
@@ -110,3 +110,5 @@ jobs:
           model: ${{ vars.CODEX_REVIEW_MODEL }}
           review-effort: ${{ vars.CODEX_REVIEW_EFFORT }}
           min-confidence: ${{ vars.CODEX_MIN_CONFIDENCE || '0' }}
+          retain-findings: ${{ vars.CODEX_RETAIN_FINDINGS }}
+          retain-findings-days: ${{ vars.CODEX_RETAIN_FINDINGS_DAYS }}

--- a/.github/workflows/codex-code-review.yaml
+++ b/.github/workflows/codex-code-review.yaml
@@ -96,6 +96,12 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - name: Validate retain-findings configuration
+        if: ${{ vars.CODEX_RETAIN_FINDINGS == 'true' && vars.CODEX_RETAIN_FINDINGS_DAYS == '' }}
+        run: |
+          echo "::error::CODEX_RETAIN_FINDINGS=true requires CODEX_RETAIN_FINDINGS_DAYS to be defined as a positive integer (action clamps at 90)."
+          exit 1
+
       - name: Download review artifacts
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # @v8 as 8.0.0
         with:

--- a/.github/workflows/codex-code-review.yaml
+++ b/.github/workflows/codex-code-review.yaml
@@ -40,13 +40,12 @@ jobs:
       skipped: ${{ steps.prepare.outputs.skipped }}
     steps:
       - name: Validate retain-findings configuration
-        if: ${{ vars.CODEX_RETAIN_FINDINGS != '' || vars.CODEX_RETAIN_FINDINGS_DAYS != '' }}
         env:
           RETAIN: ${{ vars.CODEX_RETAIN_FINDINGS }}
           DAYS: ${{ vars.CODEX_RETAIN_FINDINGS_DAYS }}
         run: |
           if [[ -z "$RETAIN" ]]; then
-            echo "::error::CODEX_RETAIN_FINDINGS_DAYS is set but CODEX_RETAIN_FINDINGS is not. Define CODEX_RETAIN_FINDINGS as 'true' or 'false'."
+            echo "::error::CODEX_RETAIN_FINDINGS is not defined. Set it to 'true' or 'false' as a repository variable."
             exit 1
           fi
           if [[ "$RETAIN" != "true" && "$RETAIN" != "false" ]]; then
@@ -54,7 +53,7 @@ jobs:
             exit 1
           fi
           if [[ "$RETAIN" == "true" ]]; then
-            if ! [[ "$DAYS" =~ ^[1-9][0-9]*$ ]] || (( DAYS > 90 )); then
+            if ! [[ "$DAYS" =~ ^[1-9][0-9]*$ ]] || (( 10#$DAYS > 90 )); then
               echo "::error::CODEX_RETAIN_FINDINGS=true requires CODEX_RETAIN_FINDINGS_DAYS to be an integer between 1 and 90. Got: '$DAYS'"
               exit 1
             fi

--- a/.github/workflows/codex-code-review.yaml
+++ b/.github/workflows/codex-code-review.yaml
@@ -40,13 +40,20 @@ jobs:
       skipped: ${{ steps.prepare.outputs.skipped }}
     steps:
       - name: Validate retain-findings configuration
-        if: ${{ vars.CODEX_RETAIN_FINDINGS == 'true' }}
+        if: ${{ vars.CODEX_RETAIN_FINDINGS != '' }}
         env:
+          RETAIN: ${{ vars.CODEX_RETAIN_FINDINGS }}
           DAYS: ${{ vars.CODEX_RETAIN_FINDINGS_DAYS }}
         run: |
-          if ! [[ "$DAYS" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::CODEX_RETAIN_FINDINGS=true requires CODEX_RETAIN_FINDINGS_DAYS to be a positive integer (action clamps values >90 at 90). Got: '$DAYS'"
+          if [[ "$RETAIN" != "true" && "$RETAIN" != "false" ]]; then
+            echo "::error::CODEX_RETAIN_FINDINGS must be 'true' or 'false'. Got: '$RETAIN'"
             exit 1
+          fi
+          if [[ "$RETAIN" == "true" ]]; then
+            if ! [[ "$DAYS" =~ ^[1-9][0-9]*$ ]] || (( DAYS > 90 )); then
+              echo "::error::CODEX_RETAIN_FINDINGS=true requires CODEX_RETAIN_FINDINGS_DAYS to be an integer between 1 and 90. Got: '$DAYS'"
+              exit 1
+            fi
           fi
 
       - name: Checkout PR

--- a/.github/workflows/codex-code-review.yaml
+++ b/.github/workflows/codex-code-review.yaml
@@ -40,11 +40,15 @@ jobs:
       skipped: ${{ steps.prepare.outputs.skipped }}
     steps:
       - name: Validate retain-findings configuration
-        if: ${{ vars.CODEX_RETAIN_FINDINGS != '' }}
+        if: ${{ vars.CODEX_RETAIN_FINDINGS != '' || vars.CODEX_RETAIN_FINDINGS_DAYS != '' }}
         env:
           RETAIN: ${{ vars.CODEX_RETAIN_FINDINGS }}
           DAYS: ${{ vars.CODEX_RETAIN_FINDINGS_DAYS }}
         run: |
+          if [[ -z "$RETAIN" ]]; then
+            echo "::error::CODEX_RETAIN_FINDINGS_DAYS is set but CODEX_RETAIN_FINDINGS is not. Define CODEX_RETAIN_FINDINGS as 'true' or 'false'."
+            exit 1
+          fi
           if [[ "$RETAIN" != "true" && "$RETAIN" != "false" ]]; then
             echo "::error::CODEX_RETAIN_FINDINGS must be 'true' or 'false'. Got: '$RETAIN'"
             exit 1

--- a/.github/workflows/codex-code-review.yaml
+++ b/.github/workflows/codex-code-review.yaml
@@ -39,6 +39,16 @@ jobs:
       chunk-matrix: ${{ steps.prepare.outputs.chunk-matrix }}
       skipped: ${{ steps.prepare.outputs.skipped }}
     steps:
+      - name: Validate retain-findings configuration
+        if: ${{ vars.CODEX_RETAIN_FINDINGS == 'true' }}
+        env:
+          DAYS: ${{ vars.CODEX_RETAIN_FINDINGS_DAYS }}
+        run: |
+          if ! [[ "$DAYS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::CODEX_RETAIN_FINDINGS=true requires CODEX_RETAIN_FINDINGS_DAYS to be a positive integer (action clamps values >90 at 90). Got: '$DAYS'"
+            exit 1
+          fi
+
       - name: Checkout PR
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
         with:
@@ -96,12 +106,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Validate retain-findings configuration
-        if: ${{ vars.CODEX_RETAIN_FINDINGS == 'true' && vars.CODEX_RETAIN_FINDINGS_DAYS == '' }}
-        run: |
-          echo "::error::CODEX_RETAIN_FINDINGS=true requires CODEX_RETAIN_FINDINGS_DAYS to be defined as a positive integer (action clamps at 90)."
-          exit 1
-
       - name: Download review artifacts
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # @v8 as 8.0.0
         with:


### PR DESCRIPTION
## Summary

- Wires the `retain-findings` and `retain-findings-days` inputs of `milanhorvatovic/codex-ai-code-review-action/publish` to two new repository variables (`CODEX_RETAIN_FINDINGS`, `CODEX_RETAIN_FINDINGS_DAYS`), so the publish step uploads the merged review JSON as a long-lived artifact for auditing.
- No fallback defaults: the workflow forwards the variable values verbatim. Both vars must be set in repository settings (`CODEX_RETAIN_FINDINGS=true`, `CODEX_RETAIN_FINDINGS_DAYS=<positive integer ≤ 90>`) — leaving `…_DAYS` unset while retention is enabled fails the action.

## Test plan

- [ ] Verify `CODEX_RETAIN_FINDINGS` and `CODEX_RETAIN_FINDINGS_DAYS` exist in repository variables before merge.
- [ ] After merge, observe the next PR review run and confirm the publish job uploads a `codex-review-findings` artifact with the configured retention.