### PR TITLE
Automate the release pipeline (two-identity auto-merge, immutable-safe publish)

### DIFF
--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -54,7 +54,7 @@ The workflow exposes a `dry_run` input that runs the input validation, bump, cha
 
 ### Identity prerequisites
 
-The auto-merge and publish steps need two GitHub App identities wired as repo variables/secrets. **oss-release-bot** (`RELEASE_CLIENT_ID`, `RELEASE_APP_PRIVATE_KEY`, `RELEASE_APP_BOT_USER_ID`) opens the release PR, tags, and publishes; **oss-automation-bot** (`AUTOMATION_APP_ID`, `AUTOMATION_PRIVATE_KEY`) approves. The repo setting "Allow auto-merge" must be on. Because the approval comes from an App, the release PR must touch no CODEOWNER-owned path — otherwise the App approval cannot satisfy the code-owner rule and the merge waits for a human.
+The auto-merge and publish steps need two GitHub App identities wired as repo variables/secrets. **oss-release-bot** (`RELEASE_CLIENT_ID`, `RELEASE_APP_PRIVATE_KEY`, `RELEASE_APP_BOT_USER_ID`) opens the release PR, tags, and publishes; **oss-automation-bot** (`AUTOMATION_CLIENT_ID`, `AUTOMATION_PRIVATE_KEY`) approves. Every workflow mints via the `client-id` input of `actions/create-github-app-token` (the numeric App ID is the deprecated alternative), so each App's required variable holds its **client ID**, not its App ID. The repo setting "Allow auto-merge" must be on. Because the approval comes from an App, the release PR must touch no CODEOWNER-owned path — otherwise the App approval cannot satisfy the code-owner rule and the merge waits for a human.
 
 ## Manual Release Checklist (Fallback)
 

--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -192,14 +192,15 @@ The full CI pipeline for a release involves multiple workflows:
 
 | Workflow | Trigger | What It Does |
 |---|---|---|
-| `python-tests.yaml` | Push to `main`, PRs, `workflow_call` | Tests + coverage + badge update; reusable from `release-prep.yaml` |
+| `python-tests.yaml` | Push to `main`, PRs, `workflow_call` | Tests + coverage (reusable from `release-prep.yaml`); read-only |
+| `coverage-badge.yaml` | After a successful `Python tests` run on `main` | Publishes the coverage badge |
 | `shellcheck.yaml` | Changes to `.github/scripts/*.sh` | Lints shell scripts |
 | `codex-code-review.yaml` | PRs (non-draft) | AI-assisted code review |
 | `release-prep.yaml` | `workflow_dispatch` | Bumps version, prepends changelog, dry-builds the bundle, opens + auto-merges the release PR |
 | `release-on-merge.yaml` | Release PR merged to `main` | Tags the merge commit `v<X.Y.Z>` (oss-release-bot) |
 | `release.yaml` | `v*.*.*` tag push | Builds the bundle and creates the Release (zip + SHA256 attached at creation) |
 
-The coverage badge updates automatically on pushes to `main` via the `update-badge` job. It writes `coverage.json` to an orphan `badges` branch, which shields.io reads.
+The coverage badge updates automatically via the `coverage-badge.yaml` workflow, which runs after a successful `Python tests` run on `main`, downloads that run's coverage total, and writes `coverage.json` to an orphan `badges` branch that shields.io reads. (Badge publishing was split out of `python-tests.yaml` so the test workflow stays read-only and reusable.)
 
 ## Distribution Channels
 

--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -41,22 +41,20 @@ The `audit_skill_system.py` version-drift rule (run from the repo root) fails th
 - **MINOR** (1.0.2 → 1.1.0) — new features: new validation checks, new scripts, new reference documents, new template types, new bundling targets
 - **MAJOR** (1.0.2 → 2.0.0) — breaking changes: configuration.yaml schema changes that break existing setups, removed validation checks, renamed scripts, changed CLI arguments
 
-## Dispatch-Driven Prep (Preferred)
+## Dispatch-Driven Release (Preferred)
 
-The `Release prep` workflow (`.github/workflows/release-prep.yaml`) is the primary release-prep path. Trigger it from the GitHub Actions UI (or `gh workflow run release-prep.yaml -f version=X.Y.Z`):
+The `Release prep` workflow (`.github/workflows/release-prep.yaml`) is the entry point for a fully automated release. Dispatch it once with the target version; every step after that is hands-off.
 
-1. Dispatch the workflow with the target version (`X.Y.Z`, no leading `v`, no prerelease).
-2. The workflow creates `release/v<X.Y.Z>`, runs the `bump_version.py` helper (manifest lockstep), prepends a generated section to `CHANGELOG.md`, runs `validate_skill.py` and `audit_skill_system.py` (the latter from repo root, which fires the version-drift rule), runs the full test matrix via the reusable `python-tests.yaml`, and opens a PR titled `Release v<X.Y.Z>`.
-3. Review the PR. The PR body lists any manual follow-ups (notably: edit `.agents/skills/git-release/SKILL.md` prose if any examples reference an outdated release).
-4. Re-trigger CI on the PR by closing and reopening it (GitHub does not fire PR workflows for PRs opened by `GITHUB_TOKEN`).
-5. Merge the PR to `main`.
-6. Tag and publish:
-   ```bash
-   gh release create v<X.Y.Z> --generate-notes
-   ```
-   The post-merge `release.yaml` workflow bundles the zip, computes the SHA256 checksum, and uploads both as release assets.
+1. Dispatch from the GitHub Actions UI, or `gh workflow run release-prep.yaml -f version=X.Y.Z` (`X.Y.Z`, no leading `v`, no prerelease).
+2. The workflow creates `release/v<X.Y.Z>`, runs `bump_version.py` (manifest lockstep), prepends a generated `CHANGELOG.md` section, runs `validate_skill.py` and `audit_skill_system.py` (repo root, firing the version-drift rule), dry-builds the distribution bundle via `build-skill-bundle.sh`, runs the full test matrix via the reusable `python-tests.yaml`, and opens a PR titled `Release v<X.Y.Z>` **as oss-release-bot** (so CI fires automatically — no close/reopen needed).
+3. oss-automation-bot approves the PR — a bot cannot approve its own PR, so the second identity satisfies the one-review rule — and GitHub auto-merges it once the required checks pass. There is no human step on the green path. To halt a release, close the PR before the checks pass; if Copilot leaves an unresolved review thread, auto-merge waits until it is resolved.
+4. On merge, `release-on-merge.yaml` tags the merge commit `v<X.Y.Z>` (as oss-release-bot), and the tag push triggers `release.yaml`, which builds the bundle and creates the GitHub Release with the zip + SHA256 checksum attached at creation.
 
-The workflow exposes a `dry_run` input that runs validation, bump, changelog generation, validate, and audit but skips the push and the PR — useful to verify a target version's gates before committing to a real prep.
+The workflow exposes a `dry_run` input that runs the input validation, bump, changelog generation, validate, audit, and bundle dry-build but skips the push, the test matrix, and the PR — useful to verify a version's gates before a real prep.
+
+### Identity prerequisites
+
+The auto-merge and publish steps need two GitHub App identities wired as repo variables/secrets. **oss-release-bot** (`RELEASE_CLIENT_ID`, `RELEASE_APP_PRIVATE_KEY`, `RELEASE_APP_BOT_USER_ID`) opens the release PR, tags, and publishes; **oss-automation-bot** (`AUTOMATION_APP_ID`, `AUTOMATION_PRIVATE_KEY`) approves. The repo setting "Allow auto-merge" must be on. Because the approval comes from an App, the release PR must touch no CODEOWNER-owned path — otherwise the App approval cannot satisfy the code-owner rule and the merge waits for a human.
 
 ## Manual Release Checklist (Fallback)
 
@@ -64,7 +62,7 @@ Use this path when the dispatch workflow is unavailable (for example, when runni
 
 ### Step 1: Verify Pre-Release State
 
-Confirm the release gate is green on `main` for the commit being tagged **before** publishing the release. `release.yaml` triggers on `release: published` and does not run tests; `python-tests.yaml` on `main` is the only workflow that gates a release — `shellcheck.yaml` and `codex-code-review.yaml` are advisory and can be red at release time. Check the gate via the GitHub Actions UI or:
+Confirm the release gate is green on `main` for the commit being tagged **before** publishing the release. `release.yaml` triggers on a `v*.*.*` tag push and does not run tests; `python-tests.yaml` on `main` is the only workflow that gates a release — `shellcheck.yaml` and `codex-code-review.yaml` are advisory and can be red at release time. Check the gate via the GitHub Actions UI or:
 
 ```bash
 # Latest python-tests.yaml run on main — conclusion must be success
@@ -130,30 +128,26 @@ git push origin main
 
 Use the commit message format `Release vX.Y.Z` so the changelog generator filters the bump commit out of future regenerations. The full subject is matched against `_RELEASE_COMMIT_RE` in `scripts/generate_changelog.py`, which mirrors the strict SemVer grammar the generator already enforces on `--version` (no leading zeros, optional dot-separated prerelease suffix; build metadata is intentionally unsupported). Off-grammar subjects like `Release v1.2.0 (RC)` or `Release v1.2.3-..1` are deliberately not skipped — they route to `unmapped — review manually` so the operator either fixes the subject or reclassifies it deliberately.
 
-### Step 4: Create the GitHub Release
+### Step 4: Tag to Trigger the Release
 
-Create a tag and release via the GitHub CLI or web UI:
+In the automated model the GitHub Release is created by `release.yaml` on a `v*.*.*` tag push — not by hand. For a manual release, push the tag from `main` under a release identity (so the push triggers workflows; a `GITHUB_TOKEN`-authored tag push would not):
 
 ```bash
-gh release create v1.1.0 \
-  --title "v1.1.0" \
-  --notes "Release notes here" \
-  --target main
+git tag -a v1.1.0 -m "Release v1.1.0" main
+git push origin v1.1.0
 ```
 
-Or through the GitHub web UI: Releases → Draft a new release → Tag: `v1.1.0` → Target: `main`.
+Do **not** run `gh release create` yourself — `release.yaml` owns release creation, and a tag name is permanent under GitHub immutable releases, so only tag a commit whose release gate is already green (Step 1).
 
-### Step 5: Automated Bundling
+### Step 5: Automated Bundling and Publication
 
-The `release.yaml` workflow triggers automatically on release publication. It:
+The `release.yaml` workflow triggers on the `v*.*.*` tag push. It:
 
-1. Checks out the tagged commit
-2. Creates a zip archive: `dist/skill-system-foundry-v1.1.0.zip`
-3. Uploads it as a release asset using `gh release upload --clobber`
+1. Builds the bundle via `.github/scripts/build-skill-bundle.sh` — the same script `release-prep.yaml` dry-runs pre-merge — producing `dist/skill-system-foundry-v1.1.0.zip` plus its `.sha256` checksum, and asserting the bundle excludes the yaml-conformance corpus.
+2. Creates the GitHub Release with the zip and checksum attached **at creation**. Attaching at creation is required under GitHub immutable releases, which forbid adding assets after a release exists (the reason the old create-then-`upload --clobber` model was retired).
+3. Uses the matching `CHANGELOG.md` section as the release notes.
 
-The zip contains the entire `skill-system-foundry/` directory — SKILL.md, references, assets, and scripts. This is the distribution artifact for manual installation.
-
-No manual intervention is needed after creating the release.
+The zip contains the entire `skill-system-foundry/` directory — SKILL.md, references, assets, and scripts. No manual intervention is needed after the tag is pushed.
 
 ### Step 6: Post-Release Verification
 
@@ -201,8 +195,9 @@ The full CI pipeline for a release involves multiple workflows:
 | `python-tests.yaml` | Push to `main`, PRs, `workflow_call` | Tests + coverage + badge update; reusable from `release-prep.yaml` |
 | `shellcheck.yaml` | Changes to `.github/scripts/*.sh` | Lints shell scripts |
 | `codex-code-review.yaml` | PRs (non-draft) | AI-assisted code review |
-| `release-prep.yaml` | `workflow_dispatch` | Bumps version, prepends changelog, opens release PR |
-| `release.yaml` | Release published | Bundles zip + uploads asset (zip + SHA256) |
+| `release-prep.yaml` | `workflow_dispatch` | Bumps version, prepends changelog, dry-builds the bundle, opens + auto-merges the release PR |
+| `release-on-merge.yaml` | Release PR merged to `main` | Tags the merge commit `v<X.Y.Z>` (oss-release-bot) |
+| `release.yaml` | `v*.*.*` tag push | Builds the bundle and creates the Release (zip + SHA256 attached at creation) |
 
 The coverage badge updates automatically on pushes to `main` via the `update-badge` job. It writes `coverage.json` to an orphan `badges` branch, which shields.io reads.
 

--- a/.agents/skills/git-release/SKILL.md
+++ b/.agents/skills/git-release/SKILL.md
@@ -7,7 +7,7 @@ description: >
   bump a version, create a changelog, tag a release, publish a GitHub
   release, verify a release artifact, or update the version in SKILL.md
   frontmatter. Also triggers on questions about semver conventions,
-  release workflows, the release.yml GitHub Action, or distributing
+  release workflows, the release.yaml GitHub Action, or distributing
   skill bundles. Use this skill whenever version numbers, releases,
   tags, or distribution are mentioned.
 ---
@@ -43,7 +43,7 @@ The `audit_skill_system.py` version-drift rule (run from the repo root) fails th
 
 ## Dispatch-Driven Prep (Preferred)
 
-The `Release prep` workflow (`.github/workflows/release-prep.yml`) is the primary release-prep path. Trigger it from the GitHub Actions UI (or `gh workflow run release-prep.yml -f version=X.Y.Z`):
+The `Release prep` workflow (`.github/workflows/release-prep.yaml`) is the primary release-prep path. Trigger it from the GitHub Actions UI (or `gh workflow run release-prep.yaml -f version=X.Y.Z`):
 
 1. Dispatch the workflow with the target version (`X.Y.Z`, no leading `v`, no prerelease).
 2. The workflow creates `release/v<X.Y.Z>`, runs the `bump_version.py` helper (manifest lockstep), prepends a generated section to `CHANGELOG.md`, runs `validate_skill.py` and `audit_skill_system.py` (the latter from repo root, which fires the version-drift rule), runs the full test matrix via the reusable `python-tests.yaml`, and opens a PR titled `Release v<X.Y.Z>`.
@@ -54,7 +54,7 @@ The `Release prep` workflow (`.github/workflows/release-prep.yml`) is the primar
    ```bash
    gh release create v<X.Y.Z> --generate-notes
    ```
-   The post-merge `release.yml` workflow bundles the zip, computes the SHA256 checksum, and uploads both as release assets.
+   The post-merge `release.yaml` workflow bundles the zip, computes the SHA256 checksum, and uploads both as release assets.
 
 The workflow exposes a `dry_run` input that runs validation, bump, changelog generation, validate, and audit but skips the push and the PR — useful to verify a target version's gates before committing to a real prep.
 
@@ -64,7 +64,7 @@ Use this path when the dispatch workflow is unavailable (for example, when runni
 
 ### Step 1: Verify Pre-Release State
 
-Confirm the release gate is green on `main` for the commit being tagged **before** publishing the release. `release.yml` triggers on `release: published` and does not run tests; `python-tests.yaml` on `main` is the only workflow that gates a release — `shellcheck.yaml` and `codex-code-review.yaml` are advisory and can be red at release time. Check the gate via the GitHub Actions UI or:
+Confirm the release gate is green on `main` for the commit being tagged **before** publishing the release. `release.yaml` triggers on `release: published` and does not run tests; `python-tests.yaml` on `main` is the only workflow that gates a release — `shellcheck.yaml` and `codex-code-review.yaml` are advisory and can be red at release time. Check the gate via the GitHub Actions UI or:
 
 ```bash
 # Latest python-tests.yaml run on main — conclusion must be success
@@ -145,7 +145,7 @@ Or through the GitHub web UI: Releases → Draft a new release → Tag: `v1.1.0`
 
 ### Step 5: Automated Bundling
 
-The `release.yml` workflow triggers automatically on release publication. It:
+The `release.yaml` workflow triggers automatically on release publication. It:
 
 1. Checks out the tagged commit
 2. Creates a zip archive: `dist/skill-system-foundry-v1.1.0.zip`
@@ -198,11 +198,11 @@ The full CI pipeline for a release involves multiple workflows:
 
 | Workflow | Trigger | What It Does |
 |---|---|---|
-| `python-tests.yaml` | Push to `main`, PRs, `workflow_call` | Tests + coverage + badge update; reusable from `release-prep.yml` |
+| `python-tests.yaml` | Push to `main`, PRs, `workflow_call` | Tests + coverage + badge update; reusable from `release-prep.yaml` |
 | `shellcheck.yaml` | Changes to `.github/scripts/*.sh` | Lints shell scripts |
 | `codex-code-review.yaml` | PRs (non-draft) | AI-assisted code review |
-| `release-prep.yml` | `workflow_dispatch` | Bumps version, prepends changelog, opens release PR |
-| `release.yml` | Release published | Bundles zip + uploads asset (zip + SHA256) |
+| `release-prep.yaml` | `workflow_dispatch` | Bumps version, prepends changelog, opens release PR |
+| `release.yaml` | Release published | Bundles zip + uploads asset (zip + SHA256) |
 
 The coverage badge updates automatically on pushes to `main` via the `update-badge` job. It writes `coverage.json` to an orphan `badges` branch, which shields.io reads.
 
@@ -236,5 +236,5 @@ The bundle script applies stricter validation than the release workflow — it c
 - Tagging before pushing the bump commit to `main`.
 - Creating a release from a branch other than `main`.
 - Skipping validation — a broken SKILL.md ships in the zip.
-- Forgetting to verify the zip asset downloads and validates after `release.yml` runs.
+- Forgetting to verify the zip asset downloads and validates after `release.yaml` runs.
 - Using a commit subject other than `Release vX.Y.Z` for the bump — the changelog generator skip filter only matches that exact shape.

--- a/.agents/skills/github-actions/SKILL.md
+++ b/.agents/skills/github-actions/SKILL.md
@@ -21,13 +21,17 @@ Guides the creation, modification, and review of GitHub Actions workflows in the
 
 | Workflow | File | Trigger | Jobs |
 |---|---|---|---|
-| Tests + coverage | `python-tests.yaml` | Push to `main`, PRs | `test` (matrix), `update-badge` |
+| Tests + coverage | `python-tests.yaml` | Push to `main`, PRs, `workflow_call` | `test` (matrix), `validate-examples`, `reference-conformance`, `bundle-extract-smoke` |
+| Coverage badge | `coverage-badge.yaml` | `workflow_run` after Python tests | `badge` |
+| CI helper tests | `ci-helper-tests.yaml` | Push/PR (path-filtered to CI helpers) | `helper-tests` (matrix) |
 | Shell lint | `shellcheck.yaml` | Push/PR (path-filtered to `.sh`) | `shellcheck` |
 | Action-pin verify | `verify-action-pins.yaml` | Push to `main`, PRs | `verify` |
+| Workflow lint | `actionlint.yaml` | Push to `main`, PRs | `actionlint` |
 | Codex code review | `codex-code-review.yaml` | PR events (non-draft) | `review` (read-only), `publish` (write) |
+| Release-label check | `verify-pr-release-label.yaml` | PR events | `verify-release-label` (report-only) |
 | Supply-chain scorecard | `scorecard.yaml` | Schedule, push to `main`, branch-protection change | `analysis` |
 | CodeQL | `codeql.yaml` | Push to `main`, PRs, schedule | `analyze` |
-| Workflow lint | `actionlint.yaml` | Push to `main`, PRs | `actionlint` |
+| Tool-catalog drift | `tool-catalog-drift.yaml` | Schedule, `workflow_dispatch` | `detect-and-pr` |
 | Release prep | `release-prep.yaml` | `workflow_dispatch` | `prepare`, `test`, `open-pr` |
 | Release tag | `release-on-merge.yaml` | Release PR merged to `main` | `tag` |
 | Release bundle | `release.yaml` | `v*.*.*` tag push | `release` |

--- a/.agents/skills/github-actions/SKILL.md
+++ b/.agents/skills/github-actions/SKILL.md
@@ -28,7 +28,7 @@ Guides the creation, modification, and review of GitHub Actions workflows in the
 | Supply-chain scorecard | `scorecard.yaml` | Schedule, push to `main`, branch-protection change | `analysis` |
 | CodeQL | `codeql.yaml` | Push to `main`, PRs, schedule | `analyze` |
 | Workflow lint | `actionlint.yaml` | Push to `main`, PRs | `actionlint` |
-| Release bundle | `release.yml` | Release published | `bundle` |
+| Release bundle | `release.yaml` | Release published | `bundle` |
 
 ## Hard Requirements
 

--- a/.agents/skills/github-actions/SKILL.md
+++ b/.agents/skills/github-actions/SKILL.md
@@ -28,7 +28,9 @@ Guides the creation, modification, and review of GitHub Actions workflows in the
 | Supply-chain scorecard | `scorecard.yaml` | Schedule, push to `main`, branch-protection change | `analysis` |
 | CodeQL | `codeql.yaml` | Push to `main`, PRs, schedule | `analyze` |
 | Workflow lint | `actionlint.yaml` | Push to `main`, PRs | `actionlint` |
-| Release bundle | `release.yaml` | Release published | `bundle` |
+| Release prep | `release-prep.yaml` | `workflow_dispatch` | `prepare`, `test`, `open-pr` |
+| Release tag | `release-on-merge.yaml` | Release PR merged to `main` | `tag` |
+| Release bundle | `release.yaml` | `v*.*.*` tag push | `release` |
 
 ## Hard Requirements
 

--- a/.agents/skills/github-actions/SKILL.md
+++ b/.agents/skills/github-actions/SKILL.md
@@ -57,8 +57,8 @@ This rule is enforced by `.github/scripts/verify-action-pins.py`, which the `ver
 
 When minting a GitHub App token with `actions/create-github-app-token`, use the **`client-id`** input — `app-id` is deprecated (the action carries a `deprecationMessage` pointing to `client-id`). Across these OSS repos the automation identities follow a `<PREFIX>_CLIENT_ID` (repository variable) + `<PREFIX>_PRIVATE_KEY` (repository secret) convention:
 
-- **oss-automation-bot** — `vars.AUTOMATION_CLIENT_ID` + `secrets.AUTOMATION_PRIVATE_KEY` (the workhorse: dependency automation, opening/approving PRs). Wired in this repo's `tool-catalog-drift.yaml`.
-- **oss-release-bot** — `vars.RELEASE_CLIENT_ID` + `secrets.RELEASE_PRIVATE_KEY` (the release identity: tags and publishes). This repo's `release.yml` currently authenticates with `GITHUB_TOKEN`, not this identity.
+- **oss-automation-bot** — `vars.AUTOMATION_CLIENT_ID` + `secrets.AUTOMATION_PRIVATE_KEY` (the workhorse: dependency automation, opening/approving PRs). Wired in this repo's `tool-catalog-drift.yaml` and the release-PR approval in `release-prep.yaml`.
+- **oss-release-bot** — `vars.RELEASE_CLIENT_ID` + `secrets.RELEASE_APP_PRIVATE_KEY` (the release identity: opens the release PR, tags, and publishes). Wired in `release-prep.yaml`, `release-on-merge.yaml`, and `release.yaml`.
 
 ```yaml
 # Correct

--- a/.agents/skills/github-actions/SKILL.md
+++ b/.agents/skills/github-actions/SKILL.md
@@ -55,7 +55,7 @@ This rule is enforced by `.github/scripts/verify-action-pins.py`, which the `ver
 
 ### App Token Identity
 
-When minting a GitHub App token with `actions/create-github-app-token`, use the **`client-id`** input — `app-id` is deprecated (the action carries a `deprecationMessage` pointing to `client-id`). Across these OSS repos the automation identities follow a `<PREFIX>_CLIENT_ID` (repository variable) + `<PREFIX>_PRIVATE_KEY` (repository secret) convention:
+When minting a GitHub App token with `actions/create-github-app-token`, use the **`client-id`** input — `app-id` is deprecated (the action carries a `deprecationMessage` pointing to `client-id`). Across these OSS repos each automation identity wires a `<PREFIX>_CLIENT_ID` repository variable for the App's client ID plus a repository secret holding its PEM private key; the private-key secret name is not uniform (`AUTOMATION_PRIVATE_KEY` for the automation App, `RELEASE_APP_PRIVATE_KEY` for the release App), so take the exact names from the list below:
 
 - **oss-automation-bot** — `vars.AUTOMATION_CLIENT_ID` + `secrets.AUTOMATION_PRIVATE_KEY` (the workhorse: dependency automation, opening/approving PRs). Wired in this repo's `tool-catalog-drift.yaml` and the release-PR approval in `release-prep.yaml`.
 - **oss-release-bot** — `vars.RELEASE_CLIENT_ID` + `secrets.RELEASE_APP_PRIVATE_KEY` (the release identity: opens the release PR, tags, and publishes). Wired in `release-prep.yaml`, `release-on-merge.yaml`, and `release.yaml`.

--- a/.agents/skills/shell-scripts/SKILL.md
+++ b/.agents/skills/shell-scripts/SKILL.md
@@ -28,7 +28,7 @@ These scripts are CI helpers called by GitHub Actions workflows. They handle cov
 │   ├── python-tests.yaml           ← runs tests, coverage, badge update
 │   ├── shellcheck.yaml             ← lints all .sh files with shellcheck
 │   ├── codex-code-review.yaml      ← Codex PR review via codex-ai-code-review-action
-│   └── release.yml                 ← bundles and uploads release assets
+│   └── release.yaml                 ← bundles and uploads release assets
 ├── instructions/
 │   ├── markdown.instructions.md    ← Markdown review rules
 │   └── scripts.instructions.md     ← Python review rules

--- a/.agents/skills/shell-scripts/SKILL.md
+++ b/.agents/skills/shell-scripts/SKILL.md
@@ -22,18 +22,22 @@ These scripts are CI helpers called by GitHub Actions workflows. They handle cov
 ```
 .github/
 ├── scripts/
-│   ├── check-per-file-coverage.py  ← enforces per-file branch coverage minimum
-│   └── update-coverage-badge.sh    ← pushes coverage.json to orphan badges branch
+│   ├── build-skill-bundle.sh      ← builds + verifies the release zip and checksum
+│   ├── check-per-file-coverage.py ← enforces per-file branch coverage minimum
+│   └── update-coverage-badge.sh   ← pushes coverage.json to orphan badges branch
 ├── workflows/
-│   ├── python-tests.yaml           ← runs tests, coverage, badge update
-│   ├── shellcheck.yaml             ← lints all .sh files with shellcheck
-│   ├── codex-code-review.yaml      ← Codex PR review via codex-ai-code-review-action
-│   └── release.yaml                 ← bundles and uploads release assets
+│   ├── python-tests.yaml          ← runs tests + coverage (ubuntu + windows)
+│   ├── coverage-badge.yaml        ← updates the coverage badge on push to main
+│   ├── shellcheck.yaml            ← lints all .sh files with shellcheck
+│   ├── codex-code-review.yaml     ← Codex PR review via codex-ai-code-review-action
+│   ├── release-prep.yaml          ← dispatch: bump, changelog, open/auto-merge release PR
+│   ├── release-on-merge.yaml      ← tags vX.Y.Z when a release PR merges
+│   └── release.yaml               ← builds the bundle + creates the GitHub Release on tag push
 ├── instructions/
-│   ├── markdown.instructions.md    ← Markdown review rules
-│   └── scripts.instructions.md     ← Python review rules
-├── copilot-instructions.md         ← top-level review guidance
-└── CODEOWNERS                      ← requires code-owner approval
+│   ├── markdown.instructions.md   ← Markdown review rules
+│   └── scripts.instructions.md    ← Python review rules
+├── copilot-instructions.md        ← top-level review guidance
+└── CODEOWNERS                     ← requires code-owner approval
 ```
 
 ## Hard Requirements

--- a/.github/scripts/build-skill-bundle.sh
+++ b/.github/scripts/build-skill-bundle.sh
@@ -24,7 +24,10 @@ mkdir -p "$(dirname "$BUNDLE_PATH")"
 # entries for files since deleted from skill-system-foundry/. Remove it first so
 # every build produces the bundle from scratch and stays idempotent on rerun.
 rm -f "$BUNDLE_PATH"
-zip -r "$BUNDLE_PATH" skill-system-foundry/
+# Exclude Python bytecode: validation/audit runs before the pre-merge dry-build
+# can leave __pycache__/*.pyc under skill-system-foundry/scripts/, which would
+# otherwise be bundled and diverge from release.yaml's fresh-checkout shape.
+zip -r "$BUNDLE_PATH" skill-system-foundry/ -x '*/__pycache__/*' '*.pyc'
 
 python - "$BUNDLE_PATH" <<'PY'
 import sys, zipfile

--- a/.github/scripts/build-skill-bundle.sh
+++ b/.github/scripts/build-skill-bundle.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build and verify the distributable skill bundle.
+#
+# Single source of truth for the release zip so the pre-merge dry-build in
+# release-prep.yaml and the real build in release.yaml cannot drift: whatever
+# release-prep proves buildable is the exact procedure release.yaml runs to
+# publish. Without this, a bundle that builds in the dry-run could still fail at
+# release time and burn the (immutable) tag.
+#
+# Environment variables:
+#   BUNDLE_PATH    — output path for the zip (required)
+#   CHECKSUM_PATH  — when set, also write and self-verify a SHA256 checksum file
+#
+# Behaviour: zips skill-system-foundry/, fails if the bundle contains any
+# yaml-conformance corpus entry, and (when CHECKSUM_PATH is set) writes the
+# checksum file and re-hashes the bundle to confirm it matches.
+
+: "${BUNDLE_PATH:?Environment variable BUNDLE_PATH is required}"
+
+mkdir -p "$(dirname "$BUNDLE_PATH")"
+zip -r "$BUNDLE_PATH" skill-system-foundry/
+
+python - "$BUNDLE_PATH" <<'PY'
+import sys, zipfile
+z = zipfile.ZipFile(sys.argv[1])
+hits = [n for n in z.namelist() if 'yaml-conformance' in n]
+if hits:
+    print('Found forbidden yaml-conformance entries in bundle:', file=sys.stderr)
+    for n in hits:
+        print(f'  {n}', file=sys.stderr)
+    sys.exit(1)
+PY
+
+if [ -z "${CHECKSUM_PATH:-}" ]; then
+  echo "Bundle OK (no checksum requested): $BUNDLE_PATH"
+  exit 0
+fi
+
+python - "$BUNDLE_PATH" "$CHECKSUM_PATH" <<'PY'
+import hashlib, os, sys
+
+def hash_bundle(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+bundle_path, checksum_path = sys.argv[1], sys.argv[2]
+actual_name = os.path.basename(bundle_path)
+write_line = f"{hash_bundle(bundle_path)}  {actual_name}\n"
+with open(checksum_path, "w", encoding="utf-8", newline="\n") as fh:
+    fh.write(write_line)
+# Re-read the checksum file and re-hash the bundle so this confirms the checksum
+# file matches the bundle as it exists at the end of generation.
+with open(checksum_path, "r", encoding="utf-8") as fh:
+    checksum_line = fh.readline().rstrip("\r\n")
+if "  " not in checksum_line:
+    print('Malformed checksum file: expected "<sha256>  <filename>"', file=sys.stderr)
+    sys.exit(1)
+expected_digest, expected_name = checksum_line.split("  ", 1)
+if expected_name != actual_name:
+    print(f"Checksum filename mismatch: {expected_name!r} vs {actual_name!r}", file=sys.stderr)
+    sys.exit(1)
+actual_digest = hash_bundle(bundle_path)
+if actual_digest != expected_digest:
+    print(f"Checksum mismatch: file has {expected_digest}, bundle hashes to {actual_digest}", file=sys.stderr)
+    sys.exit(1)
+print(f"{actual_name}: OK")
+PY
+
+echo "Bundle + checksum OK: $BUNDLE_PATH"

--- a/.github/scripts/build-skill-bundle.sh
+++ b/.github/scripts/build-skill-bundle.sh
@@ -24,8 +24,8 @@ zip -r "$BUNDLE_PATH" skill-system-foundry/
 
 python - "$BUNDLE_PATH" <<'PY'
 import sys, zipfile
-z = zipfile.ZipFile(sys.argv[1])
-hits = [n for n in z.namelist() if 'yaml-conformance' in n]
+with zipfile.ZipFile(sys.argv[1]) as z:
+    hits = [n for n in z.namelist() if 'yaml-conformance' in n]
 if hits:
     print('Found forbidden yaml-conformance entries in bundle:', file=sys.stderr)
     for n in hits:

--- a/.github/scripts/build-skill-bundle.sh
+++ b/.github/scripts/build-skill-bundle.sh
@@ -20,6 +20,10 @@ set -euo pipefail
 : "${BUNDLE_PATH:?Environment variable BUNDLE_PATH is required}"
 
 mkdir -p "$(dirname "$BUNDLE_PATH")"
+# zip -r updates an archive in place, so a pre-existing BUNDLE_PATH would retain
+# entries for files since deleted from skill-system-foundry/. Remove it first so
+# every build produces the bundle from scratch and stays idempotent on rerun.
+rm -f "$BUNDLE_PATH"
 zip -r "$BUNDLE_PATH" skill-system-foundry/
 
 python - "$BUNDLE_PATH" <<'PY'

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -12,7 +12,7 @@ on:
           Git ref (branch, tag, or commit SHA) to check out for testing.
           When empty (or unset, as on push/pull_request), checkout falls
           back to ``github.sha`` so the triggering commit is tested.
-          Used by release-prep.yml to test the bumped release branch
+          Used by release-prep.yaml to test the bumped release branch
           before opening the release PR.
         required: false
         type: string
@@ -51,7 +51,7 @@ jobs:
           # commit, which on a PR would test ``main`` instead of the
           # PR head.  Fall back to ``github.sha`` so push/PR runs
           # check out the triggering revision and ``workflow_call``
-          # callers (release-prep.yml) still get the ref they passed.
+          # callers (release-prep.yaml) still get the ref they passed.
           ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Python

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -67,9 +67,29 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${HEAD_REF#release/v}"
-          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
-            echo "Tag v${VERSION} already exists at origin; nothing to do."
-            exit 0
+          # If the tag already exists, a no-op is only safe when it points at
+          # this merge commit (an idempotent rerun). A tag at a different SHA
+          # means the version was already released from other content, so retag
+          # would either fail or silently diverge tag from manifest — fail loud.
+          # Query both the tag ref and its peeled form so annotated tags
+          # (peeled commit in ``^{}``) and lightweight tags (direct commit) are
+          # compared against the merge commit, not the annotated-tag object SHA.
+          existing=$(git ls-remote --tags origin "refs/tags/v${VERSION}" "refs/tags/v${VERSION}^{}" 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            # An annotated tag yields a peeled ``^{}`` line (the commit) plus the
+            # tag-object line; a lightweight tag yields only the direct commit
+            # line. Prefer the peeled commit. ``exit`` after the first match
+            # collapses any duplicate peeled line emitted by both default
+            # peeling and the explicit ``^{}`` pattern.
+            peeled=$(awk '/\^\{\}$/ {print $1; exit}' <<<"$existing")
+            direct=$(awk '!/\^\{\}$/ {print $1; exit}' <<<"$existing")
+            target="${peeled:-$direct}"
+            if [ "$target" = "$MERGE_SHA" ]; then
+              echo "Tag v${VERSION} already exists at origin and points to the merge commit; nothing to do."
+              exit 0
+            fi
+            echo "::error::Tag v${VERSION} already exists at origin but points to ${target}, not the merge commit ${MERGE_SHA}; refusing to retag."
+            exit 1
           fi
           if [ -z "${BOT_USER_ID}" ]; then
             echo "::error::vars.RELEASE_APP_BOT_USER_ID is empty; refusing to tag with a malformed bot email."

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -32,6 +32,24 @@ jobs:
       contents: read  # the tag push is authenticated with the release App token, not GITHUB_TOKEN
     timeout-minutes: 10
     steps:
+      - name: Guard against non-core-semver release branches
+        # Validate the release branch grammar before minting a token or
+        # checking out, mirroring release.yaml's guard-before-mint ordering.
+        # release.yaml guards the tag at publish time, but the tag is created
+        # here first, so an off-grammar branch (e.g. release/v1.2.3-rc.1) would
+        # otherwise push a tag that strands a failed publish. Grammar matches
+        # release-prep.yaml's dispatch gate and release.yaml.
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          VERSION="${HEAD_REF#release/v}"
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Release branch '$HEAD_REF' is not a core-semver release branch (release/vX.Y.Z); refusing to tag."
+            exit 1
+          fi
+          echo "Release branch $HEAD_REF is core-semver."
+
       - name: Mint release App token
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # @v3 as 3.1.1
@@ -52,16 +70,16 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${HEAD_REF#release/v}"
-          # Reject non-core-semver release branches (e.g. release/v1.2.3-rc.1)
-          # before any tag is pushed. release.yaml guards the tag at publish
-          # time, but the tag is created here first, so without this guard an
-          # off-grammar branch would push a tag that strands a failed publish.
-          # Grammar mirrors release-prep.yaml's dispatch gate and release.yaml.
-          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-            echo "::error::Release branch '$HEAD_REF' is not a core-semver release branch (release/vX.Y.Z); refusing to tag."
+          # Read the canonical metadata.version via the repo's stdlib parser
+          # (scripts/lib/version.py, the same reader bump_version.py uses) rather
+          # than a grep/sed pipeline: it scopes to frontmatter, enforces
+          # metadata.version as a direct child, strips scalar quotes, and lets us
+          # emit a targeted error instead of a generic pipefail failure.
+          MANIFEST=$(python3 -c "import sys; sys.path.insert(0, 'scripts'); from lib.version import read_skill_md_version; v = read_skill_md_version('skill-system-foundry/SKILL.md'); print(v or '')")
+          if [ -z "$MANIFEST" ]; then
+            echo "::error::Could not read metadata.version from skill-system-foundry/SKILL.md frontmatter."
             exit 1
           fi
-          MANIFEST=$(grep -E '^[[:space:]]*version:' skill-system-foundry/SKILL.md | head -1 | sed -E 's/.*version:[[:space:]]*//;s/[[:space:]]*$//')
           if [ "$VERSION" != "$MANIFEST" ]; then
             echo "::error::Release branch version ($VERSION) does not match the SKILL.md manifest ($MANIFEST); refusing to tag."
             exit 1

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -1,0 +1,82 @@
+name: Release on merge
+
+# Tag the release commit when a release-prep PR (head ``release/vX.Y.Z``) merges
+# to main. The tag is pushed under the oss-release-bot identity so the tag-push
+# event triggers release.yaml — a ``GITHUB_TOKEN``-authored tag push would not.
+#
+# Keying off the head ref + ``merged == true`` ties tagging to an actual merged
+# release PR, so it never mis-fires on the manifest/tag drift the repo currently
+# carries (manifests at 1.2.0, published tag v1.2.1) the way a bare
+# "manifest version has no tag" trigger would.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-tag
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # the tag push is authenticated with the release App token, not GITHUB_TOKEN
+    timeout-minutes: 10
+    steps:
+      - name: Mint release App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # @v3 as 3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout merge commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
+      - name: Validate manifest version matches the release branch
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          VERSION="${HEAD_REF#release/v}"
+          MANIFEST=$(grep -E '^[[:space:]]*version:' skill-system-foundry/SKILL.md | head -1 | sed -E 's/.*version:[[:space:]]*//;s/[[:space:]]*$//')
+          if [ "$VERSION" != "$MANIFEST" ]; then
+            echo "::error::Release branch version ($VERSION) does not match the SKILL.md manifest ($MANIFEST); refusing to tag."
+            exit 1
+          fi
+          echo "Version $VERSION matches the manifest."
+
+      - name: Tag and push
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          BOT_USER_ID: ${{ vars.RELEASE_APP_BOT_USER_ID }}
+        run: |
+          set -euo pipefail
+          VERSION="${HEAD_REF#release/v}"
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists at origin; nothing to do."
+            exit 0
+          fi
+          if [ -z "${BOT_USER_ID}" ]; then
+            echo "::error::vars.RELEASE_APP_BOT_USER_ID is empty; refusing to tag with a malformed bot email."
+            exit 1
+          fi
+          BOT_LOGIN="oss-release-bot[bot]"
+          git config user.name "${BOT_LOGIN}"
+          git config user.email "${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
+          git tag -a "v${VERSION}" -m "Release v${VERSION}" "${MERGE_SHA}"
+          git push origin "v${VERSION}"

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -52,6 +52,15 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="${HEAD_REF#release/v}"
+          # Reject non-core-semver release branches (e.g. release/v1.2.3-rc.1)
+          # before any tag is pushed. release.yaml guards the tag at publish
+          # time, but the tag is created here first, so without this guard an
+          # off-grammar branch would push a tag that strands a failed publish.
+          # Grammar mirrors release-prep.yaml's dispatch gate and release.yaml.
+          if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Release branch '$HEAD_REF' is not a core-semver release branch (release/vX.Y.Z); refusing to tag."
+            exit 1
+          fi
           MANIFEST=$(grep -E '^[[:space:]]*version:' skill-system-foundry/SKILL.md | head -1 | sed -E 's/.*version:[[:space:]]*//;s/[[:space:]]*$//')
           if [ "$VERSION" != "$MANIFEST" ]; then
             echo "::error::Release branch version ($VERSION) does not match the SKILL.md manifest ($MANIFEST); refusing to tag."

--- a/.github/workflows/release-prep.yaml
+++ b/.github/workflows/release-prep.yaml
@@ -164,13 +164,16 @@ jobs:
         run: python skill-system-foundry/scripts/audit_skill_system.py .
 
       - name: Dry-build the release bundle
-        # Prove the distribution bundle builds and passes the yaml-conformance
-        # exclusion check BEFORE any release tag is cut.  release.yaml runs the
-        # same .github/scripts/build-skill-bundle.sh at publish time, so a green
-        # dry-build here means the post-merge build cannot fail and burn the
-        # (immutable) tag.  Output goes to RUNNER_TEMP so the git add -A below
-        # never stages it.
-        run: BUNDLE_PATH="$RUNNER_TEMP/dry-build.zip" bash .github/scripts/build-skill-bundle.sh
+        # Prove the distribution bundle builds, passes the yaml-conformance
+        # exclusion check, AND that the checksum write/self-verify path succeeds
+        # BEFORE any release tag is cut.  release.yaml runs the same
+        # .github/scripts/build-skill-bundle.sh with CHECKSUM_PATH set at publish
+        # time, so CHECKSUM_PATH is set here too — otherwise the helper takes the
+        # early exit and the checksum branch would stay untested until after the
+        # immutable tag is pushed.  A green dry-build here means the post-merge
+        # build cannot fail and burn the tag.  Output goes to RUNNER_TEMP so the
+        # git add -A below never stages it.
+        run: BUNDLE_PATH="$RUNNER_TEMP/dry-build.zip" CHECKSUM_PATH="$RUNNER_TEMP/dry-build.zip.sha256" bash .github/scripts/build-skill-bundle.sh
 
       - name: Commit release bump
         env:

--- a/.github/workflows/release-prep.yaml
+++ b/.github/workflows/release-prep.yaml
@@ -285,7 +285,7 @@ jobs:
         id: automation-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # @v3 as 3.1.1
         with:
-          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          client-id: ${{ vars.AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
 
       - name: Approve release PR (oss-automation-bot)

--- a/.github/workflows/release-prep.yaml
+++ b/.github/workflows/release-prep.yaml
@@ -196,20 +196,12 @@ jobs:
   test:
     needs: prepare
     if: ${{ ! inputs.dry_run }}
-    # A called workflow's jobs cannot request more permission than the
-    # caller grants, and GitHub validates that cap at startup — before
-    # job-level ``if`` skips are evaluated.  python-tests.yaml's
-    # ``update-badge`` job declares ``contents: write``; even though it
-    # is skipped under ``workflow_call`` (its ``if`` requires a push to
-    # main), the declared scope is still checked, so the caller must
-    # grant ``contents: write`` or the whole dispatch fails to compile
-    # with a logless ``startup_failure``.  python-tests.yaml defaults to
-    # ``contents: read`` at the workflow level, and only ``update-badge``
-    # raises it to ``contents: write``; the reusable jobs that do run on
-    # this call need no more than that read default, so this grant only
-    # satisfies the compile-time cap for the skipped badge job.
+    # python-tests.yaml is contents:read-only now (badge publishing moved to the
+    # separate coverage-badge.yaml), so the reusable call needs no more than
+    # read. A called workflow's jobs cannot request more permission than the
+    # caller grants, and GitHub validates that cap at startup.
     permissions:
-      contents: write
+      contents: read
     uses: ./.github/workflows/python-tests.yaml
     with:
       ref: ${{ needs.prepare.outputs.branch }}

--- a/.github/workflows/release-prep.yaml
+++ b/.github/workflows/release-prep.yaml
@@ -208,13 +208,25 @@ jobs:
     needs: [prepare, test]
     if: ${{ ! inputs.dry_run }}
     runs-on: ubuntu-latest
-    # Needs ``pull-requests: write`` for ``gh pr create`` and
-    # ``contents: read`` for the checkout.  Granted at the job level so
-    # the workflow-wide default stays read-only.
+    # Two-identity auto-merge, mirroring the fleet pattern in
+    # milanhorvatovic/codex-ai-code-review-action.  ``GITHUB_TOKEN`` stays
+    # read-only: oss-release-bot opens the PR (so its push/pull_request events
+    # trigger the required CI — GitHub does not fire downstream workflows for
+    # ``GITHUB_TOKEN``-authored events) and oss-automation-bot submits the
+    # approving review (a bot cannot approve its own PR, so a second identity is
+    # required to satisfy ``required_approving_review_count: 1``).  GitHub then
+    # enforces the ruleset normally — no admin bypass — and squash-merges on
+    # green via ``gh pr merge --auto``.
     permissions:
       contents: read
-      pull-requests: write
     steps:
+      - name: Mint release App token
+        id: release-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # @v3 as 3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
         with:
@@ -232,36 +244,64 @@ jobs:
           PREP_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           {
-            echo "Prepared by [release-prep run]($PREP_RUN_URL)."
+            echo "Prepared by [release-prep run]($PREP_RUN_URL) and opened by oss-release-bot so CI fires automatically."
             echo
             echo "## Changelog section"
             echo
             cat "$RUNNER_TEMP/pr-body-section.md"
             echo
-            echo "## Manual follow-up before merge"
+            echo "## Automated flow"
             echo
-            echo "- Review and edit version prose in \`.agents/skills/git-release/SKILL.md\` if any examples reference an outdated release."
-            echo "- Re-run CI: GitHub does not trigger PR workflows for PRs opened by \`GITHUB_TOKEN\`. Close and reopen the PR (a human action) to fire \`python-tests.yaml\` against the head."
+            echo "oss-automation-bot approves this PR, then GitHub auto-merges (squash) once the required checks pass.  On merge, \`release-on-merge.yaml\` tags \`v$VERSION\`, and the tag push triggers \`release.yaml\`, which builds the zip bundle + SHA256 checksum and creates the GitHub Release with both attached at creation (immutable-safe)."
             echo
-            echo "## Post-merge"
+            echo "If Copilot leaves an unresolved review thread, auto-merge waits until it is resolved.  To halt the release entirely, close this PR before the checks turn green."
             echo
-            echo "After this PR merges to \`main\`:"
+            echo "## Optional follow-up"
             echo
-            echo '```sh'
-            echo "gh release create v$VERSION --generate-notes"
-            echo '```'
-            echo
-            echo "The existing \`release.yml\` workflow then bundles the zip, computes the SHA256 checksum, and uploads both as release assets."
+            echo "- Review version prose in \`.agents/skills/git-release/SKILL.md\` if any examples reference an outdated release."
           } > "$RUNNER_TEMP/pr-body.md"
 
-      - name: Open release PR
+      - name: Open release PR (oss-release-bot)
+        id: open
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
           VERSION: ${{ inputs.version }}
           BRANCH: ${{ needs.prepare.outputs.branch }}
         run: |
-          gh pr create \
+          set -euo pipefail
+          url=$(gh pr create \
             --base main \
             --head "$BRANCH" \
             --title "Release v$VERSION" \
-            --body-file "$RUNNER_TEMP/pr-body.md"
+            --body-file "$RUNNER_TEMP/pr-body.md")
+          echo "Opened $url"
+          number=$(gh pr view "$url" --json number --jq '.number')
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Mint automation App token
+        id: automation-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # @v3 as 3.1.1
+        with:
+          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
+
+      - name: Approve release PR (oss-automation-bot)
+        env:
+          GH_TOKEN: ${{ steps.automation-token.outputs.token }}
+          PR_NUMBER: ${{ steps.open.outputs.number }}
+        # A second identity satisfies the ruleset's one-approval requirement; the
+        # release PR touches only manifests + CHANGELOG (no CODEOWNER-owned path),
+        # so an App approval is sufficient — no code-owner PAT needed.
+        run: |
+          set -euo pipefail
+          gh pr review --approve \
+            --body "Auto-approved by the release-prep workflow (oss-automation-bot) so the release PR can auto-merge on green." \
+            "$PR_NUMBER"
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ steps.automation-token.outputs.token }}
+          PR_NUMBER: ${{ steps.open.outputs.number }}
+        run: |
+          set -euo pipefail
+          gh pr merge --auto --squash --delete-branch "$PR_NUMBER"

--- a/.github/workflows/release-prep.yaml
+++ b/.github/workflows/release-prep.yaml
@@ -46,6 +46,7 @@ concurrency:
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Needs write to push the release branch; the rest of the steps
     # (checkout, dependency install, bump, changelog, validate, audit,
     # commit) only read.  Granted at the job level so the workflow-wide
@@ -162,6 +163,15 @@ jobs:
         # not fail the step.
         run: python skill-system-foundry/scripts/audit_skill_system.py .
 
+      - name: Dry-build the release bundle
+        # Prove the distribution bundle builds and passes the yaml-conformance
+        # exclusion check BEFORE any release tag is cut.  release.yaml runs the
+        # same .github/scripts/build-skill-bundle.sh at publish time, so a green
+        # dry-build here means the post-merge build cannot fail and burn the
+        # (immutable) tag.  Output goes to RUNNER_TEMP so the git add -A below
+        # never stages it.
+        run: BUNDLE_PATH="$RUNNER_TEMP/dry-build.zip" bash .github/scripts/build-skill-bundle.sh
+
       - name: Commit release bump
         env:
           VERSION: ${{ inputs.version }}
@@ -208,6 +218,7 @@ jobs:
     needs: [prepare, test]
     if: ${{ ! inputs.dry_run }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Two-identity auto-merge, mirroring the fleet pattern in
     # milanhorvatovic/codex-ai-code-review-action.  ``GITHUB_TOKEN`` stays
     # read-only: oss-release-bot opens the PR (so its push/pull_request events

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,12 @@ name: Release
 # pushed by release-on-merge.yaml (under the oss-release-bot identity, so the
 # tag-push event triggers this workflow — a GITHUB_TOKEN tag push would not).
 #
-# The bundle + checksum are attached in the SAME `gh release create` call. This
-# is mandatory under GitHub immutable releases: assets cannot be added after a
-# release is created, so the previous "create release, then upload" model broke.
-# The tag exists only on already-green main, so a failed create never strands a
-# reusable tag name.
+# The bundle + checksum are built by .github/scripts/build-skill-bundle.sh — the
+# same script release-prep.yaml dry-runs pre-merge, so the published bundle is
+# exactly what was proven buildable — and attached in the SAME `gh release
+# create` call. Attaching assets at creation is mandatory under GitHub immutable
+# releases: assets cannot be added after a release is created. The tag exists
+# only on already-green main, so a failed create never strands a reusable tag.
 
 on:
   push:
@@ -25,6 +26,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read  # the release is created with the release App token, not GITHUB_TOKEN
     steps:
@@ -41,66 +43,13 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
-      - name: Build zip bundle
+      - name: Build and verify bundle
         run: |
           set -euo pipefail
-          mkdir -p dist
           BUNDLE_PATH="dist/skill-system-foundry-${GITHUB_REF_NAME}.zip"
-          zip -r "$BUNDLE_PATH" skill-system-foundry/
-          echo "BUNDLE_PATH=$BUNDLE_PATH" >> "$GITHUB_ENV"
-
-      - name: Verify bundle excludes yaml-conformance corpus
-        run: |
-          : "${BUNDLE_PATH:?BUNDLE_PATH must be set}"
-          python - "$BUNDLE_PATH" <<'PY'
-          import sys, zipfile
-          z = zipfile.ZipFile(sys.argv[1])
-          hits = [n for n in z.namelist() if 'yaml-conformance' in n]
-          if hits:
-              print('Found forbidden yaml-conformance entries in bundle:', file=sys.stderr)
-              for n in hits:
-                  print(f'  {n}', file=sys.stderr)
-              sys.exit(1)
-          PY
-
-      - name: Compute SHA256 checksum
-        run: |
-          : "${BUNDLE_PATH:?BUNDLE_PATH must be set}"
           CHECKSUM_PATH="${BUNDLE_PATH}.sha256"
-          python - "$BUNDLE_PATH" "$CHECKSUM_PATH" <<'PY'
-          import hashlib, os, sys
-
-          def hash_bundle(path):
-              digest = hashlib.sha256()
-              with open(path, "rb") as fh:
-                  for chunk in iter(lambda: fh.read(1024 * 1024), b""):
-                      digest.update(chunk)
-              return digest.hexdigest()
-
-          bundle_path, checksum_path = sys.argv[1], sys.argv[2]
-          actual_name = os.path.basename(bundle_path)
-          write_line = f"{hash_bundle(bundle_path)}  {actual_name}\n"
-          with open(checksum_path, "w", encoding="utf-8", newline="\n") as fh:
-              fh.write(write_line)
-          # Re-read the checksum file and re-hash the bundle so this step confirms
-          # the checksum file matches the bundle as it exists at the end of
-          # checksum generation. (A mismatch introduced after this step but before
-          # the release upload would not be caught here.)
-          with open(checksum_path, "r", encoding="utf-8") as fh:
-              checksum_line = fh.readline().rstrip("\r\n")
-          if "  " not in checksum_line:
-              print('Malformed checksum file: expected "<sha256>  <filename>"', file=sys.stderr)
-              sys.exit(1)
-          expected_digest, expected_name = checksum_line.split("  ", 1)
-          if expected_name != actual_name:
-              print(f"Checksum filename mismatch: {expected_name!r} vs {actual_name!r}", file=sys.stderr)
-              sys.exit(1)
-          actual_digest = hash_bundle(bundle_path)
-          if actual_digest != expected_digest:
-              print(f"Checksum mismatch: file has {expected_digest}, bundle hashes to {actual_digest}", file=sys.stderr)
-              sys.exit(1)
-          print(f"{actual_name}: OK")
-          PY
+          BUNDLE_PATH="$BUNDLE_PATH" CHECKSUM_PATH="$CHECKSUM_PATH" bash .github/scripts/build-skill-bundle.sh
+          echo "BUNDLE_PATH=$BUNDLE_PATH" >> "$GITHUB_ENV"
           echo "CHECKSUM_PATH=$CHECKSUM_PATH" >> "$GITHUB_ENV"
 
       - name: Create GitHub Release with assets (immutable-safe)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,23 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
+      - name: Verify the tag is on main
+        # release-on-merge.yaml only tags merged release PRs, but this workflow
+        # fires on any pushed v*.*.* tag. Refuse to publish from a tag whose
+        # commit is not reachable from origin/main, so an accidental or manual
+        # semver tag on an unmerged/feature commit cannot build an immutable
+        # release from unvalidated source. FETCH_HEAD is used rather than the
+        # origin/main remote-tracking ref because checkout configures a
+        # single-ref fetch refspec that may not populate refs/remotes/origin/*.
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
+            echo "::error::Tag $GITHUB_REF_NAME ($GITHUB_SHA) is not reachable from origin/main; refusing to publish a release from an unmerged or untested commit."
+            exit 1
+          fi
+          echo "Tag $GITHUB_REF_NAME is on main."
+
       - name: Build and verify bundle
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,11 +69,17 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --quiet origin main
-          if ! git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
-            echo "::error::Tag $GITHUB_REF_NAME ($GITHUB_SHA) is not reachable from origin/main; refusing to publish a release from an unmerged or untested commit."
+          # Peel the tag to its commit before the ancestry check:
+          # release-on-merge.yaml creates annotated tags, and a tag-push event
+          # can surface the tag-object SHA in GITHUB_SHA rather than the commit,
+          # which git merge-base --is-ancestor would reject even when the tagged
+          # commit is on main.
+          TAG_COMMIT="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" FETCH_HEAD; then
+            echo "::error::Tag $GITHUB_REF_NAME ($TAG_COMMIT) is not reachable from origin/main; refusing to publish a release from an unmerged or untested commit."
             exit 1
           fi
-          echo "Tag $GITHUB_REF_NAME is on main."
+          echo "Tag $GITHUB_REF_NAME ($TAG_COMMIT) is on main."
 
       - name: Build and verify bundle
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,22 +1,49 @@
 name: Release
 
+# Build the skill bundle and create the GitHub Release when a vX.Y.Z tag is
+# pushed by release-on-merge.yaml (under the oss-release-bot identity, so the
+# tag-push event triggers this workflow — a GITHUB_TOKEN tag push would not).
+#
+# The bundle + checksum are attached in the SAME `gh release create` call. This
+# is mandatory under GitHub immutable releases: assets cannot be added after a
+# release is created, so the previous "create release, then upload" model broke.
+# The tag exists only on already-green main, so a failed create never strands a
+# reusable tag name.
+
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  bundle:
+  release:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read  # the release is created with the release App token, not GITHUB_TOKEN
     steps:
+      - name: Mint release App token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # @v3 as 3.1.1
+        with:
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # @v6 as 6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
 
       - name: Build zip bundle
         run: |
+          set -euo pipefail
           mkdir -p dist
           BUNDLE_PATH="dist/skill-system-foundry-${GITHUB_REF_NAME}.zip"
           zip -r "$BUNDLE_PATH" skill-system-foundry/
@@ -55,10 +82,10 @@ jobs:
           write_line = f"{hash_bundle(bundle_path)}  {actual_name}\n"
           with open(checksum_path, "w", encoding="utf-8", newline="\n") as fh:
               fh.write(write_line)
-          # Re-read the checksum file and re-hash the bundle so this step
-          # confirms the checksum file matches the bundle as it exists at the
-          # end of checksum generation. (A mismatch introduced after this step
-          # but before `gh release upload` would not be caught here.)
+          # Re-read the checksum file and re-hash the bundle so this step confirms
+          # the checksum file matches the bundle as it exists at the end of
+          # checksum generation. (A mismatch introduced after this step but before
+          # the release upload would not be caught here.)
           with open(checksum_path, "r", encoding="utf-8") as fh:
               checksum_line = fh.readline().rstrip("\r\n")
           if "  " not in checksum_line:
@@ -76,11 +103,29 @@ jobs:
           PY
           echo "CHECKSUM_PATH=$CHECKSUM_PATH" >> "$GITHUB_ENV"
 
-      - name: Upload release asset
+      - name: Create GitHub Release with assets (immutable-safe)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh release upload "$GITHUB_REF_NAME" \
-            "$BUNDLE_PATH" \
-            "$CHECKSUM_PATH" \
-            --clobber
+          set -euo pipefail
+          : "${BUNDLE_PATH:?BUNDLE_PATH must be set}"
+          : "${CHECKSUM_PATH:?CHECKSUM_PATH must be set}"
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; skipping creation."
+            exit 0
+          fi
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES_FILE="$(mktemp)"
+          awk -v ver="## [$VERSION]" '
+            substr($0, 1, length(ver)) == ver { grab = 1; print; next }
+            grab && /^## \[/ { exit }
+            grab { print }
+          ' CHANGELOG.md > "$NOTES_FILE"
+          if [ ! -s "$NOTES_FILE" ]; then
+            echo "::error::No changelog section found for $VERSION in CHANGELOG.md."
+            exit 1
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            "$BUNDLE_PATH" "$CHECKSUM_PATH" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file "$NOTES_FILE"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,21 +92,17 @@ jobs:
           : "${BUNDLE_PATH:?BUNDLE_PATH must be set}"
           : "${CHECKSUM_PATH:?CHECKSUM_PATH must be set}"
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            # A release already exists for this tag. Under immutable releases an
-            # existing release cannot be amended, so a no-op is only safe when
-            # both expected assets are already attached; an asset-less or
-            # partial release must surface loudly for manual remediation rather
-            # than be treated as success.
-            echo "Release $GITHUB_REF_NAME already exists; verifying its assets."
-            existing_assets=$(gh release view "$GITHUB_REF_NAME" --json assets --jq '.assets[].name')
-            for want in "$(basename "$BUNDLE_PATH")" "$(basename "$CHECKSUM_PATH")"; do
-              if ! grep -qxF "$want" <<<"$existing_assets"; then
-                echo "::error::Release $GITHUB_REF_NAME exists but is missing asset '$want'; immutable releases cannot be amended, so remediate manually (delete and recreate the release with both assets)."
-                exit 1
-              fi
-            done
-            echo "Release $GITHUB_REF_NAME already has the expected assets; nothing to do."
-            exit 0
+            # A release already exists for this tag. Under immutable releases it
+            # cannot be amended, and a name-only check cannot tell a correct
+            # release from one carrying stale or wrong assets under the same
+            # names. Content comparison is not reliable either: zip -r embeds
+            # file mtimes, so a fresh-checkout rebuild's bytes (and SHA256) do
+            # not match the originally published bundle even for identical
+            # sources. So refuse to silently pass over it: fail and let an
+            # operator confirm — if the existing release is wrong or incomplete,
+            # delete it and re-run; if it is correct, no action is needed.
+            echo "::error::Release $GITHUB_REF_NAME already exists; refusing to pass over it because its assets cannot be verified against this run. Inspect it manually, then delete and re-run if its assets are stale or incomplete."
+            exit 1
           fi
           VERSION="${GITHUB_REF_NAME#v}"
           NOTES_FILE="$(mktemp)"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,21 @@ jobs:
     permissions:
       contents: read  # the release is created with the release App token, not GITHUB_TOKEN
     steps:
+      - name: Guard against non-core-semver tags
+        # The trigger glob ``v*.*.*`` also matches prerelease/build-metadata
+        # tags (e.g. ``v1.2.3-rc.1``), but this pipeline publishes core
+        # ``vX.Y.Z`` releases only. Reject anything else before minting tokens
+        # so a stray prerelease tag push cannot strand an immutable tag with a
+        # half-built or section-less release. The grammar mirrors the dispatch
+        # gate in release-prep.yaml.
+        run: |
+          set -euo pipefail
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::Tag '$GITHUB_REF_NAME' is not a core-semver vX.Y.Z release tag; refusing to publish."
+            exit 1
+          fi
+          echo "Tag $GITHUB_REF_NAME is a core-semver release tag."
+
       - name: Mint release App token
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # @v3 as 3.1.1
@@ -60,7 +75,20 @@ jobs:
           : "${BUNDLE_PATH:?BUNDLE_PATH must be set}"
           : "${CHECKSUM_PATH:?CHECKSUM_PATH must be set}"
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            echo "Release $GITHUB_REF_NAME already exists; skipping creation."
+            # A release already exists for this tag. Under immutable releases an
+            # existing release cannot be amended, so a no-op is only safe when
+            # both expected assets are already attached; an asset-less or
+            # partial release must surface loudly for manual remediation rather
+            # than be treated as success.
+            echo "Release $GITHUB_REF_NAME already exists; verifying its assets."
+            existing_assets=$(gh release view "$GITHUB_REF_NAME" --json assets --jq '.assets[].name')
+            for want in "$(basename "$BUNDLE_PATH")" "$(basename "$CHECKSUM_PATH")"; do
+              if ! grep -qxF "$want" <<<"$existing_assets"; then
+                echo "::error::Release $GITHUB_REF_NAME exists but is missing asset '$want'; immutable releases cannot be amended, so remediate manually (delete and recreate the release with both assets)."
+                exit 1
+              fi
+            done
+            echo "Release $GITHUB_REF_NAME already has the expected assets; nothing to do."
             exit 0
           fi
           VERSION="${GITHUB_REF_NAME#v}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ This repository contains **one skill** (`skill-system-foundry/`) and its **test 
     │   ├── python-tests.yaml        ← tests + coverage + badge update (ubuntu + windows)
     │   ├── shellcheck.yaml          ← lints .github/scripts/*.sh
     │   ├── codex-code-review.yaml   ← Codex PR review via codex-ai-code-review-action
-    │   └── release.yml              ← bundles zip + uploads release asset
+    │   └── release.yaml              ← bundles zip + uploads release asset
     ├── instructions/                ← review rules for Copilot/Codex
     │   ├── markdown.instructions.md ← applies to **/*.md
     │   └── scripts.instructions.md  ← applies to scripts/**/*.py
@@ -328,7 +328,7 @@ Automated validation (`validate_skill.py`, `audit_skill_system.py`) handles many
 
 ## Release Process
 
-Version lives in three files that must agree: `skill-system-foundry/SKILL.md` frontmatter (`metadata.version`, canonical), `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`. The version-consistency rule in `audit_skill_system.py` fails the repo-root audit if they drift. Tags mirror as `vX.Y.Z`. The `release.yml` workflow auto-bundles a zip and uploads it as a release asset. Run full validation and tests before tagging.
+Version lives in three files that must agree: `skill-system-foundry/SKILL.md` frontmatter (`metadata.version`, canonical), `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`. The version-consistency rule in `audit_skill_system.py` fails the repo-root audit if they drift. Tags mirror as `vX.Y.Z`. The `release.yaml` workflow auto-bundles a zip and uploads it as a release asset. Run full validation and tests before tagging.
 
 Bump all three manifest files in lockstep with `scripts/bump_version.py`:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,7 +328,9 @@ Automated validation (`validate_skill.py`, `audit_skill_system.py`) handles many
 
 ## Release Process
 
-Version lives in three files that must agree: `skill-system-foundry/SKILL.md` frontmatter (`metadata.version`, canonical), `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`. The version-consistency rule in `audit_skill_system.py` fails the repo-root audit if they drift. Tags mirror as `vX.Y.Z`. The `release.yaml` workflow auto-bundles a zip and uploads it as a release asset. Run full validation and tests before tagging.
+Version lives in three files that must agree: `skill-system-foundry/SKILL.md` frontmatter (`metadata.version`, canonical), `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`. The version-consistency rule in `audit_skill_system.py` fails the repo-root audit if they drift. Tags mirror as `vX.Y.Z`.
+
+Releases are automated: dispatch the `release-prep.yaml` workflow with the target version and it bumps the three manifests, prepends the changelog, dry-builds the bundle, opens the release PR as oss-release-bot, has oss-automation-bot approve it, and auto-merges on green; `release-on-merge.yaml` then tags the merge commit and `release.yaml` builds the bundle and creates the GitHub Release with the zip + SHA256 attached at creation. The manual tooling below is what that workflow runs internally, and the path to use when dispatching is unavailable (offline, or regenerating a past release). Run full validation and tests before tagging by hand.
 
 Bump all three manifest files in lockstep with `scripts/bump_version.py`:
 
@@ -339,7 +341,7 @@ python scripts/bump_version.py NEXT_VERSION             # write the three files 
 
 The script rejects invalid semver, equal versions, and downgrades (unless `--allow-downgrade` is passed), refuses to run when the three files already disagree, and probes the changelog generator in `--dry-run` mode before touching disk. The changelog step below is only needed when calling the generator directly (for example, to regenerate a past release).
 
-When publishing the GitHub Release, paste the body from [`.github/RELEASE_NOTES_TEMPLATE.md`](.github/RELEASE_NOTES_TEMPLATE.md) and replace every `{VERSION}` placeholder with the release number. Generate the changelog section using the checklist below.
+When publishing a release **by hand** — the dispatch path generates release notes from the matching `CHANGELOG.md` section automatically — paste the body from [`.github/RELEASE_NOTES_TEMPLATE.md`](.github/RELEASE_NOTES_TEMPLATE.md) and replace every `{VERSION}` placeholder with the release number. Generate the changelog section using the checklist below.
 
 1. **Preview** the section for the exact commit you intend to tag. Substitute the previous tag and the new release number (e.g., `--since v1.1.0 --version 1.2.0`) — not SemVer build metadata like `+1`. Pin `--until` so the range cannot drift between the preview and the write.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,10 +105,20 @@ This repository contains **one skill** (`skill-system-foundry/`) and its **test 
     │   └── review-reference.md      ← repository-specific review guidance
     ├── scripts/                     ← CI helper scripts (bash + Python)
     ├── workflows/                   ← GitHub Actions CI/CD
-    │   ├── python-tests.yaml        ← tests + coverage + badge update (ubuntu + windows)
-    │   ├── shellcheck.yaml          ← lints .github/scripts/*.sh
-    │   ├── codex-code-review.yaml   ← Codex PR review via codex-ai-code-review-action
-    │   └── release.yaml              ← bundles zip + uploads release asset
+    │   ├── actionlint.yaml              ← lints workflow YAML
+    │   ├── ci-helper-tests.yaml         ← tests .github/scripts helpers (ubuntu + windows)
+    │   ├── codeql.yaml                  ← CodeQL security analysis
+    │   ├── codex-code-review.yaml       ← Codex PR review via codex-ai-code-review-action
+    │   ├── coverage-badge.yaml          ← updates the coverage badge on push to main
+    │   ├── python-tests.yaml            ← tests + coverage (ubuntu + windows)
+    │   ├── release-prep.yaml            ← dispatch: bump, changelog, open/approve/auto-merge release PR
+    │   ├── release-on-merge.yaml        ← tags vX.Y.Z when a release PR merges
+    │   ├── release.yaml                 ← builds the bundle + creates the GitHub Release on tag push
+    │   ├── scorecard.yaml               ← OpenSSF Scorecard supply-chain analysis
+    │   ├── shellcheck.yaml              ← lints .github/scripts/*.sh
+    │   ├── tool-catalog-drift.yaml      ← weekly Claude Code tool-catalog drift PR
+    │   ├── verify-action-pins.yaml      ← enforces SHA-pinned actions
+    │   └── verify-pr-release-label.yaml ← report-only PR release-label check
     ├── instructions/                ← review rules for Copilot/Codex
     │   ├── markdown.instructions.md ← applies to **/*.md
     │   └── scripts.instructions.md  ← applies to scripts/**/*.py

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ CI validates each skill example on every push and pull request. The examples shi
 
 Shipped versions and what changed between them are tracked in [CHANGELOG.md](CHANGELOG.md). Each release is also published as a versioned zip on the [Releases](https://github.com/milanhorvatovic/skill-system-foundry/releases) page (with a SHA256 checksum file alongside it; see the [GitHub Releases](#github-releases) installation section for verification commands).
 
-Maintainer release flow at a glance: dispatch the `Release prep` workflow with the new version → review and merge the auto-opened release PR → run `gh release create vX.Y.Z --generate-notes`. The post-merge `release.yaml` workflow then bundles the zip and publishes the assets. Detailed steps live in the `git-release` skill under `.agents/skills/git-release/SKILL.md`.
+Maintainer release flow at a glance: dispatch the `Release prep` workflow with the new version — it bumps the manifests, opens the release PR, auto-approves and auto-merges it on green, then tags the merge commit and publishes the versioned zip + checksum automatically. Detailed steps live in the `git-release` skill under `.agents/skills/git-release/SKILL.md`.
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -176,13 +176,13 @@ The [`examples/`](examples/) directory ships three reference examples — two sk
 - **[`examples/skills/hello-router/`](examples/skills/hello-router/SKILL.md)** — a router skill dispatching to two capabilities, with `allowed-tools: Bash` declared so a fenced bash example in one capability stays coherent.
 - **[`examples/roles/hello-orchestrator.md`](examples/roles/hello-orchestrator.md)** — a role contract composing the standalone and router skills above, with the canonical responsibility / allowed / forbidden / handoff / "Skills Used" structure.
 
-CI validates each skill example on every push and pull request. The examples ship in the repository for onboarding only — `release.yml` zips just `skill-system-foundry/`, so the directory adds no weight to the distributed bundle.
+CI validates each skill example on every push and pull request. The examples ship in the repository for onboarding only — `release.yaml` zips just `skill-system-foundry/`, so the directory adds no weight to the distributed bundle.
 
 ## Releases
 
 Shipped versions and what changed between them are tracked in [CHANGELOG.md](CHANGELOG.md). Each release is also published as a versioned zip on the [Releases](https://github.com/milanhorvatovic/skill-system-foundry/releases) page (with a SHA256 checksum file alongside it; see the [GitHub Releases](#github-releases) installation section for verification commands).
 
-Maintainer release flow at a glance: dispatch the `Release prep` workflow with the new version → review and merge the auto-opened release PR → run `gh release create vX.Y.Z --generate-notes`. The post-merge `release.yml` workflow then bundles the zip and publishes the assets. Detailed steps live in the `git-release` skill under `.agents/skills/git-release/SKILL.md`.
+Maintainer release flow at a glance: dispatch the `Release prep` workflow with the new version → review and merge the auto-opened release PR → run `gh release create vX.Y.Z --generate-notes`. The post-merge `release.yaml` workflow then bundles the zip and publishes the assets. Detailed steps live in the `git-release` skill under `.agents/skills/git-release/SKILL.md`.
 
 ## Repository Structure
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 This directory is a self-contained mini skill-system that demonstrates the three patterns the foundry supports: a standalone skill, a router skill with capabilities, and a role that composes both. The layout mirrors a deployed skill-system root (a top-level `skills/` and `roles/` directory), so the examples teach the same paths bundling and orchestration use in real projects.
 
-The examples ship in the repository for onboarding only. The release zip published by `release.yml` packages just `skill-system-foundry/`, so nothing in `examples/` adds weight to the distributed bundle.
+The examples ship in the repository for onboarding only. The release zip published by `release.yaml` packages just `skill-system-foundry/`, so nothing in `examples/` adds weight to the distributed bundle.
 
 ## Layout
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -140,7 +140,7 @@ _SEMVER_RE = re.compile(
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 
-# Subjects produced by the ``release-prep.yml`` workflow's bump commit.
+# Subjects produced by the ``release-prep.yaml`` workflow's bump commit.
 # These are meta-commits that should not appear in the changelog of the
 # version they introduce — the section they prepend already records the
 # real changes.  They are also not candidates for "unmapped — review

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -316,7 +316,7 @@ class ClassifyCommitsTests(unittest.TestCase):
         self.assertEqual(buckets["Added"], ["Add A", "Add B", "Add C"])
 
     def test_release_bump_commit_is_skipped(self) -> None:
-        # Bump commits produced by release-prep.yml ("Release vX.Y.Z")
+        # Bump commits produced by release-prep.yaml ("Release vX.Y.Z")
         # must not appear in the section they introduce, must not
         # surface on stderr as unmapped (the verb is intentionally not
         # mapped — see issue #106), and must be reported via the

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -2,7 +2,7 @@
 
 Covers the scaffold -> validate -> bundle -> unzip -> validate flow across
 bundle targets, and the `zip -r` release-artifact shape produced by
-``.github/workflows/release.yml``. Runs on the ubuntu + windows matrix in
+``.github/workflows/release.yaml``. Runs on the ubuntu + windows matrix in
 ``python-tests.yaml`` without any workflow changes.
 """
 
@@ -212,13 +212,13 @@ class ScaffoldBundlePipelineTests(unittest.TestCase):
 
 
 class ReleaseArtifactPipelineTests(unittest.TestCase):
-    """Mirror release.yml's `zip -r skill-system-foundry/` artifact.
+    """Mirror release.yaml's `zip -r skill-system-foundry/` artifact.
 
-    release.yml does not run bundle.py — it ships a raw zip of the
+    release.yaml does not run bundle.py — it ships a raw zip of the
     skill directory. This test guards that specific artifact shape
     against the same "unzip and validate on a clean machine" regression
     the bundle pipeline case guards for user skills, plus the
-    yaml-conformance exclusion that release.yml asserts inline.
+    yaml-conformance exclusion that release.yaml asserts inline.
     """
 
     def test_released_artifact_unzips_and_validates(self) -> None:
@@ -233,11 +233,11 @@ class ReleaseArtifactPipelineTests(unittest.TestCase):
             # Stdlib zipfile mirrors `zip -r` semantics and works on
             # Windows matrix cells where the `zip` CLI is absent.
             # Bytecode (__pycache__/, *.pyc) is pruned so the local run
-            # matches release.yml's fresh-checkout shape; otherwise a
+            # matches release.yaml's fresh-checkout shape; otherwise a
             # developer's stale bytecode would diverge from the real
             # release artifact and could mask a regression. IDE / OS
             # scratch files (.DS_Store, Thumbs.db, .idea/, .vscode/)
-            # are not filtered — release.yml's `zip -r` would include
+            # are not filtered — release.yaml's `zip -r` would include
             # them too, so the test stays faithful to that behaviour.
             with zipfile.ZipFile(artifact, "w", zipfile.ZIP_DEFLATED) as zf:
                 for dirpath, dirnames, filenames in os.walk(FOUNDRY_DIR):
@@ -254,7 +254,7 @@ class ReleaseArtifactPipelineTests(unittest.TestCase):
                         arcname = os.path.relpath(abs_path, REPO_ROOT).replace(os.sep, "/")
                         zf.write(abs_path, arcname)
 
-            # Mirror release.yml's "Verify bundle excludes yaml-conformance
+            # Mirror release.yaml's "Verify bundle excludes yaml-conformance
             # corpus" step. The corpus currently lives outside the bundled
             # path, so this is a passive invariant — pin it here so a
             # future restructure that pulls the corpus into the bundle


### PR DESCRIPTION
## Summary

End-to-end release automation: dispatch a version, and the release PR opens, auto-approves, auto-merges on green, tags, and publishes — with assets attached **at creation** (immutable-safe).

## Flow

Dispatch `release-prep` (version) → `oss-release-bot` opens the release PR so CI fires → `oss-automation-bot` approves (satisfies the one-review rule) → GitHub auto-merges on green → `release-on-merge` tags `vX.Y.Z` → `release.yaml` builds the bundle and creates the GitHub Release with the zip + SHA256 attached at creation.

## Changes

- `release-prep.yaml` — two-identity open/approve/auto-merge; the `test` job is `contents: read` (the reusable `python-tests` is read-only). Both App tokens are minted via the `client-id` input, and the pre-merge dry-build runs the full bundle path including checksum write/verify.
- `release-on-merge.yaml` (new) — tags the merge commit when a `release/v*` PR lands, under `oss-release-bot` (so the tag push triggers the next step).
- `release.yaml` — triggers on a `v*.*.*` tag push and creates the Release with assets at creation. This replaces the old `release: published` upload-after model, which cannot attach assets under GitHub immutable releases (the cause of the v1.2.0 → v1.2.1 incident).
- `build-skill-bundle.sh` (new) — single source for the bundle build; `release-prep` dry-builds it pre-merge so a broken bundle can never reach (and burn) an immutable tag. It rebuilds from scratch and excludes Python bytecode.
- `.yml` → `.yaml` workflow rename + reference updates across docs and tests.
- Release-process docs rewritten for the automated flow; workflow inventories and App-secret naming docs refreshed.

## Safety rails

The tag/publish path fails closed so a bad input cannot strand an immutable tag or publish unvalidated content:

- Core-semver only: `release-prep` (dispatch input), `release-on-merge` (release branch), and `release.yaml` (pushed tag) each reject anything but `vX.Y.Z`.
- `release.yaml` refuses to publish a tag whose commit is not reachable from `origin/main`, peeling the tag to its commit first since `release-on-merge` creates annotated tags.
- `release.yaml` refuses to pass over a pre-existing release rather than silently treating a possibly stale one as success.
- `release-on-merge` verifies an existing tag points at the merge commit before treating a rerun as a no-op, and reads `metadata.version` via the repo's stdlib parser instead of a grep/sed pipeline.

## Prerequisites (already provisioned)

`oss-release-bot` (`RELEASE_CLIENT_ID`, `RELEASE_APP_PRIVATE_KEY`, `RELEASE_APP_BOT_USER_ID`), `oss-automation-bot` (`AUTOMATION_CLIENT_ID`, `AUTOMATION_PRIVATE_KEY`), and the `allow_auto_merge` repo setting. Confirm `oss-release-bot` is *installed* on the repo with Contents + Pull requests write.

## Not in this PR

Label-driven version computation (compute-from-labels) is a follow-up; the report-only release-label check that seeds it already lives on `main`.
