### PR TITLE
Harden CI workflows and decouple the coverage badge

### DIFF
--- a/.github/workflows/ci-helper-tests.yaml
+++ b/.github/workflows/ci-helper-tests.yaml
@@ -57,6 +57,7 @@ jobs:
     # cleanly distinguish meta-skill vs helper failures (raised in
     # PR #143 review by both Codex and Copilot).
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/coverage-badge.yaml
+++ b/.github/workflows/coverage-badge.yaml
@@ -34,8 +34,14 @@ jobs:
       contents: write  # force-push the coverage badge to the orphan badges branch
       actions: read    # download the coverage-total artifact from the triggering run
     steps:
-      - name: Checkout
+      - name: Checkout the commit that produced the coverage
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+        with:
+          # Pin to the triggering run's commit so the badge script and the
+          # coverage total come from the same revision, not a newer main tip.
+          # Safe because this workflow only triggers on push runs on main, so
+          # head_sha is always a trusted main commit.
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Download coverage total from the test run
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # @v4 as 4.3.0

--- a/.github/workflows/coverage-badge.yaml
+++ b/.github/workflows/coverage-badge.yaml
@@ -1,0 +1,51 @@
+name: Coverage badge
+
+# Publish the coverage badge after a successful main run of "Python tests".
+# Kept separate from python-tests.yaml so the test workflow stays contents:read
+# and composable (it is reused by release-prep via workflow_call); this is the
+# only place that needs contents:write to force-push the orphan badges branch.
+#
+# Using workflow_run also removes the old in-workflow guard: a workflow_call
+# invocation (release-prep) runs nested and emits no workflow_run event, so the
+# reusable path can never reach this badge step.
+
+on:
+  workflow_run:
+    workflows: ["Python tests"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-badge
+  cancel-in-progress: true
+
+jobs:
+  badge:
+    # Only after a genuine push-to-main test run that succeeded.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write  # force-push the coverage badge to the orphan badges branch
+      actions: read    # download the coverage-total artifact from the triggering run
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+
+      - name: Download coverage total from the test run
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # @v4 as 4.3.0
+        with:
+          name: coverage-total
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Update coverage badge
+        run: |
+          TOTAL=$(cat coverage-total.txt)
+          export TOTAL
+          bash .github/scripts/update-coverage-badge.sh

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -21,12 +21,13 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded in-progress runs for the same PR. Gated to pull_request so
-# push-to-main runs (which upload the coverage-total artifact the coverage-badge
-# workflow consumes) and workflow_call invocations (release-prep, which fires as
-# workflow_dispatch) always run to completion and are never cancelled mid-flight.
+# Concurrency: PR runs share a ref-based group so a new push to the PR cancels
+# the superseded run. Push-to-main and workflow_call (release-prep) runs instead
+# get a unique per-run group, so they neither cancel nor queue behind each other
+# — a shared group on refs/heads/main would serialize mainline CI and delay the
+# coverage-badge workflow_run that fires on a successful push run.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -21,9 +21,18 @@ on:
 permissions:
   contents: read
 
+# Cancel superseded in-progress runs for the same PR. Gated to pull_request so
+# push-to-main runs (badge update) and workflow_call invocations (release-prep,
+# which fires as workflow_dispatch) always run to completion and are never
+# cancelled mid-flight.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -107,6 +116,7 @@ jobs:
 
   validate-examples:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:
@@ -158,6 +168,7 @@ jobs:
     # under standard markdown semantics or any markdown file under the
     # skill is unreachable from SKILL.md / capability.md roots.
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -194,6 +205,7 @@ jobs:
     # archive arcnames) so those surfaces are exercised in this
     # workflow without making the happy-path bundle step fail.
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     permissions:
       contents: read
     strategy:
@@ -300,6 +312,7 @@ jobs:
     # the badge must not be updated from a release branch's coverage.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     concurrency:

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -22,9 +22,9 @@ permissions:
   contents: read
 
 # Cancel superseded in-progress runs for the same PR. Gated to pull_request so
-# push-to-main runs (badge update) and workflow_call invocations (release-prep,
-# which fires as workflow_dispatch) always run to completion and are never
-# cancelled mid-flight.
+# push-to-main runs (which upload the coverage-total artifact the coverage-badge
+# workflow consumes) and workflow_call invocations (release-prep, which fires as
+# workflow_dispatch) always run to completion and are never cancelled mid-flight.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -299,39 +299,3 @@ jobs:
           python .github/scripts/smoke-validate-extracted.py smoke-extracted skill-system-foundry/scripts/validate_skill.py
         env:
           PYTHONUTF8: "1"
-
-  update-badge:
-    needs:
-      - test
-      - validate-examples
-      - reference-conformance
-      - bundle-extract-smoke
-    # Restrict to genuine pushes to main; this skips reusable
-    # workflow_call invocations (e.g. release-prep.yml) where
-    # github.event_name is the caller's event (workflow_dispatch) and
-    # the badge must not be updated from a release branch's coverage.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
-    concurrency:
-      group: update-badge-main
-      cancel-in-progress: true
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
-        with:
-          ref: ${{ github.sha }}
-
-      - name: Download coverage total
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # @v4 as 4.3.0
-        with:
-          name: coverage-total
-
-      - name: Update coverage badge
-        run: |
-          TOTAL=$(cat coverage-total.txt)
-          export TOTAL
-          bash .github/scripts/update-coverage-badge.sh

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/verify-action-pins.yaml
+++ b/.github/workflows/verify-action-pins.yaml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2


### PR DESCRIPTION
## Summary

Hardens the existing CI workflows and decouples coverage-badge publishing from the test gate, so the test workflow becomes a clean, read-only, reusable building block.

## Changes

- Add `timeout-minutes` to every job in `python-tests`, `ci-helper-tests`, `shellcheck`, and `verify-action-pins` (`codex-code-review` and `tool-catalog-drift` already set theirs and are unchanged).
- Add workflow-level `concurrency` to `python-tests` that cancels superseded in-progress runs on the same PR, gated to `pull_request` so push-to-main runs and the `release-prep` `workflow_call` always run to completion.
- Split coverage-badge publishing out of `python-tests` into a dedicated `coverage-badge` workflow triggered by `workflow_run` on a successful push run of `python-tests`. `python-tests` is now `contents: read` only; the badge workflow holds the sole `contents: write` (plus `actions: read` to fetch the coverage artifact across runs). The badge mechanism itself (`update-coverage-badge.sh`, the orphan badges branch, the README endpoint) is unchanged.

## Why

The badge job's `contents: write` previously polluted the reusable `python-tests` contract: callers such as `release-prep` had to over-grant `contents: write` to satisfy the startup-time permission cap for a job they never run. Moving publishing into its own `workflow_run` workflow makes the test gate read-only and removes the in-workflow event guard — a nested `workflow_call` emits no `workflow_run` event, so the reusable path cannot publish a badge.

## Follow-up (must land after this)

Once this is on `main`, `release-prep`'s reusable `python-tests` call can drop its now-unnecessary `contents: write` grant. That change must not merge before this one, or the under-grant would `startup_failure`.

## Out of scope

A composite `setup-python` action and extracting `tool-catalog-drift`'s inline bash into scripts — deferred.

## Validation

`actionlint` clean on all touched workflows.
