### PR TITLE
Fix release-prep dispatch startup failure and unmapped changelog verbs

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -186,8 +186,20 @@ jobs:
   test:
     needs: prepare
     if: ${{ ! inputs.dry_run }}
+    # A called workflow's jobs cannot request more permission than the
+    # caller grants, and GitHub validates that cap at startup — before
+    # job-level ``if`` skips are evaluated.  python-tests.yaml's
+    # ``update-badge`` job declares ``contents: write``; even though it
+    # is skipped under ``workflow_call`` (its ``if`` requires a push to
+    # main), the declared scope is still checked, so the caller must
+    # grant ``contents: write`` or the whole dispatch fails to compile
+    # with a logless ``startup_failure``.  The reusable jobs that do run
+    # on this call (test, validate-examples, reference-conformance,
+    # bundle-extract-smoke) each declare ``contents: read`` and narrow
+    # themselves back down; this grant only satisfies the compile-time
+    # cap for the skipped badge job.
     permissions:
-      contents: read
+      contents: write
     uses: ./.github/workflows/python-tests.yaml
     with:
       ref: ${{ needs.prepare.outputs.branch }}

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -193,11 +193,11 @@ jobs:
     # is skipped under ``workflow_call`` (its ``if`` requires a push to
     # main), the declared scope is still checked, so the caller must
     # grant ``contents: write`` or the whole dispatch fails to compile
-    # with a logless ``startup_failure``.  The reusable jobs that do run
-    # on this call (test, validate-examples, reference-conformance,
-    # bundle-extract-smoke) each declare ``contents: read`` and narrow
-    # themselves back down; this grant only satisfies the compile-time
-    # cap for the skipped badge job.
+    # with a logless ``startup_failure``.  python-tests.yaml defaults to
+    # ``contents: read`` at the workflow level, and only ``update-badge``
+    # raises it to ``contents: write``; the reusable jobs that do run on
+    # this call need no more than that read default, so this grant only
+    # satisfies the compile-time cap for the skipped badge job.
     permissions:
       contents: write
     uses: ./.github/workflows/python-tests.yaml

--- a/scripts/lib/changelog.yaml
+++ b/scripts/lib/changelog.yaml
@@ -22,6 +22,9 @@ changelog:
   verb_mapping:
     Added:
       - Add
+      - Suggest
+      - Fail
+      - Emit
     Changed:
       - Update
       - Refactor
@@ -33,6 +36,13 @@ changelog:
       - Enforce
       - Restructure
       - Bump
+      - Sync
+      - Apply
+      - Switch
+      - Overhaul
+      - Move
+      - Make
+      - Recognize
     Deprecated:
       - Deprecate
     Removed:
@@ -43,6 +53,7 @@ changelog:
       - Fix
       - Catch
       - Resolve
+      - Address
     Security:
       - Patch
       - Secure

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -70,6 +70,30 @@ class LoadVerbMappingTests(unittest.TestCase):
         mapping = gc.load_verb_mapping()
         self.assertEqual(mapping["Bump"], "Changed")
 
+    def test_observed_release_verbs_present(self) -> None:
+        # Verbs drawn from real merged commit subjects across the
+        # repository's history.  They route releases away from the
+        # unmapped path (exit 3) that aborts the release-prep workflow;
+        # this guard turns an accidental removal or rename into a unit
+        # failure here rather than a startup/exit-3 failure at release
+        # time.
+        mapping = gc.load_verb_mapping()
+        expected = {
+            "Suggest": "Added",
+            "Fail": "Added",
+            "Emit": "Added",
+            "Sync": "Changed",
+            "Apply": "Changed",
+            "Switch": "Changed",
+            "Overhaul": "Changed",
+            "Move": "Changed",
+            "Make": "Changed",
+            "Recognize": "Changed",
+            "Address": "Fixed",
+        }
+        for verb, section in expected.items():
+            self.assertEqual(mapping[verb], section)
+
     def test_unknown_section_rejected(self) -> None:
         bad = (
             "changelog:\n"

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -92,6 +92,10 @@ class LoadVerbMappingTests(unittest.TestCase):
             "Address": "Fixed",
         }
         for verb, section in expected.items():
+            # assertIn first so a removed/renamed verb fails with an
+            # actionable message naming the verb, rather than a bare
+            # KeyError reported as a test error.
+            self.assertIn(verb, mapping, f"{verb!r} missing from verb mapping")
             self.assertEqual(mapping[verb], section)
 
     def test_unknown_section_rejected(self) -> None:


### PR DESCRIPTION
## Why

The `release-prep.yml` dispatch workflow had never been run successfully. Its first invocation (a v1.2.0 dry-run) failed at startup with a logless `startup_failure`, and a second blocker sat behind it. Both are fixed here so the dispatch-driven release path works end to end.

## Blocker 1 — reusable-workflow permission escalation (startup_failure)

The `test` job calls the reusable `python-tests.yaml` while granting only `contents: read`. That reusable workflow's `update-badge` job declares `contents: write`. A called workflow's job cannot request more permission than the caller grants, and GitHub validates that cap at *startup* — before job-level `if` skips are evaluated. So even though `update-badge` is skipped under `workflow_call` (its `if` requires a push to `main`), and even though `test` itself is skipped in dry-run, the whole graph failed to compile.

Fix: the `test` job now grants `contents: write`. The reusable jobs that actually run on this call (`test`, `validate-examples`, `reference-conformance`, `bundle-extract-smoke`) each declare `contents: read` and narrow themselves back down; the grant only satisfies the compile-time cap for the skipped badge job. `actionlint` does not cross-validate caller→callee permission caps for local reusable workflows, which is why it stayed green.

## Blocker 2 — unmapped changelog verbs

Once startup is fixed, `prepare` runs `bump_version.py`, which probes `generate_changelog.py` and refuses (exit 3) on any commit verb not mapped in `changelog.yaml`. Thirteen commits since `v1.1.0` used unmapped first-word verbs. Added the missing verbs:

- **Added** — `Suggest`, `Fail`, `Emit`
- **Changed** — `Sync`, `Apply`, `Switch`, `Overhaul`, `Move`, `Make`, `Recognize`
- **Fixed** — `Address`

## Verification

- `actionlint` clean on the workflow.
- `bump_version.py 1.2.0 --dry-run` exits 0 with zero unmapped verbs and a complete `1.2.0` changelog section.
- A dry-run dispatched from this branch reached the `prepare` job (past startup, confirming blocker 1), then failed only at the bump step against `main`'s still-stale `changelog.yaml` (confirming blocker 2 and that the mappings must land on `main`).

## After merge

Run the real prep from `main`: `gh workflow run release-prep.yml -f version=1.2.0`.