### PR TITLE
Add structural description validation rules to validate_skill

### DIFF
--- a/examples/skills/hello-greeter/SKILL.md
+++ b/examples/skills/hello-greeter/SKILL.md
@@ -2,12 +2,11 @@
 name: hello-greeter
 description: >
   Greets a single recipient with a friendly welcome message rendered in a
-  formal or casual tone. Activates whenever the conversation asks to say
-  hello, welcome someone, or produce an opening greeting. Single-purpose,
-  no branching, no shell access. Demonstrates the smallest valid standalone
-  skill in the Skill System Foundry — required `name` and `description`
-  fields plus an optional `metadata` block, third-person description, body
-  well under the recommended line cap.
+  formal or casual tone. Activates when the conversation asks to say hello or
+  welcome someone; use when a minimal standalone skill is needed. Demonstrates
+  the smallest valid standalone skill in the Skill System Foundry — required
+  name and description frontmatter plus an optional metadata block — and how
+  its layout passes validation.
 metadata:
   version: "1.0.0"
 ---

--- a/examples/skills/hello-router/SKILL.md
+++ b/examples/skills/hello-router/SKILL.md
@@ -2,12 +2,12 @@
 name: hello-router
 description: >
   Greets a recipient through one of two registered tones — formal or casual —
-  by dispatching to a dedicated capability. Activates whenever the
-  conversation asks for a tone-specific welcome, a switch between formal and
-  casual greetings, or a comparison of the two styles. Demonstrates the
-  router pattern in the Skill System Foundry — a thin SKILL.md entry point
-  routing to capability files that hold the actual instructions, with
-  allowed-tools declared so capability-level shell fences stay coherent.
+  by dispatching to a dedicated capability. Activates when the conversation
+  asks for a tone-specific welcome or a switch between formal and casual
+  greetings; use when comparing the two styles. Demonstrates the router
+  pattern in the Skill System Foundry — a thin SKILL.md entry point routing to
+  capability files, with allowed-tools declared in frontmatter so capability
+  shell fences pass validation.
 allowed-tools: Bash
 metadata:
   version: "1.0.0"

--- a/skill-system-foundry/SKILL.md
+++ b/skill-system-foundry/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: skill-system-foundry
 description: >
-  Designs and evolves AI-agnostic skill systems with skills, capabilities, and
-  roles. Triggers on skill/capability creation, role definition, router
-  migration, consistency audits, or token efficiency.
+  Designs and evolves AI-agnostic skill systems. Triggers on
+  skill/capability creation, role definition, or router migration; use
+  when auditing consistency or improving token efficiency.
 allowed-tools: Bash Read Write Edit
 compatibility: Requires Python 3.12+ (stdlib only) for validation, scaffolding, and bundling scripts.
 license: MIT

--- a/skill-system-foundry/references/authoring-principles.md
+++ b/skill-system-foundry/references/authoring-principles.md
@@ -119,7 +119,7 @@ description: Helps with deployments.
 
 - **Trigger-clause strength** — at least two distinct trigger phrases (WARN below two). Reuses `skill.description.trigger_phrases`; the audit keeps the historical one-phrase minimum.
 - **Negative trigger** — notes a "don't use when…" clause when present (INFO).
-- **Length tiers** — advisory INFO below the lower tier or above the upper tier; the lower tier sits below the bundle description cap so a maximally sized claude description is never flagged as too short.
+- **Length tiers** — advisory INFO below the lower tier or above the upper tier; the lower tier sits below the bundler's `claude`-target description cap (`bundle.description_max_length`) so a description sized right up to that cap is never simultaneously flagged as too short.
 - **Filler detection** — WARN on "helps with" / "handles" / … only when no concrete qualifier follows.
 - **Domain vocabulary** — INFO when fewer than the configured number of domain terms appear; the vocabulary list is integrator-owned and an empty list disables the check.
 - **Boundary clause** — notes an "X vs Y" / "use Y instead" clause when present (INFO).

--- a/skill-system-foundry/references/authoring-principles.md
+++ b/skill-system-foundry/references/authoring-principles.md
@@ -115,7 +115,7 @@ description: Helps with deployments.
 
 ### Structural checks
 
-`validate_skill.py` enforces eight structural description checks on top of the length, character-set, and voice rules above. All are advisory — they emit INFO or WARN, never FAIL (the only description FAIL is the 1024-character spec limit). Phrase lists and thresholds live under `skill.description.structural_rules` in [configuration.yaml](../scripts/lib/configuration.yaml), the canonical source; integrators tune them to their own domain.
+`validate_skill.py` enforces eight structural description checks on top of the length, character-set, and voice rules above. The structural checks themselves are advisory — they emit INFO or WARN, never FAIL. (`validate_description` still FAILs separately when the description is empty or exceeds the 1024-character spec limit.) Phrase lists and thresholds live under `skill.description.structural_rules` in [configuration.yaml](../scripts/lib/configuration.yaml), the canonical source; integrators tune them to their own domain.
 
 - **Trigger-clause strength** — at least two distinct trigger phrases (WARN below two). Reuses `skill.description.trigger_phrases`; the audit keeps the historical one-phrase minimum.
 - **Negative trigger** — notes a "don't use when…" clause when present (INFO).

--- a/skill-system-foundry/references/authoring-principles.md
+++ b/skill-system-foundry/references/authoring-principles.md
@@ -115,7 +115,7 @@ description: Helps with deployments.
 
 ### Structural checks
 
-`validate_skill.py` enforces eight structural description checks on top of the length, character-set, and voice rules above. The structural checks themselves are advisory — they emit INFO or WARN, never FAIL. (`validate_description` still FAILs separately when the description is empty or exceeds the 1024-character spec limit.) Phrase lists and thresholds live under `skill.description.structural_rules` in [configuration.yaml](../scripts/lib/configuration.yaml), the canonical source; integrators tune them to their own domain.
+`validate_skill.py` enforces eight structural description checks on top of the length, XML-tag, voice, and trigger-presence rules above. The structural checks themselves are advisory — they emit INFO or WARN, never FAIL. (`validate_description` still FAILs separately when the description is empty or exceeds the 1024-character spec limit.) Phrase lists and thresholds live under `skill.description.structural_rules` in [configuration.yaml](../scripts/lib/configuration.yaml), the canonical source; integrators tune them to their own domain.
 
 - **Trigger-clause strength** — at least two distinct trigger phrases (WARN below two). Reuses `skill.description.trigger_phrases`; the audit keeps the historical one-phrase minimum.
 - **Negative trigger** — notes a "don't use when…" clause when present (INFO).

--- a/skill-system-foundry/references/authoring-principles.md
+++ b/skill-system-foundry/references/authoring-principles.md
@@ -113,6 +113,18 @@ description: >
 description: Helps with deployments.
 ```
 
+### Structural checks
+
+`validate_skill.py` enforces eight structural description checks on top of the length, character-set, and voice rules above. All are advisory — they emit INFO or WARN, never FAIL (the only description FAIL is the 1024-character spec limit). Phrase lists and thresholds live under `skill.description.structural_rules` in [configuration.yaml](../scripts/lib/configuration.yaml), the canonical source; integrators tune them to their own domain.
+
+- **Trigger-clause strength** — at least two distinct trigger phrases (WARN below two). Reuses `skill.description.trigger_phrases`; the audit keeps the historical one-phrase minimum.
+- **Negative trigger** — notes a "don't use when…" clause when present (INFO).
+- **Length tiers** — advisory INFO below the lower tier or above the upper tier; the lower tier sits below the bundle description cap so a maximally sized claude description is never flagged as too short.
+- **Filler detection** — WARN on "helps with" / "handles" / … only when no concrete qualifier follows.
+- **Domain vocabulary** — INFO when fewer than the configured number of domain terms appear; the vocabulary list is integrator-owned and an empty list disables the check.
+- **Boundary clause** — notes an "X vs Y" / "use Y instead" clause when present (INFO).
+- **Over-repetition** — WARN when one content word both repeats past a floor and dominates the description (a length-normalized ratio, so legitimately repeating a subject noun does not trip it).
+
 ### Testing activation
 
 Well-formed is not the same as well-targeted — a description can pass every rule above and still under- or over-trigger. Measure activation precision and recall against a prompt corpus with [evaluate_descriptions.py](../scripts/evaluate_descriptions.py) (a deterministic, stdlib-only heuristic check); the corpus format is documented in the validation capability's "Description-Quality Evaluation" section.

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -186,7 +186,11 @@ skill:
       filler_lookahead_tokens: 3
 
       # R8 — Boundary clauses.  INFO.  Names the boundary against an
-      # adjacent skill ("X vs Y", "use Y instead").  Distinct from R2:
+      # adjacent skill ("X vs Y", "use Y instead").  Matching is plain
+      # case-insensitive substring, so each phrase must appear
+      # contiguously — use "instead" (which catches "use Y instead",
+      # "Y instead of Z", etc.) rather than "use instead", which would
+      # only match the unnatural contiguous wording.  Distinct from R2:
       # R2 = "do not activate at all", R8 = "which adjacent skill to use
       # instead".  Keep this list to phrases that genuinely imply an
       # adjacent alternative — do NOT add bare negative-activation
@@ -198,7 +202,7 @@ skill:
       # strip these.
       boundary_clause_phrases:
         - " vs "
-        - use instead
+        - instead
         - rather than
 
       # R3 + R4 — Length tier guidance.  The hard FAIL at >1024 stays

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -141,8 +141,8 @@ skill:
         - do
         - does
     # Structural description-quality rules (validate_skill.py only).
-    # Eight checks layered on top of the length / character-set /
-    # voice / trigger-presence rules above.  All route through the
+    # Eight checks layered on top of the length / XML-tag / voice /
+    # trigger-presence rules above.  All route through the
     # existing FAIL / WARN / INFO machinery; none introduce a new
     # entry point or require a corpus.  Numeric scalars load as
     # strings (custom YAML parser) and are converted in constants.py.

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -167,18 +167,23 @@ skill:
         - skip when
         - avoid when
 
-      # R5 — Filler detection.  WARN only when one of these phrases is
-      # followed by no concrete (non-stopword) word within the next
-      # few tokens — i.e. the phrase trails into a stopword or the end
-      # of the description.  "handles skill manifests" is fine;
-      # "handles things"/"handles" trailing is not.  The look-ahead
-      # guard is what keeps legitimate uses of "handles" from firing.
+      # R5 — Filler detection.  Phrases match on word boundaries (so
+      # "handles" does not match inside "mishandles").  WARN only when
+      # a matched phrase is followed by no concrete (non-stopword) word
+      # within the next filler_lookahead_tokens tokens — i.e. the phrase
+      # trails into stopwords or the end of the description.  "handles
+      # skill manifests" is fine; "handles things"/"handles" trailing is
+      # not (note "things" is a stopword below).  The look-ahead guard
+      # keeps legitimate uses of "handles" from firing.
       filler_phrases:
         - helps with
         - useful for
         - handles
         - works with
         - deals with
+      # How many tokens after a filler phrase are scanned for a concrete
+      # qualifier before the phrase is treated as vague.
+      filler_lookahead_tokens: 3
 
       # R8 — Boundary clauses.  INFO.  Names the boundary against an
       # adjacent skill ("X vs Y", "use Y instead").  Distinct from R2:
@@ -238,11 +243,13 @@ skill:
       redundancy_min_count: 5
       redundancy_max_ratio: 0.22
 
-      # Stopwords for R7 and R9 tokenization.  Distinct from the
+      # Stopwords for R5, R7, and R9 tokenization.  Distinct from the
       # eval-runner stopwords above (those are tuned for prompt
       # tokenization).  Trigger-scaffolding words (use/when/triggers/
       # ...) are stripped too so the trigger phrasing R6 rewards does
-      # not count as R9 over-repetition.
+      # not count as R9 over-repetition.  Generic placeholders like
+      # "things" count as stopwords so a filler phrase trailing into one
+      # (e.g. "handles things") is treated as vague (R5).
       stopwords:
         - the
         - a
@@ -260,6 +267,7 @@ skill:
         - are
         - this
         - that
+        - things
         - and
         - or
         - also

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -140,6 +140,135 @@ skill:
         - as
         - do
         - does
+    # Structural description-quality rules (validate_skill.py only).
+    # Eight checks layered on top of the length / character-set /
+    # voice / trigger-presence rules above.  All route through the
+    # existing FAIL / WARN / INFO machinery; none introduce a new
+    # entry point or require a corpus.  Numeric scalars load as
+    # strings (custom YAML parser) and are converted in constants.py.
+    structural_rules:
+      # R6 — Trigger-clause strength.  Reuses the trigger_phrases list
+      # above (single source of truth — there is no separate
+      # imperative_phrases list; the agentskills.io "use imperative
+      # phrasing" guidance is satisfied by those phrases).  Graduated
+      # and non-blocking: 0 distinct triggers -> WARN, 1 -> WARN,
+      # >=2 -> pass.  validate_description opts into this minimum;
+      # validate_description_triggers defaults to minimum_count=1, so
+      # audit_skill_system.py keeps its existing behaviour unchanged.
+      trigger_minimum_count: 2
+
+      # R2 — Negative triggers.  INFO when present — naming when the
+      # skill should NOT activate aids routing.  Case-insensitive
+      # substring on the lowered description.
+      negative_trigger_phrases:
+        - don't use when
+        - do not use
+        - not for
+        - skip when
+        - avoid when
+
+      # R5 — Filler detection.  WARN only when one of these phrases is
+      # followed by no concrete (non-stopword) word within the next
+      # few tokens — i.e. the phrase trails into a stopword or the end
+      # of the description.  "handles skill manifests" is fine;
+      # "handles things"/"handles" trailing is not.  The look-ahead
+      # guard is what keeps legitimate uses of "handles" from firing.
+      filler_phrases:
+        - helps with
+        - useful for
+        - handles
+        - works with
+        - deals with
+
+      # R8 — Boundary clauses.  INFO.  Names the boundary against an
+      # adjacent skill ("X vs Y", "use Y instead").  Distinct from R2:
+      # R2 = "do not activate at all", R8 = "which adjacent skill to
+      # use instead".  Leading/trailing spaces in quoted entries are
+      # significant and preserved (" vs " must not match "vs" inside a
+      # word) — constants.py lowercases but does not strip these.
+      boundary_clause_phrases:
+        - " vs "
+        - " not for "
+        - use instead
+        - rather than
+
+      # R3 + R4 — Length tier guidance.  The hard FAIL at >1024 stays
+      # in the existing length rule (description.max_length).  These
+      # are advisory INFOs at the soft edges of the spectrum.
+      length_tier_warn_below: 200
+      length_tier_warn_above: 800
+
+      # R7 — Domain-vocabulary presence (INFO, opt-in).  Counts
+      # DISTINCT matching tokens; INFO when below the minimum.  The
+      # list is integrator-owned: an EMPTY vocabulary_list DISABLES
+      # the rule entirely, so it never biases skills outside the
+      # foundry's domain.  The foundry ships its own vocabulary here
+      # for its own dogfood; integrators replace it (or empty it).
+      vocabulary_minimum: 3
+      vocabulary_list:
+        - validation
+        - audit
+        - bundling
+        - scaffolding
+        - corpus
+        - frontmatter
+        - manifest
+        - capability
+        - skill
+        - workflow
+        - migration
+        - changelog
+        - release
+        - pipeline
+        - configuration
+
+      # R9 — Over-repetition.  A content word that dominates the
+      # description signals padding.  Length-normalized so the rule is
+      # universal across short and long descriptions: WARN only when a
+      # word's raw count >= redundancy_min_count AND its share of all
+      # content tokens >= redundancy_max_ratio.  Tuned against the
+      # meta-skill + .agents/skills/ corpus (top content-word ratios
+      # run ~4-20%) so good "pushy" descriptions that repeat their
+      # subject noun stay silent and only genuine padding trips it.
+      redundancy_min_count: 5
+      redundancy_max_ratio: 0.22
+
+      # Stopwords for R7 and R9 tokenization.  Distinct from the
+      # eval-runner stopwords above (those are tuned for prompt
+      # tokenization).  Trigger-scaffolding words (use/when/triggers/
+      # ...) are stripped too so the trigger phrasing R6 rewards does
+      # not count as R9 over-repetition.
+      stopwords:
+        - the
+        - a
+        - an
+        - of
+        - in
+        - on
+        - at
+        - to
+        - for
+        - with
+        - by
+        - from
+        - is
+        - are
+        - this
+        - that
+        - and
+        - or
+        - also
+        - use
+        - used
+        - using
+        - when
+        - whenever
+        - triggers
+        - trigger
+        - activates
+        - activate
+        - invoked
+        - invoke
   body:
     max_lines: 500
     # Cross-file reference patterns.

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -187,13 +187,17 @@ skill:
 
       # R8 — Boundary clauses.  INFO.  Names the boundary against an
       # adjacent skill ("X vs Y", "use Y instead").  Distinct from R2:
-      # R2 = "do not activate at all", R8 = "which adjacent skill to
-      # use instead".  Leading/trailing spaces in quoted entries are
-      # significant and preserved (" vs " must not match "vs" inside a
-      # word) — constants.py lowercases but does not strip these.
+      # R2 = "do not activate at all", R8 = "which adjacent skill to use
+      # instead".  Keep this list to phrases that genuinely imply an
+      # adjacent alternative — do NOT add bare negative-activation
+      # fragments like "not for", which R2 already owns; listing such a
+      # phrase here would emit a contradictory second INFO for an
+      # ordinary negative-trigger description.  Leading/trailing spaces
+      # in quoted entries are significant and preserved (" vs " must not
+      # match "vs" inside a word) — constants.py lowercases but does not
+      # strip these.
       boundary_clause_phrases:
         - " vs "
-        - " not for "
         - use instead
         - rather than
 

--- a/skill-system-foundry/scripts/lib/configuration.yaml
+++ b/skill-system-foundry/scripts/lib/configuration.yaml
@@ -194,8 +194,13 @@ skill:
 
       # R3 + R4 — Length tier guidance.  The hard FAIL at >1024 stays
       # in the existing length rule (description.max_length).  These
-      # are advisory INFOs at the soft edges of the spectrum.
-      length_tier_warn_below: 200
+      # are advisory INFOs at the soft edges of the spectrum.  The
+      # lower tier sits below the bundle.description_max_length cap
+      # (200, enforced as an error for the 'claude' target) so a
+      # maximally-sized claude description is not simultaneously
+      # flagged as "too short" — it also keeps every shipped foundry
+      # description (meta-skill, examples, .agents/skills) clean.
+      length_tier_warn_below: 160
       length_tier_warn_above: 800
 
       # R7 — Domain-vocabulary presence (INFO, opt-in).  Counts

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -333,7 +333,7 @@ for _phrase in DESCRIPTION_TRIGGER_PHRASES:
 DESCRIPTION_TRIGGER_EXAMPLE_PHRASES = tuple(_example_phrases_buffer)
 
 # --- Structural description-quality rules (validate_skill.py only) ---
-# Eight checks layered on top of the length / character-set / voice /
+# Eight checks layered on top of the length / XML-tag / voice /
 # trigger-presence rules.  All settings live under
 # skill.description.structural_rules in configuration.yaml.  The custom
 # YAML parser returns every scalar as a string, so counts go through

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -435,6 +435,15 @@ DESCRIPTION_NEGATIVE_TRIGGER_PHRASES = _normalize_structural_phrases(
 DESCRIPTION_FILLER_PHRASES = _normalize_structural_phrases(
     _structural, "filler_phrases",
 )
+DESCRIPTION_FILLER_LOOKAHEAD = int(
+    _require_structural_key(_structural, "filler_lookahead_tokens")
+)
+if DESCRIPTION_FILLER_LOOKAHEAD < 1:
+    raise RuntimeError(
+        "configuration.yaml has invalid value for "
+        "'skill.description.structural_rules.filler_lookahead_tokens': "
+        f"{DESCRIPTION_FILLER_LOOKAHEAD} (must be >= 1)."
+    )
 # Boundary clauses keep significant edge spaces (" vs "): lowercase
 # only, do not strip.
 DESCRIPTION_BOUNDARY_PHRASES = _normalize_structural_phrases(

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -332,6 +332,172 @@ for _phrase in DESCRIPTION_TRIGGER_PHRASES:
         break
 DESCRIPTION_TRIGGER_EXAMPLE_PHRASES = tuple(_example_phrases_buffer)
 
+# --- Structural description-quality rules (validate_skill.py only) ---
+# Eight checks layered on top of the length / character-set / voice /
+# trigger-presence rules.  All settings live under
+# skill.description.structural_rules in configuration.yaml.  The custom
+# YAML parser returns every scalar as a string, so counts go through
+# int() and the ratio through float(); phrase lists pass through as
+# tuples and the stopword list as a frozenset.  Fail-fast on a missing
+# or malformed section mirrors the trigger_phrases / evaluation loaders
+# above so a stale checkout errors loudly at import.
+if "structural_rules" not in _skill_desc:
+    raise RuntimeError(
+        "configuration.yaml is missing required section "
+        "'skill.description.structural_rules'; update your checkout "
+        "or restore the full configuration file."
+    )
+_structural = _skill_desc["structural_rules"]
+if not isinstance(_structural, dict):
+    raise RuntimeError(
+        "configuration.yaml has invalid value for "
+        "'skill.description.structural_rules': expected a mapping, got "
+        f"{_structural!r}."
+    )
+
+
+def _require_structural_key(structural: dict, key: str) -> object:
+    """Return ``structural[key]`` or raise a clear RuntimeError.
+
+    Takes the mapping as an argument (rather than closing over a
+    module global) so the helper can be deleted after import without
+    leaving a dangling reference.
+    """
+    if key not in structural:
+        raise RuntimeError(
+            "configuration.yaml is missing required key "
+            f"'skill.description.structural_rules.{key}'; update your "
+            "checkout or restore the full configuration file."
+        )
+    return structural[key]
+
+
+def _normalize_structural_phrases(
+    structural: dict, key: str, *,
+    strip: bool = True, allow_empty_list: bool = False,
+) -> tuple[str, ...]:
+    """Normalize a structural-rules phrase list to a lowercased tuple.
+
+    Rejects non-list values, empty lists (unless *allow_empty_list*),
+    non-string entries, blank entries, and duplicates — each would
+    silently neuter the rule it feeds.  When *strip* is False the entry
+    text is preserved verbatim apart from lowercasing (boundary clauses
+    rely on significant leading/trailing spaces, e.g. ``" vs "``); a
+    whitespace-only entry is still rejected.
+    """
+    raw = _require_structural_key(structural, key)
+    if not isinstance(raw, list) or (not raw and not allow_empty_list):
+        raise RuntimeError(
+            "configuration.yaml has invalid value for "
+            f"'skill.description.structural_rules.{key}': expected a "
+            f"{'list' if allow_empty_list else 'non-empty list'}, got {raw!r}."
+        )
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, str):
+            raise RuntimeError(
+                "configuration.yaml has a non-string entry in "
+                f"'skill.description.structural_rules.{key}': {item!r}."
+            )
+        candidate = item.lower()
+        if strip:
+            candidate = candidate.strip()
+        if not candidate.strip():
+            raise RuntimeError(
+                "configuration.yaml has an empty / whitespace-only entry "
+                f"in 'skill.description.structural_rules.{key}'; remove it "
+                "or replace it with a real value."
+            )
+        if candidate in seen:
+            raise RuntimeError(
+                f"configuration.yaml has a duplicate entry '{item}' in "
+                f"'skill.description.structural_rules.{key}'; remove the "
+                "redundant entry."
+            )
+        seen.add(candidate)
+        normalized.append(candidate)
+    return tuple(normalized)
+
+
+DESCRIPTION_TRIGGER_MIN_COUNT = int(
+    _require_structural_key(_structural, "trigger_minimum_count")
+)
+if DESCRIPTION_TRIGGER_MIN_COUNT < 1:
+    raise RuntimeError(
+        "configuration.yaml has invalid value for "
+        "'skill.description.structural_rules.trigger_minimum_count': "
+        f"{DESCRIPTION_TRIGGER_MIN_COUNT} (must be >= 1)."
+    )
+DESCRIPTION_NEGATIVE_TRIGGER_PHRASES = _normalize_structural_phrases(
+    _structural, "negative_trigger_phrases",
+)
+DESCRIPTION_FILLER_PHRASES = _normalize_structural_phrases(
+    _structural, "filler_phrases",
+)
+# Boundary clauses keep significant edge spaces (" vs "): lowercase
+# only, do not strip.
+DESCRIPTION_BOUNDARY_PHRASES = _normalize_structural_phrases(
+    _structural, "boundary_clause_phrases", strip=False,
+)
+DESCRIPTION_LENGTH_WARN_BELOW = int(
+    _require_structural_key(_structural, "length_tier_warn_below")
+)
+DESCRIPTION_LENGTH_WARN_ABOVE = int(
+    _require_structural_key(_structural, "length_tier_warn_above")
+)
+if DESCRIPTION_LENGTH_WARN_BELOW < 0 or DESCRIPTION_LENGTH_WARN_ABOVE < 0:
+    raise RuntimeError(
+        "configuration.yaml has invalid length-tier values: "
+        f"below={DESCRIPTION_LENGTH_WARN_BELOW}, "
+        f"above={DESCRIPTION_LENGTH_WARN_ABOVE}; both must be non-negative."
+    )
+if DESCRIPTION_LENGTH_WARN_BELOW >= DESCRIPTION_LENGTH_WARN_ABOVE:
+    raise RuntimeError(
+        "configuration.yaml has "
+        "'skill.description.structural_rules.length_tier_warn_below' "
+        f"({DESCRIPTION_LENGTH_WARN_BELOW}) >= 'length_tier_warn_above' "
+        f"({DESCRIPTION_LENGTH_WARN_ABOVE}); the advisory tiers would "
+        "overlap."
+    )
+DESCRIPTION_VOCABULARY_MINIMUM = int(
+    _require_structural_key(_structural, "vocabulary_minimum")
+)
+if DESCRIPTION_VOCABULARY_MINIMUM < 1:
+    raise RuntimeError(
+        "configuration.yaml has invalid value for "
+        "'skill.description.structural_rules.vocabulary_minimum': "
+        f"{DESCRIPTION_VOCABULARY_MINIMUM} (must be >= 1)."
+    )
+# An empty vocabulary list is legal — it disables R7 for integrators
+# who do not curate a domain vocabulary.
+DESCRIPTION_VOCABULARY_LIST = _normalize_structural_phrases(
+    _structural, "vocabulary_list", allow_empty_list=True,
+)
+DESCRIPTION_REDUNDANCY_MIN_COUNT = int(
+    _require_structural_key(_structural, "redundancy_min_count")
+)
+if DESCRIPTION_REDUNDANCY_MIN_COUNT < 2:
+    raise RuntimeError(
+        "configuration.yaml has invalid value for "
+        "'skill.description.structural_rules.redundancy_min_count': "
+        f"{DESCRIPTION_REDUNDANCY_MIN_COUNT} (must be >= 2)."
+    )
+DESCRIPTION_REDUNDANCY_MAX_RATIO = float(
+    _require_structural_key(_structural, "redundancy_max_ratio")
+)
+if not 0.0 < DESCRIPTION_REDUNDANCY_MAX_RATIO <= 1.0:
+    raise RuntimeError(
+        "configuration.yaml has invalid value for "
+        "'skill.description.structural_rules.redundancy_max_ratio': "
+        f"{DESCRIPTION_REDUNDANCY_MAX_RATIO!r}. Expected a number in "
+        "(0.0, 1.0]."
+    )
+DESCRIPTION_STRUCTURAL_STOPWORDS = frozenset(
+    _normalize_structural_phrases(_structural, "stopwords")
+)
+del _structural, _require_structural_key, _normalize_structural_phrases
+
 # --- Path Resolution ---
 # Loaded before the skill body reference patterns because the body's
 # ``markdown_link`` regex carries a ``__EXT_ALT__`` placeholder that

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -17,7 +17,7 @@ from .constants import (
     TOOL_FENCE_LANGUAGES, TOOLS_INDICATING_SCRIPTS,
     DESCRIPTION_TRIGGER_PHRASES, DESCRIPTION_TRIGGER_EXAMPLE_PHRASES,
     DESCRIPTION_NEGATIVE_TRIGGER_PHRASES, DESCRIPTION_FILLER_PHRASES,
-    DESCRIPTION_BOUNDARY_PHRASES,
+    DESCRIPTION_FILLER_LOOKAHEAD, DESCRIPTION_BOUNDARY_PHRASES,
     DESCRIPTION_LENGTH_WARN_BELOW, DESCRIPTION_LENGTH_WARN_ABOVE,
     DESCRIPTION_VOCABULARY_MINIMUM, DESCRIPTION_VOCABULARY_LIST,
     DESCRIPTION_REDUNDANCY_MIN_COUNT, DESCRIPTION_REDUNDANCY_MAX_RATIO,
@@ -269,11 +269,14 @@ def validate_description_filler(
 ) -> tuple[list[str], list[str]]:
     """R5 — flag a filler phrase with no concrete qualifier following.
 
-    WARN only when one of ``DESCRIPTION_FILLER_PHRASES`` appears and no
-    content (non-stopword, length >= 3) word follows it within the next
-    few tokens — i.e. the phrase trails into a stopword or the end of
-    the description.  "handles skill manifests" is fine; "handles
-    things" (no real qualifier) or a trailing "handles" is not.  The
+    Phrases match on word boundaries — ``handles`` matches the standalone
+    word but not a substring inside ``mishandles`` — so legitimate words
+    that merely contain a filler phrase do not trip the rule.  WARN only
+    when a matched phrase is followed by no content (non-stopword,
+    length >= 3) word within the next ``DESCRIPTION_FILLER_LOOKAHEAD``
+    tokens — i.e. the phrase trails into stopwords or the end of the
+    description.  "handles skill manifests" is fine; "handles things"
+    (``things`` is a stopword) or a trailing "handles" is not.  The
     look-ahead guard keeps legitimate uses of "handles" / "works with"
     from firing.
 
@@ -286,10 +289,15 @@ def validate_description_filler(
     lowered = description.lower()
     flagged: list[str] = []
     for phrase in DESCRIPTION_FILLER_PHRASES:
-        start = lowered.find(phrase)
-        while start != -1:
-            after = lowered[start + len(phrase):]
-            following = _RE_WORD_TOKEN.findall(after)[:3]
+        # Word-boundary guards (no alphanumeric immediately before/after)
+        # so a single-word phrase like "handles" does not match inside
+        # "mishandles".  Phrases are already lowercased in constants.
+        pattern = re.compile(
+            r"(?<![a-z0-9])" + re.escape(phrase) + r"(?![a-z0-9])"
+        )
+        for match in pattern.finditer(lowered):
+            after = lowered[match.end():]
+            following = _RE_WORD_TOKEN.findall(after)[:DESCRIPTION_FILLER_LOOKAHEAD]
             has_qualifier = any(
                 token not in DESCRIPTION_STRUCTURAL_STOPWORDS and len(token) >= 3
                 for token in following
@@ -297,7 +305,6 @@ def validate_description_filler(
             if not has_qualifier:
                 flagged.append(phrase)
                 break
-            start = lowered.find(phrase, start + 1)
     if flagged:
         errors.append(
             f"{LEVEL_WARN}: [foundry] 'description' uses filler phrase "

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -256,9 +256,9 @@ def validate_description_negative_triggers(
     """R2 — note when the description includes a negative trigger.
 
     Naming when the skill should *not* activate aids routing.  Presence
-    is informational (INFO); absence is silent (the clause is optional).
-    Case-insensitive substring match against
-    ``DESCRIPTION_NEGATIVE_TRIGGER_PHRASES``.
+    emits an INFO; absence emits an informational pass (the clause is
+    optional, so its absence is never a finding).  Case-insensitive
+    substring match against ``DESCRIPTION_NEGATIVE_TRIGGER_PHRASES``.
 
     Returns ``(errors, passes)`` per the standard validator contract.
     """
@@ -328,6 +328,11 @@ def validate_description_filler(
             if not has_qualifier:
                 flagged.append(phrase)
                 break
+        if flagged:
+            # Only the first flagged phrase is reported, so stop scanning
+            # the remaining phrases once one trips — no need to keep
+            # matching across the whole phrase list.
+            break
     if flagged:
         errors.append(
             f"{LEVEL_WARN}: [foundry] 'description' uses filler phrase "
@@ -345,11 +350,12 @@ def validate_description_boundary(
     """R8 — note when the description names a boundary against an adjacent skill.
 
     A boundary clause ("X vs Y", "use Y instead") aids routing between
-    overlapping skills.  Presence is informational (INFO); absence is
-    silent.  Distinct from R2: R2 says "do not activate at all", R8 says
-    "which adjacent skill to use instead".  Match is case-insensitive
-    substring; boundary phrases keep their significant edge spaces
-    (" vs ").
+    overlapping skills.  Presence emits an INFO; absence emits an
+    informational pass (the clause is optional, so its absence is never
+    a finding).  Distinct from R2: R2 says "do not activate at all", R8
+    says "which adjacent skill to use instead".  Match is
+    case-insensitive substring; boundary phrases keep their significant
+    edge spaces (" vs ").
 
     Returns ``(errors, passes)`` per the standard validator contract.
     """

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -104,26 +104,61 @@ def _is_explicit_empty_allowed_tools(value: object) -> bool:
     return False
 
 
+def count_trigger_phrases(description: str) -> list[str]:
+    """Return the distinct trigger phrases present in *description*.
+
+    Pure helper extracted so the trigger heuristic has a single
+    matching implementation: lowercases once and does a
+    case-insensitive substring match against
+    ``DESCRIPTION_TRIGGER_PHRASES`` (configured under
+    ``skill.description.trigger_phrases``).  The result preserves the
+    configured tuple's order (already sorted and de-duplicated), so it
+    is deterministic across processes.  Empty / whitespace-only input
+    returns ``[]``.
+    """
+    if not description or not description.strip():
+        return []
+    lowered = description.lower()
+    return [
+        phrase for phrase in DESCRIPTION_TRIGGER_PHRASES if phrase in lowered
+    ]
+
+
 def validate_description_triggers(
     description: str,
+    *,
+    minimum_count: int = 1,
 ) -> tuple[list[str], list[str]]:
-    """Check that the description contains at least one trigger phrase.
+    """Check that the description states *when* the skill activates.
 
     The agentskills.io specification requires descriptions to state
     both *what* the skill does and *when* it activates.  This rule
-    enforces the "when" half by case-insensitive substring matching
-    against ``DESCRIPTION_TRIGGER_PHRASES`` (configured under
-    ``skill.description.trigger_phrases`` in ``configuration.yaml``).
+    enforces the "when" half via :func:`count_trigger_phrases`.
+
+    *minimum_count* (default ``1``) is the number of distinct trigger
+    phrases the description should contain.  The default reproduces the
+    historical behaviour — zero matches WARN, one or more pass — so
+    callers that do not opt in (notably the per-skill block in
+    ``audit_skill_system.py``) are unaffected.  ``validate_description``
+    in ``validate_skill.py`` passes ``DESCRIPTION_TRIGGER_MIN_COUNT``
+    (the foundry strictening) to require at least two distinct trigger
+    clauses.
+
+    Outcomes are graduated and non-blocking (WARN, never FAIL):
+
+    - zero matches → the spec-tagged "does not state when it activates"
+      WARN (unchanged wording);
+    - ``0 < matches < minimum_count`` → a foundry WARN recommending an
+      additional trigger clause;
+    - ``matches >= minimum_count`` → pass.
 
     Detection is heuristic — phrase matching cannot enumerate every
-    valid wording — so the rule emits WARN, not FAIL.  Empty /
-    whitespace-only inputs short-circuit silently: the spec-required
-    non-empty FAIL is owned by the caller (``validate_description``
-    in ``validate_skill.py`` and the per-skill block in
-    ``audit_skill_system.py``), and stacking a trigger WARN on top
-    of that FAIL would be redundant.  The guard is kept so direct
-    API callers (e.g. ad-hoc scripts) can invoke the helper without
-    a separate non-empty check of their own.
+    valid wording — so the rule never escalates to FAIL: a legitimate
+    but unlisted trigger wording must not block the author.  Empty /
+    whitespace-only inputs short-circuit silently — the spec-required
+    non-empty FAIL is owned by the caller (``validate_description`` in
+    ``validate_skill.py`` and the per-skill block in
+    ``audit_skill_system.py``).
 
     Returns ``(errors, passes)`` per the standard validator contract.
     """
@@ -133,27 +168,39 @@ def validate_description_triggers(
     if not description or not description.strip():
         return errors, passes
 
-    lowered = description.lower()
-    for phrase in DESCRIPTION_TRIGGER_PHRASES:
-        if phrase in lowered:
-            passes.append(
-                f"description: contains trigger phrase '{phrase}'"
-            )
-            return errors, passes
+    matched = count_trigger_phrases(description)
+    count = len(matched)
 
-    # Build the example list from the curated example subset so the
-    # message never drifts from the YAML.  Examples are first-word
-    # distinct (different root verbs) for educational variety; the
-    # YAML pointer remains the canonical source for the full list.
-    example_phrases = ", ".join(
-        f"'{phrase.capitalize()} ...'"
-        for phrase in DESCRIPTION_TRIGGER_EXAMPLE_PHRASES
-    )
-    errors.append(
-        f"{LEVEL_WARN}: [spec] 'description' does not state when the skill "
-        f"activates — add a trigger clause (e.g. {example_phrases}).  "
-        "Phrase list configured under skill.description.trigger_phrases "
-        "in configuration.yaml."
+    if count == 0:
+        # Unchanged spec-tagged WARN.  Examples come from the curated
+        # first-word-distinct subset so the message never drifts from
+        # the YAML.
+        example_phrases = ", ".join(
+            f"'{phrase.capitalize()} ...'"
+            for phrase in DESCRIPTION_TRIGGER_EXAMPLE_PHRASES
+        )
+        errors.append(
+            f"{LEVEL_WARN}: [spec] 'description' does not state when the skill "
+            f"activates — add a trigger clause (e.g. {example_phrases}).  "
+            "Phrase list configured under skill.description.trigger_phrases "
+            "in configuration.yaml."
+        )
+        return errors, passes
+
+    if count < minimum_count:
+        errors.append(
+            f"{LEVEL_WARN}: [foundry] 'description' contains {count} distinct "
+            f"trigger phrase(s) (e.g. '{matched[0]}') but the foundry "
+            f"recommends at least {minimum_count} for routing precision — add "
+            "another trigger clause covering a different activation context.  "
+            "Phrase list configured under skill.description.trigger_phrases "
+            "in configuration.yaml."
+        )
+        return errors, passes
+
+    passes.append(
+        f"description: contains {count} trigger phrase(s) "
+        f"(>= {minimum_count}; e.g. '{matched[0]}')"
     )
     return errors, passes
 

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -4,6 +4,7 @@ import difflib
 import glob
 import os
 import re
+from collections import Counter
 
 from .constants import (
     MAX_NAME_CHARS, MIN_NAME_CHARS,
@@ -15,6 +16,12 @@ from .constants import (
     RE_MCP_TOOL_NAME, RE_HARNESS_TOOL_SHAPE,
     TOOL_FENCE_LANGUAGES, TOOLS_INDICATING_SCRIPTS,
     DESCRIPTION_TRIGGER_PHRASES, DESCRIPTION_TRIGGER_EXAMPLE_PHRASES,
+    DESCRIPTION_NEGATIVE_TRIGGER_PHRASES, DESCRIPTION_FILLER_PHRASES,
+    DESCRIPTION_BOUNDARY_PHRASES,
+    DESCRIPTION_LENGTH_WARN_BELOW, DESCRIPTION_LENGTH_WARN_ABOVE,
+    DESCRIPTION_VOCABULARY_MINIMUM, DESCRIPTION_VOCABULARY_LIST,
+    DESCRIPTION_REDUNDANCY_MIN_COUNT, DESCRIPTION_REDUNDANCY_MAX_RATIO,
+    DESCRIPTION_STRUCTURAL_STOPWORDS,
     CAPABILITY_SKILL_ONLY_FIELDS,
     DIR_CAPABILITIES, DIR_SCRIPTS,
     FILE_CAPABILITY_MD, FILE_SKILL_MD,
@@ -202,6 +209,257 @@ def validate_description_triggers(
         f"description: contains {count} trigger phrase(s) "
         f"(>= {minimum_count}; e.g. '{matched[0]}')"
     )
+    return errors, passes
+
+
+# Word-token pattern shared by the structural description rules.  Matches
+# a run beginning with an alphanumeric and optionally containing inner
+# apostrophes / hyphens (so "don't" and "ai-agnostic" tokenize as one
+# word).  Callers lowercase the text first.
+_RE_WORD_TOKEN = re.compile(r"[a-z0-9][a-z0-9'-]*")
+
+
+def _description_content_tokens(description: str) -> list[str]:
+    """Lowercase *description* and return word tokens with structural
+    stopwords removed.
+
+    Shared by the vocabulary (R7) and over-repetition (R9) rules so both
+    tokenize identically.  Trigger-scaffolding words (use / when /
+    triggers / ...) are part of ``DESCRIPTION_STRUCTURAL_STOPWORDS`` and
+    are therefore stripped here — the trigger phrasing R6 rewards must
+    not be re-counted as over-repetition.
+    """
+    return [
+        token
+        for token in _RE_WORD_TOKEN.findall(description.lower())
+        if token not in DESCRIPTION_STRUCTURAL_STOPWORDS
+    ]
+
+
+def validate_description_negative_triggers(
+    description: str,
+) -> tuple[list[str], list[str]]:
+    """R2 — note when the description includes a negative trigger.
+
+    Naming when the skill should *not* activate aids routing.  Presence
+    is informational (INFO); absence is silent (the clause is optional).
+    Case-insensitive substring match against
+    ``DESCRIPTION_NEGATIVE_TRIGGER_PHRASES``.
+
+    Returns ``(errors, passes)`` per the standard validator contract.
+    """
+    errors: list[str] = []
+    passes: list[str] = []
+    if not description or not description.strip():
+        return errors, passes
+    lowered = description.lower()
+    found = [p for p in DESCRIPTION_NEGATIVE_TRIGGER_PHRASES if p in lowered]
+    if found:
+        errors.append(
+            f"{LEVEL_INFO}: [foundry] 'description' includes a negative "
+            f"trigger ('{found[0]}') — this helps routing precision."
+        )
+    else:
+        passes.append("description: no negative trigger (optional)")
+    return errors, passes
+
+
+def validate_description_filler(
+    description: str,
+) -> tuple[list[str], list[str]]:
+    """R5 — flag a filler phrase with no concrete qualifier following.
+
+    WARN only when one of ``DESCRIPTION_FILLER_PHRASES`` appears and no
+    content (non-stopword, length >= 3) word follows it within the next
+    few tokens — i.e. the phrase trails into a stopword or the end of
+    the description.  "handles skill manifests" is fine; "handles
+    things" (no real qualifier) or a trailing "handles" is not.  The
+    look-ahead guard keeps legitimate uses of "handles" / "works with"
+    from firing.
+
+    Returns ``(errors, passes)`` per the standard validator contract.
+    """
+    errors: list[str] = []
+    passes: list[str] = []
+    if not description or not description.strip():
+        return errors, passes
+    lowered = description.lower()
+    flagged: list[str] = []
+    for phrase in DESCRIPTION_FILLER_PHRASES:
+        start = lowered.find(phrase)
+        while start != -1:
+            after = lowered[start + len(phrase):]
+            following = _RE_WORD_TOKEN.findall(after)[:3]
+            has_qualifier = any(
+                token not in DESCRIPTION_STRUCTURAL_STOPWORDS and len(token) >= 3
+                for token in following
+            )
+            if not has_qualifier:
+                flagged.append(phrase)
+                break
+            start = lowered.find(phrase, start + 1)
+    if flagged:
+        errors.append(
+            f"{LEVEL_WARN}: [foundry] 'description' uses filler phrase "
+            f"'{flagged[0]}' with no concrete qualifier following — replace "
+            "it with a specific action or object."
+        )
+    else:
+        passes.append("description: no vague filler phrases")
+    return errors, passes
+
+
+def validate_description_boundary(
+    description: str,
+) -> tuple[list[str], list[str]]:
+    """R8 — note when the description names a boundary against an adjacent skill.
+
+    A boundary clause ("X vs Y", "use Y instead") aids routing between
+    overlapping skills.  Presence is informational (INFO); absence is
+    silent.  Distinct from R2: R2 says "do not activate at all", R8 says
+    "which adjacent skill to use instead".  Match is case-insensitive
+    substring; boundary phrases keep their significant edge spaces
+    (" vs ").
+
+    Returns ``(errors, passes)`` per the standard validator contract.
+    """
+    errors: list[str] = []
+    passes: list[str] = []
+    if not description or not description.strip():
+        return errors, passes
+    lowered = description.lower()
+    found = [p for p in DESCRIPTION_BOUNDARY_PHRASES if p in lowered]
+    if found:
+        errors.append(
+            f"{LEVEL_INFO}: [foundry] 'description' names a boundary clause "
+            f"('{found[0].strip()}') — this aids routing between adjacent "
+            "skills."
+        )
+    else:
+        passes.append("description: no boundary clause (optional)")
+    return errors, passes
+
+
+def validate_description_length_tiers(
+    description: str,
+) -> tuple[list[str], list[str]]:
+    """R3 / R4 — advisory length-tier guidance.
+
+    The hard FAIL above ``MAX_DESCRIPTION_CHARS`` (1024) lives in
+    ``validate_description``.  This rule adds advisory INFOs at the soft
+    edges: below ``DESCRIPTION_LENGTH_WARN_BELOW`` (likely too terse for
+    reliable routing) and above ``DESCRIPTION_LENGTH_WARN_ABOVE``
+    (descriptions tend to grow during optimization; consider
+    compressing).  Never WARN or FAIL.
+
+    Returns ``(errors, passes)`` per the standard validator contract.
+    """
+    errors: list[str] = []
+    passes: list[str] = []
+    if not description or not description.strip():
+        return errors, passes
+    length = len(description)
+    if length < DESCRIPTION_LENGTH_WARN_BELOW:
+        errors.append(
+            f"{LEVEL_INFO}: [foundry] 'description' is {length} characters "
+            f"(< {DESCRIPTION_LENGTH_WARN_BELOW}) — consider expanding it with "
+            "more trigger contexts for routing precision."
+        )
+    elif length > DESCRIPTION_LENGTH_WARN_ABOVE:
+        errors.append(
+            f"{LEVEL_INFO}: [foundry] 'description' is {length} characters "
+            f"(> {DESCRIPTION_LENGTH_WARN_ABOVE}) — consider compressing it; "
+            "descriptions tend to grow during optimization."
+        )
+    else:
+        passes.append(
+            f"description: length {length} within advisory tiers "
+            f"({DESCRIPTION_LENGTH_WARN_BELOW}-{DESCRIPTION_LENGTH_WARN_ABOVE})"
+        )
+    return errors, passes
+
+
+def validate_description_vocabulary(
+    description: str,
+) -> tuple[list[str], list[str]]:
+    """R7 — optional domain-vocabulary presence.
+
+    Counts the distinct tokens from ``DESCRIPTION_VOCABULARY_LIST``
+    present in the description and emits an INFO when fewer than
+    ``DESCRIPTION_VOCABULARY_MINIMUM`` appear.  The list is
+    integrator-owned: when it is empty the rule is inert (returns no
+    findings at all) so it never biases skills outside the foundry's
+    domain.  INFO only — "specificity" is a soft signal.
+
+    Returns ``(errors, passes)`` per the standard validator contract.
+    """
+    errors: list[str] = []
+    passes: list[str] = []
+    if not DESCRIPTION_VOCABULARY_LIST:
+        return errors, passes
+    if not description or not description.strip():
+        return errors, passes
+    present = set(_description_content_tokens(description))
+    matched = sorted(present.intersection(DESCRIPTION_VOCABULARY_LIST))
+    if len(matched) >= DESCRIPTION_VOCABULARY_MINIMUM:
+        passes.append(
+            f"description: {len(matched)} domain-vocabulary token(s) "
+            f"(>= {DESCRIPTION_VOCABULARY_MINIMUM})"
+        )
+    else:
+        errors.append(
+            f"{LEVEL_INFO}: [foundry] 'description' includes {len(matched)} "
+            f"domain-vocabulary token(s) (recommended >= "
+            f"{DESCRIPTION_VOCABULARY_MINIMUM}) — consider adding more specific "
+            "domain terms.  Vocabulary configured under "
+            "skill.description.structural_rules.vocabulary_list."
+        )
+    return errors, passes
+
+
+def validate_description_redundancy(
+    description: str,
+) -> tuple[list[str], list[str]]:
+    """R9 — flag a single content word that dominates the description.
+
+    A word that both repeats at least ``DESCRIPTION_REDUNDANCY_MIN_COUNT``
+    times and makes up at least ``DESCRIPTION_REDUNDANCY_MAX_RATIO`` of
+    all content tokens signals padding.  The ratio gate makes the rule
+    length-independent: a long, varied description that repeats its
+    subject noun a dozen times stays silent, while a short description
+    where one word is a fifth of the content trips.  Stopwords (incl.
+    trigger scaffolding) are stripped first; tokens shorter than three
+    characters are not counted.  WARN only.
+
+    Returns ``(errors, passes)`` per the standard validator contract.
+    """
+    errors: list[str] = []
+    passes: list[str] = []
+    if not description or not description.strip():
+        return errors, passes
+    content = [
+        token
+        for token in _description_content_tokens(description)
+        if len(token) >= 3
+    ]
+    if not content:
+        return errors, passes
+    word, occurrences = Counter(content).most_common(1)[0]
+    ratio = occurrences / len(content)
+    if (
+        occurrences >= DESCRIPTION_REDUNDANCY_MIN_COUNT
+        and ratio >= DESCRIPTION_REDUNDANCY_MAX_RATIO
+    ):
+        errors.append(
+            f"{LEVEL_WARN}: [foundry] 'description' repeats '{word}' "
+            f"{occurrences} times ({ratio:.0%} of content words) — likely "
+            "padding; vary the wording or compress."
+        )
+    else:
+        passes.append(
+            f"description: no over-repeated content word "
+            f"(top '{word}' {occurrences}x, {ratio:.0%})"
+        )
     return errors, passes
 
 

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -366,10 +366,12 @@ def validate_description_boundary(
     lowered = description.lower()
     found = [p for p in DESCRIPTION_BOUNDARY_PHRASES if p in lowered]
     if found:
+        # Render the matched phrase verbatim (no strip): boundary phrases
+        # keep significant edge spaces (" vs "), and stripping them would
+        # imply the bare word ("vs") matches when only " vs " does.
         errors.append(
             f"{LEVEL_INFO}: [foundry] 'description' names a boundary clause "
-            f"('{found[0].strip()}') — this aids routing between adjacent "
-            "skills."
+            f"('{found[0]}') — this aids routing between adjacent skills."
         )
     else:
         passes.append("description: no boundary clause (optional)")

--- a/skill-system-foundry/scripts/lib/validation.py
+++ b/skill-system-foundry/scripts/lib/validation.py
@@ -5,6 +5,7 @@ import glob
 import os
 import re
 from collections import Counter
+from itertools import islice
 
 from .constants import (
     MAX_NAME_CHARS, MIN_NAME_CHARS,
@@ -219,6 +220,19 @@ def validate_description_triggers(
 _RE_WORD_TOKEN = re.compile(r"[a-z0-9][a-z0-9'-]*")
 
 
+# Pre-compiled word-boundary patterns for each R5 filler phrase.  The
+# phrase list is fixed once ``constants`` loads, so recompiling per phrase
+# on every call is pure repeated work; build the ``(phrase, pattern)``
+# pairs once at import.  ``re.escape`` keeps a phrase containing regex
+# metacharacters literal, and the ``(?<![a-z0-9]) ... (?![a-z0-9])``
+# guards reproduce the word-boundary match exactly (so "handles" does not
+# fire inside "mishandles").
+_FILLER_PHRASE_PATTERNS = tuple(
+    (phrase, re.compile(r"(?<![a-z0-9])" + re.escape(phrase) + r"(?![a-z0-9])"))
+    for phrase in DESCRIPTION_FILLER_PHRASES
+)
+
+
 def _description_content_tokens(description: str) -> list[str]:
     """Lowercase *description* and return word tokens with structural
     stopwords removed.
@@ -288,16 +302,25 @@ def validate_description_filler(
         return errors, passes
     lowered = description.lower()
     flagged: list[str] = []
-    for phrase in DESCRIPTION_FILLER_PHRASES:
-        # Word-boundary guards (no alphanumeric immediately before/after)
-        # so a single-word phrase like "handles" does not match inside
-        # "mishandles".  Phrases are already lowercased in constants.
-        pattern = re.compile(
-            r"(?<![a-z0-9])" + re.escape(phrase) + r"(?![a-z0-9])"
-        )
+    for phrase, pattern in _FILLER_PHRASE_PATTERNS:
+        # Patterns are pre-compiled at import (see _FILLER_PHRASE_PATTERNS);
+        # their word-boundary guards mean a single-word phrase like
+        # "handles" does not match inside "mishandles".  Phrases are
+        # already lowercased in constants.
         for match in pattern.finditer(lowered):
-            after = lowered[match.end():]
-            following = _RE_WORD_TOKEN.findall(after)[:DESCRIPTION_FILLER_LOOKAHEAD]
+            # Look ahead at the next DESCRIPTION_FILLER_LOOKAHEAD word
+            # tokens after the phrase.  ``finditer`` with an explicit
+            # start position scans the original string in place (no tail
+            # slice), and ``islice`` halts the lazy scan once the window
+            # is full — so the work is bounded by the look-ahead window
+            # rather than the remaining description length.
+            following = [
+                m.group()
+                for m in islice(
+                    _RE_WORD_TOKEN.finditer(lowered, match.end()),
+                    DESCRIPTION_FILLER_LOOKAHEAD,
+                )
+            ]
             has_qualifier = any(
                 token not in DESCRIPTION_STRUCTURAL_STOPWORDS and len(token) >= 3
                 for token in following

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -43,6 +43,12 @@ from lib.validation import (
     validate_name,
     validate_allowed_tools,
     validate_description_triggers,
+    validate_description_negative_triggers,
+    validate_description_filler,
+    validate_description_boundary,
+    validate_description_length_tiers,
+    validate_description_vocabulary,
+    validate_description_redundancy,
     validate_metadata,
     validate_license,
     validate_known_keys,
@@ -58,6 +64,7 @@ from lib.constants import (
     MAX_BODY_LINES, MAX_COMPATIBILITY_CHARS,
     RE_XML_TAG, RE_FIRST_PERSON, RE_FIRST_PERSON_PLURAL,
     RE_SECOND_PERSON, RE_IMPERATIVE_START,
+    DESCRIPTION_TRIGGER_MIN_COUNT,
     RECOGNIZED_DIRS,
     DIR_CAPABILITIES,
     FILE_SKILL_MD, FILE_CAPABILITY_MD, SEPARATOR_WIDTH,
@@ -147,9 +154,27 @@ def validate_description(description: str) -> tuple[list[str], list[str]]:
     else:
         passes.append("description: third-person voice")
 
-    trigger_errors, trigger_passes = validate_description_triggers(description)
+    trigger_errors, trigger_passes = validate_description_triggers(
+        description, minimum_count=DESCRIPTION_TRIGGER_MIN_COUNT,
+    )
     errors.extend(trigger_errors)
     passes.extend(trigger_passes)
+
+    # Structural description-quality rules (R2-R9).  Each returns
+    # (errors, passes) and accumulates into the existing FAIL / WARN /
+    # INFO streams; all are advisory (INFO / WARN), none introduce a
+    # FAIL.  Settings live under skill.description.structural_rules.
+    for structural_rule in (
+        validate_description_negative_triggers,
+        validate_description_filler,
+        validate_description_boundary,
+        validate_description_length_tiers,
+        validate_description_vocabulary,
+        validate_description_redundancy,
+    ):
+        rule_errors, rule_passes = structural_rule(description)
+        errors.extend(rule_errors)
+        passes.extend(rule_passes)
 
     return errors, passes
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -2,7 +2,9 @@ import os
 
 
 DEFAULT_DESCRIPTION = (
-    "Packages a minimal demo skill. Use when running bundling smoke tests."
+    "Packages a minimal demo skill into a bundle and runs validation over its "
+    "manifest and frontmatter. Triggers when a skill is scaffolded; use when "
+    "running bundling smoke tests across the workflow."
 )
 
 

--- a/tests/test_capability_lift.py
+++ b/tests/test_capability_lift.py
@@ -115,8 +115,9 @@ def _mechanical_lift(parent_skill: str, capability_name: str, dest: str) -> None
             "---\n"
             f"name: {capability_name}\n"
             "description: >\n"
-            f"  Lifted from a capability for testing — triggers when "
-            f"exercising the {capability_name} workflow end to end.\n"
+            f"  Lifted from the {capability_name} capability for testing — "
+            f"triggers when exercising the {capability_name} workflow; use "
+            "when validating the lift end to end.\n"
             "---\n"
         )
         with open(skill_md, "w", encoding="utf-8") as f:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -143,6 +143,23 @@ class AllowedOrphansConfigTests(unittest.TestCase):
             "      recommended_prompts_per_side: 8\n"
             "      stopwords:\n"
             "        - the\n"
+            "    structural_rules:\n"
+            "      trigger_minimum_count: 2\n"
+            "      negative_trigger_phrases:\n"
+            "        - do not use\n"
+            "      filler_phrases:\n"
+            "        - helps with\n"
+            "      boundary_clause_phrases:\n"
+            "        - \" vs \"\n"
+            "      length_tier_warn_below: 200\n"
+            "      length_tier_warn_above: 800\n"
+            "      vocabulary_minimum: 3\n"
+            "      vocabulary_list:\n"
+            "        - validation\n"
+            "      redundancy_min_count: 5\n"
+            "      redundancy_max_ratio: 0.22\n"
+            "      stopwords:\n"
+            "        - the\n"
             "  body:\n"
             "    max_lines: 500\n"
             "    reference_patterns:\n"
@@ -1095,6 +1112,50 @@ class MissingSectionFailFastTests(unittest.TestCase):
                 self._full_config_minus_nested("description", "evaluation")
             )
         self.assertIn("evaluation", str(ctx.exception))
+
+    def test_missing_description_structural_rules_block_raises(self) -> None:
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_minus_nested(
+                    "description", "structural_rules",
+                )
+            )
+        self.assertIn("structural_rules", str(ctx.exception))
+
+    def test_invalid_structural_trigger_minimum_count_raises(self) -> None:
+        # A minimum below 1 would make the graduated trigger rule
+        # meaningless.  Loader must refuse it.
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_with_substitution(
+                    "trigger_minimum_count: 2", "trigger_minimum_count: 0",
+                )
+            )
+        self.assertIn("trigger_minimum_count", str(ctx.exception))
+
+    def test_invalid_structural_redundancy_ratio_raises(self) -> None:
+        # The redundancy ratio is a fraction in (0.0, 1.0]; a value > 1
+        # could never fire and signals a config edit accident.
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_with_substitution(
+                    "redundancy_max_ratio: 0.22", "redundancy_max_ratio: 1.5",
+                )
+            )
+        self.assertIn("redundancy_max_ratio", str(ctx.exception))
+
+    def test_structural_boundary_phrases_preserve_edge_spaces(self) -> None:
+        # Boundary clauses rely on significant leading/trailing spaces
+        # (" vs " must not match "vs" inside a word), so the loader
+        # lowercases but does not strip them.
+        self.assertIn(" vs ", constants.DESCRIPTION_BOUNDARY_PHRASES)
+
+    def test_structural_stopwords_strip_trigger_scaffolding(self) -> None:
+        # Trigger-scaffolding words are stripped during R7/R9
+        # tokenization so the trigger phrasing R6 rewards is not also
+        # counted as over-repetition.
+        for word in ("when", "use", "triggers"):
+            self.assertIn(word, constants.DESCRIPTION_STRUCTURAL_STOPWORDS)
 
     def test_missing_evaluation_key_raises(self) -> None:
         with self.assertRaises(RuntimeError) as ctx:

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -149,6 +149,7 @@ class AllowedOrphansConfigTests(unittest.TestCase):
             "        - do not use\n"
             "      filler_phrases:\n"
             "        - helps with\n"
+            "      filler_lookahead_tokens: 3\n"
             "      boundary_clause_phrases:\n"
             "        - \" vs \"\n"
             "      length_tier_warn_below: 200\n"
@@ -1143,6 +1144,23 @@ class MissingSectionFailFastTests(unittest.TestCase):
                 )
             )
         self.assertIn("redundancy_max_ratio", str(ctx.exception))
+
+    def test_invalid_structural_filler_lookahead_raises(self) -> None:
+        # The filler look-ahead window must be at least one token.
+        with self.assertRaises(RuntimeError) as ctx:
+            self._reimport_with_config(
+                self._full_config_with_substitution(
+                    "filler_lookahead_tokens: 3", "filler_lookahead_tokens: 0",
+                )
+            )
+        self.assertIn("filler_lookahead_tokens", str(ctx.exception))
+
+    def test_structural_filler_lookahead_loaded(self) -> None:
+        self.assertGreaterEqual(constants.DESCRIPTION_FILLER_LOOKAHEAD, 1)
+
+    def test_structural_stopwords_include_generic_things(self) -> None:
+        # "things" is a stopword so "handles things" trips the filler rule.
+        self.assertIn("things", constants.DESCRIPTION_STRUCTURAL_STOPWORDS)
 
     def test_structural_boundary_phrases_preserve_edge_spaces(self) -> None:
         # Boundary clauses rely on significant leading/trailing spaces

--- a/tests/test_validate_examples_script.py
+++ b/tests/test_validate_examples_script.py
@@ -68,9 +68,10 @@ def _write(path: str, content: str) -> None:
 def _write_minimal_skill(skill_dir: str, *, name: str) -> None:
     """Create a minimal valid skill at *skill_dir* with directory name *name*."""
     description = (
-        "Greets a single recipient with a one-line message. "
-        "Test fixture used by the validate-examples CI helper. "
-        "Activates only when the conversation explicitly asks for a hello."
+        "Validates a minimal demo skill fixture for the validate-examples "
+        "helper, checking its manifest and frontmatter. Triggers when an "
+        "example skill is scaffolded; use when running validation smoke tests "
+        "across the workflow."
     )
     content = textwrap.dedent(
         f"""\

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -283,11 +283,14 @@ class ValidateDescriptionTests(unittest.TestCase):
         self.assertEqual(len(voice_pass), 1)
 
     def test_description_with_trigger_phrase_emits_no_trigger_warn(self) -> None:
-        """A description containing a configured trigger phrase emits no
-        trigger-clause WARN through the end-to-end validate_description."""
+        """A description meeting the foundry trigger minimum emits no
+        trigger-clause WARN through the end-to-end validate_description.
+
+        validate_description requests DESCRIPTION_TRIGGER_MIN_COUNT (2)
+        distinct trigger phrases, so the fixture carries two."""
         desc = (
             "Manages project timelines and tracks milestones. Triggers when "
-            "a milestone changes."
+            "a milestone changes; use when planning a sprint."
         )
         errors, passes = validate_description(desc)
         trigger_warns = [
@@ -309,6 +312,34 @@ class ValidateDescriptionTests(unittest.TestCase):
         ]
         self.assertEqual(len(trigger_warns), 1)
         self.assertIn("[spec]", trigger_warns[0])
+
+    def test_structural_rules_invoked_end_to_end(self) -> None:
+        """validate_description routes through the structural rules: a poor
+        description surfaces the R6 (one-trigger), R5 (filler), and R3
+        (short) findings together."""
+        desc = "Validates skills. Use when needed. Handles."
+        errors, _ = validate_description(desc)
+        joined = " ".join(errors)
+        # R6: one distinct trigger, below the foundry minimum of two.
+        self.assertIn("at least", joined)
+        # R5: trailing filler phrase with no concrete qualifier.
+        self.assertIn("filler phrase", joined)
+        # R3: under the lower length tier.
+        self.assertIn("characters (<", joined)
+
+    def test_clean_description_has_no_warn_or_fail(self) -> None:
+        """A well-formed description (>= 2 triggers, >= 3 vocabulary tokens,
+        within the length tiers, no filler/redundancy) produces no FAIL or
+        WARN through the full validate_description path."""
+        desc = (
+            "Packages a minimal demo skill into a bundle and runs validation "
+            "over its manifest and frontmatter. Triggers when a skill is "
+            "scaffolded; use when running bundling smoke tests across the "
+            "workflow."
+        )
+        errors, _ = validate_description(desc)
+        self.assertEqual([e for e in errors if e.startswith(LEVEL_FAIL)], [])
+        self.assertEqual([e for e in errors if e.startswith(LEVEL_WARN)], [])
 
 
 # ===================================================================
@@ -4085,8 +4116,9 @@ class ValidateSkillOptionalFieldsTests(unittest.TestCase):
             write_text(
                 os.path.join(skill_dir, "SKILL.md"),
                 "---\nname: demo-skill\n"
-                "description: Validates data files and generates reports. "
-                "Triggers when a data file is touched.\n"
+                "description: Validates data files and generates reports over "
+                "a configured pipeline. Triggers when a data file changes; "
+                "use when running the validation workflow.\n"
                 "compatibility: Requires Python 3.12 or later.\n"
                 "allowed-tools: bash git python\n"
                 "license: MIT\n"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1277,11 +1277,23 @@ class StructuralDescriptionRuleTests(unittest.TestCase):
         self.assertIn("boundary clause", infos[0])
 
     def test_boundary_use_instead_emits_info(self) -> None:
+        # Natural "use Y instead" wording is detected via the "instead"
+        # substring (the contiguous "use instead" never appears in real
+        # descriptions).
         errors, _ = validate_description_boundary(
-            "Handles structured data; for logs use instead the log skill."
+            "Handles structured data; for raw logs use the log skill instead."
         )
         infos = [e for e in errors if e.startswith(LEVEL_INFO)]
         self.assertEqual(len(infos), 1)
+
+    def test_boundary_message_preserves_edge_spaces(self) -> None:
+        # The INFO message renders the matched phrase verbatim so the
+        # significant edge spaces of " vs " are visible (not stripped to
+        # the bare "vs", which would not match on its own).
+        errors, _ = validate_description_boundary(
+            "Routes cache vs database lookups."
+        )
+        self.assertIn("' vs '", errors[0])
 
     def test_boundary_edge_spaces_avoid_substring_false_positive(self) -> None:
         # " vs " carries significant edge spaces, so "vs" inside a word

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,6 +10,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 SCRIPTS_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "skill-system-foundry", "scripts")
@@ -18,12 +19,19 @@ if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
 from helpers import write_capability_md, write_skill_md, write_text
+from lib import validation as validation_mod
 from lib.validation import (
     aggregate_capability_allowed_tools,
     parse_allowed_tools_tokens,
     validate_capability_skill_only_fields,
     count_trigger_phrases,
     validate_description_triggers,
+    validate_description_negative_triggers,
+    validate_description_filler,
+    validate_description_boundary,
+    validate_description_length_tiers,
+    validate_description_vocabulary,
+    validate_description_redundancy,
     validate_name,
     validate_tool_coherence,
 )
@@ -1182,6 +1190,180 @@ class ValidateDescriptionTriggersTests(unittest.TestCase):
         self.assertEqual(errors, [])
         self.assertEqual(len(passes), 1)
         self.assertIn(">= 2", passes[0])
+
+
+# ===================================================================
+# Structural description rules (R2, R3/R4, R5, R7, R8, R9)
+# ===================================================================
+
+
+class StructuralDescriptionRuleTests(unittest.TestCase):
+    """Tests for the structural description-quality validators."""
+
+    # --- R2: negative triggers (INFO when present) ---
+
+    def test_negative_trigger_present_emits_info(self) -> None:
+        errors, passes = validate_description_negative_triggers(
+            "Processes data. Do not use for raw log analysis."
+        )
+        infos = [e for e in errors if e.startswith(LEVEL_INFO)]
+        self.assertEqual(len(infos), 1)
+        self.assertIn("negative trigger", infos[0])
+        self.assertEqual(passes, [])
+
+    def test_negative_trigger_absent_is_silent_pass(self) -> None:
+        errors, passes = validate_description_negative_triggers(
+            "Processes data. Triggers when a file changes."
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+
+    def test_negative_trigger_empty_short_circuits(self) -> None:
+        for value in ("", "   "):
+            errors, passes = validate_description_negative_triggers(value)
+            self.assertEqual((errors, passes), ([], []))
+
+    # --- R5: filler detection (WARN when no qualifier follows) ---
+
+    def test_filler_trailing_emits_warn(self) -> None:
+        errors, _ = validate_description_filler("This skill handles.")
+        warns = [e for e in errors if e.startswith(LEVEL_WARN)]
+        self.assertEqual(len(warns), 1)
+        self.assertIn("filler phrase", warns[0])
+
+    def test_filler_followed_by_stopword_emits_warn(self) -> None:
+        errors, _ = validate_description_filler("It handles the and the.")
+        warns = [e for e in errors if e.startswith(LEVEL_WARN)]
+        self.assertEqual(len(warns), 1)
+
+    def test_filler_with_concrete_qualifier_passes(self) -> None:
+        errors, passes = validate_description_filler(
+            "It handles skill manifests and reports drift."
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+
+    def test_filler_absent_passes(self) -> None:
+        errors, passes = validate_description_filler(
+            "Validates skills and audits systems."
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+
+    # --- R8: boundary clauses (INFO when present) ---
+
+    def test_boundary_vs_clause_emits_info(self) -> None:
+        errors, _ = validate_description_boundary(
+            "Routes requests for cache vs database lookups."
+        )
+        infos = [e for e in errors if e.startswith(LEVEL_INFO)]
+        self.assertEqual(len(infos), 1)
+        self.assertIn("boundary clause", infos[0])
+
+    def test_boundary_use_instead_emits_info(self) -> None:
+        errors, _ = validate_description_boundary(
+            "Handles structured data; for logs use instead the log skill."
+        )
+        infos = [e for e in errors if e.startswith(LEVEL_INFO)]
+        self.assertEqual(len(infos), 1)
+
+    def test_boundary_edge_spaces_avoid_substring_false_positive(self) -> None:
+        # " vs " carries significant edge spaces, so "vs" inside a word
+        # (e.g. "services") must not trip the rule.
+        errors, passes = validate_description_boundary(
+            "Manages services and servers across regions."
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+
+    # --- R3 / R4: length tiers (INFO at the soft edges) ---
+
+    def test_length_below_tier_emits_info(self) -> None:
+        errors, _ = validate_description_length_tiers("Short description.")
+        infos = [e for e in errors if e.startswith(LEVEL_INFO)]
+        self.assertEqual(len(infos), 1)
+        self.assertIn("consider expanding", infos[0])
+
+    def test_length_above_tier_emits_info(self) -> None:
+        errors, _ = validate_description_length_tiers("x" * 801)
+        infos = [e for e in errors if e.startswith(LEVEL_INFO)]
+        self.assertEqual(len(infos), 1)
+        self.assertIn("consider compressing", infos[0])
+
+    def test_length_within_tiers_passes(self) -> None:
+        errors, passes = validate_description_length_tiers("y" * 400)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+
+    def test_length_tiers_never_fail_or_warn(self) -> None:
+        for desc in ("a", "z" * 5000):
+            errors, _ = validate_description_length_tiers(desc)
+            self.assertFalse(
+                any(
+                    e.startswith(LEVEL_FAIL) or e.startswith(LEVEL_WARN)
+                    for e in errors
+                )
+            )
+
+    # --- R7: domain-vocabulary presence (INFO, opt-in) ---
+
+    def test_vocabulary_below_minimum_emits_info(self) -> None:
+        errors, _ = validate_description_vocabulary(
+            "Greets people warmly and remembers their names."
+        )
+        infos = [e for e in errors if e.startswith(LEVEL_INFO)]
+        self.assertEqual(len(infos), 1)
+        self.assertIn("domain-vocabulary", infos[0])
+
+    def test_vocabulary_meets_minimum_passes(self) -> None:
+        errors, passes = validate_description_vocabulary(
+            "Validation, audit, and bundling of skill manifests."
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+
+    def test_vocabulary_empty_list_disables_rule(self) -> None:
+        # An empty vocabulary list makes the rule inert (no findings at
+        # all) so it never biases skills outside the foundry's domain.
+        with mock.patch.object(
+            validation_mod, "DESCRIPTION_VOCABULARY_LIST", (),
+        ):
+            errors, passes = validate_description_vocabulary(
+                "Greets people warmly with no domain terms at all."
+            )
+        self.assertEqual((errors, passes), ([], []))
+
+    # --- R9: over-repetition (ratio-gated WARN) ---
+
+    def test_redundancy_dominant_word_emits_warn(self) -> None:
+        errors, _ = validate_description_redundancy(
+            "data data data data data data analysis report summary."
+        )
+        warns = [e for e in errors if e.startswith(LEVEL_WARN)]
+        self.assertEqual(len(warns), 1)
+        self.assertIn("repeats 'data'", warns[0])
+
+    def test_redundancy_varied_description_passes(self) -> None:
+        errors, passes = validate_description_redundancy(
+            "Validates skills, audits systems, bundles manifests, "
+            "scaffolds roles, and migrates routers."
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+
+    def test_redundancy_high_count_low_ratio_passes(self) -> None:
+        # A word repeated >= the count floor but well under the ratio
+        # threshold (long, varied description) must not trip the rule.
+        body = " ".join(f"term{i}" for i in range(60))
+        desc = ("review " * 5) + body
+        errors, passes = validate_description_redundancy(desc)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+
+    def test_redundancy_empty_short_circuits(self) -> None:
+        for value in ("", "   ", "the a an of"):
+            errors, passes = validate_description_redundancy(value)
+            self.assertEqual((errors, passes), ([], []))
 
 
 # ===================================================================

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -22,6 +22,7 @@ from lib.validation import (
     aggregate_capability_allowed_tools,
     parse_allowed_tools_tokens,
     validate_capability_skill_only_fields,
+    count_trigger_phrases,
     validate_description_triggers,
     validate_name,
     validate_tool_coherence,
@@ -1118,6 +1119,69 @@ class ValidateDescriptionTriggersTests(unittest.TestCase):
             None,
         )
         self.assertIsNotNone(matched)
+
+    # --- count_trigger_phrases helper ---
+
+    def test_count_trigger_phrases_returns_distinct_sorted(self) -> None:
+        # Two distinct phrases present; helper returns both in the
+        # configured (sorted) order.
+        desc = (
+            "Audits skill systems. Triggers on drift; use when the "
+            "structure may have changed."
+        )
+        matched = count_trigger_phrases(desc)
+        self.assertEqual(matched, sorted(matched))
+        self.assertIn("triggers on", matched)
+        self.assertIn("use when", matched)
+
+    def test_count_trigger_phrases_empty_input(self) -> None:
+        for value in ("", "   ", "\n\t "):
+            self.assertEqual(count_trigger_phrases(value), [])
+
+    def test_count_trigger_phrases_no_match(self) -> None:
+        self.assertEqual(
+            count_trigger_phrases("Validates skills and reports findings."), []
+        )
+
+    # --- Graduated minimum_count behaviour ---
+
+    def test_default_minimum_count_passes_at_one(self) -> None:
+        # Default minimum_count=1 reproduces the historical behaviour:
+        # a single trigger phrase passes (keeps audit_skill_system.py
+        # unchanged).
+        desc = "Validates skills. Triggers when a skill is created."
+        errors, passes = validate_description_triggers(desc)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+
+    def test_minimum_count_two_one_match_emits_foundry_warn(self) -> None:
+        desc = "Validates skills. Triggers when a skill is created."
+        errors, passes = validate_description_triggers(desc, minimum_count=2)
+        warns = [e for e in errors if e.startswith(LEVEL_WARN)]
+        self.assertEqual(len(warns), 1)
+        self.assertIn("[foundry]", warns[0])
+        self.assertIn("at least 2", warns[0])
+        self.assertEqual(passes, [])
+
+    def test_minimum_count_two_zero_match_emits_spec_warn(self) -> None:
+        # Zero matches always emits the unchanged spec WARN regardless
+        # of the minimum — never the foundry "add another" message.
+        desc = "Validates skills and reports findings to stdout."
+        errors, _ = validate_description_triggers(desc, minimum_count=2)
+        warns = [e for e in errors if e.startswith(LEVEL_WARN)]
+        self.assertEqual(len(warns), 1)
+        self.assertIn("[spec]", warns[0])
+        self.assertIn("when the skill activates", warns[0])
+
+    def test_minimum_count_two_two_matches_pass(self) -> None:
+        desc = (
+            "Validates skills. Triggers on creation; use when the "
+            "structure may have drifted."
+        )
+        errors, passes = validate_description_triggers(desc, minimum_count=2)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+        self.assertIn(">= 2", passes[0])
 
 
 # ===================================================================

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1250,6 +1250,22 @@ class StructuralDescriptionRuleTests(unittest.TestCase):
         self.assertEqual(errors, [])
         self.assertEqual(len(passes), 1)
 
+    def test_filler_handles_things_emits_warn(self) -> None:
+        # The documented vague case: "things" is a stopword, so it is
+        # not a concrete qualifier and the filler phrase trips.
+        errors, _ = validate_description_filler("This skill handles things.")
+        warns = [e for e in errors if e.startswith(LEVEL_WARN)]
+        self.assertEqual(len(warns), 1)
+
+    def test_filler_substring_inside_word_not_flagged(self) -> None:
+        # "handles" must match on a word boundary, so a description that
+        # only contains it inside "mishandles" does not trip the rule.
+        errors, passes = validate_description_filler(
+            "Detects when the parser mishandles malformed manifest input."
+        )
+        self.assertEqual(errors, [])
+        self.assertEqual(len(passes), 1)
+
     # --- R8: boundary clauses (INFO when present) ---
 
     def test_boundary_vs_clause_emits_info(self) -> None:


### PR DESCRIPTION
## Summary

Adds eight structural description-quality checks to `validate_skill.py`, layered on top of the existing length, XML-tag, voice, and trigger-presence rules. Every check routes through the existing FAIL / WARN / INFO machinery with all phrase lists and thresholds in `configuration.yaml` — no corpus, no API tokens, and no new entry point, so the checks run wherever `validate_skill.py` already runs.

## Checks added

- **Trigger-clause strength** — recommends at least two distinct trigger phrases (warns at zero or one, passes at two or more). Reuses the configured trigger-phrase list and never fails, since a heuristic that cannot enumerate every valid wording must not block authors.
- **Negative trigger** — notes a "don't use when…" clause when present.
- **Length tiers** — advisory note below 160 or above 800 characters.
- **Filler detection** — warns on phrases like "helps with" / "handles" only when no concrete (non-stopword) word follows within the next few tokens, so "handles skill manifests" passes while a trailing "handles" trips.
- **Domain vocabulary** — notes when fewer than the configured number of domain terms appear; the vocabulary list is integrator-owned and an empty list disables the check entirely.
- **Boundary clause** — notes an "X vs Y" / "use Y instead" clause when present.
- **Over-repetition** — warns when one content word both repeats past a floor and dominates the description, using a length-normalized ratio so a description that legitimately repeats its subject noun does not trip.

## Trigger-rule refactor

The existing trigger check is split into a pure `count_trigger_phrases` helper and a `validate_description_triggers` that takes a keyword-only `minimum_count`. The default preserves the current behaviour, so `audit_skill_system.py` is unaffected; `validate_description` opts into the stricter two-phrase minimum.

## Changes

- `scripts/lib/configuration.yaml`: add the `skill.description.structural_rules` block (trigger minimum, phrase lists, length tiers, opt-in vocabulary, redundancy count + ratio, tokenization stopwords).
- `scripts/lib/constants.py`: load the new keys as typed constants with fail-fast validation mirroring the existing loaders.
- `scripts/lib/validation.py`: add the six rule functions, the `count_trigger_phrases` helper, and the `minimum_count` refactor.
- `scripts/validate_skill.py`: invoke the new rules from `validate_description`.
- `references/authoring-principles.md`: document the structural checks and point to `configuration.yaml` as the canonical source.
- `examples/skills/hello-greeter`, `examples/skills/hello-router`: give the reference examples two trigger clauses and domain vocabulary so they model the guidance and validate cleanly.
- `tests/`: unit tests for every rule, the helper, and the graduated trigger tiers; end-to-end wiring tests; fail-fast config tests; and fixture updates for the stricter happy path.

## Design notes

- `length_tier_warn_below` is set to 160 so the lower advisory tier sits below the `bundle.description_max_length` cap (200, enforced for the claude target); a maximally-sized claude description is not simultaneously flagged as too short, and every shipped foundry description stays clean.
- Over-repetition uses a count-and-ratio gate rather than a raw repeat count, so descriptions that legitimately repeat a domain noun are not flagged.
- The meta-skill's own description satisfies the new trigger minimum: it was reworded to carry two distinct trigger phrases ("Triggers on …; use when …") within the bundler's `claude`-target description cap (now 184 characters), so the documented self-check (`validate_skill.py . --foundry-self`) reports zero warnings.

## Verification

- `python -m coverage run -m unittest discover -s tests -p "test_*.py"` — full suite passes; branch coverage 95% (validation.py 98%, constants.py 86%) against the 70% gate.
- `validate_skill.py . --allow-nested-references --foundry-self` — exit 0.
- `audit_skill_system.py .` — exit 0.
- `.github/scripts/validate-examples.py` — both example skills and their capabilities validate with zero findings.
- Validation against the meta-skill and every `.agents/skills` skill — zero FAILs.

Refs #133


