### PR TITLE
Add report-only release-label check and document the taxonomy

### DIFF
--- a/.github/workflows/verify-pr-release-label.yaml
+++ b/.github/workflows/verify-pr-release-label.yaml
@@ -1,0 +1,44 @@
+name: verify-pr-release-label
+
+# Checks that each PR carries exactly one `release: major|minor|patch|skip`
+# label — the signal the (future) label-driven version computation reads.
+#
+# REPORT-ONLY for now: it warns but never fails, so it cannot strand open PRs
+# before the labeling habit and the Dependabot auto-labeler are in place. A
+# later change (WI-4 in docs/automation-unification-plan.md) flips it to a
+# required, blocking check.
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: verify-pr-release-label-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Verify exactly one release label (report-only)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          total=$(gh pr view "$PR" --repo "$REPO" --json labels \
+            --jq '[.labels[].name | select(startswith("release: "))] | length')
+          valid=$(gh pr view "$PR" --repo "$REPO" --json labels \
+            --jq '[.labels[].name | select(. == "release: major" or . == "release: minor" or . == "release: patch" or . == "release: skip")] | length')
+          if [ "$total" = "1" ] && [ "$valid" = "1" ]; then
+            echo "OK: exactly one valid release label."
+          else
+            echo "::warning::This PR should carry exactly one of 'release: major', 'release: minor', 'release: patch', 'release: skip' (found $total release-prefixed label(s), $valid valid). Report-only for now — this becomes a required check once the labeling habit and the Dependabot auto-labeler are in place."
+          fi

--- a/.github/workflows/verify-pr-release-label.yaml
+++ b/.github/workflows/verify-pr-release-label.yaml
@@ -3,10 +3,10 @@ name: verify-pr-release-label
 # Checks that each PR carries exactly one `release: major|minor|patch|skip`
 # label — the signal the (future) label-driven version computation reads.
 #
-# REPORT-ONLY for now: it warns but never fails, so it cannot strand open PRs
-# before the labeling habit and the Dependabot auto-labeler are in place. A
-# later change (WI-4 in docs/automation-unification-plan.md) flips it to a
-# required, blocking check.
+# REPORT-ONLY for now: it warns but never fails — not even on a transient
+# gh/API error — so it cannot strand open PRs or add red CI noise before the
+# labeling habit and the Dependabot auto-labeler are in place. A later change
+# makes it a required, blocking check.
 
 on:
   pull_request:
@@ -32,11 +32,15 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          set -euo pipefail
-          total=$(gh pr view "$PR" --repo "$REPO" --json labels \
-            --jq '[.labels[].name | select(startswith("release: "))] | length')
-          valid=$(gh pr view "$PR" --repo "$REPO" --json labels \
-            --jq '[.labels[].name | select(. == "release: major" or . == "release: minor" or . == "release: patch" or . == "release: skip")] | length')
+          set -uo pipefail
+          # Fail-soft: a transient gh/API error must not turn this report-only
+          # check red. If the read fails, warn and pass.
+          if ! labels=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name'); then
+            echo "::warning::Could not read PR labels (transient gh/API error); skipping the report-only release-label check."
+            exit 0
+          fi
+          total=$(printf '%s\n' "$labels" | grep -c '^release: ' || true)
+          valid=$(printf '%s\n' "$labels" | grep -cE '^release: (major|minor|patch|skip)$' || true)
           if [ "$total" = "1" ] && [ "$valid" = "1" ]; then
             echo "OK: exactly one valid release label."
           else

--- a/.github/workflows/verify-pr-release-label.yaml
+++ b/.github/workflows/verify-pr-release-label.yaml
@@ -32,7 +32,12 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          # Report-only contract: this check warns but must never fail. The
+          # default Actions bash shell runs with -e (errexit), so disable it
+          # explicitly and end with an unconditional exit 0 — neither a
+          # transient gh/API error nor a future edit may turn this check red.
           set -uo pipefail
+          set +e
           # Fail-soft: a transient gh/API error must not turn this report-only
           # check red. If the read fails, warn and pass.
           if ! labels=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name'); then
@@ -46,3 +51,4 @@ jobs:
           else
             echo "::warning::This PR should carry exactly one of 'release: major', 'release: minor', 'release: patch', 'release: skip' (found $total release-prefixed label(s), $valid valid). Report-only for now — this becomes a required check once the labeling habit and the Dependabot auto-labeler are in place."
           fi
+          exit 0

--- a/.github/workflows/verify-pr-release-label.yaml
+++ b/.github/workflows/verify-pr-release-label.yaml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  verify:
+  verify-release-label:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/verify-pr-release-label.yaml
+++ b/.github/workflows/verify-pr-release-label.yaml
@@ -33,11 +33,19 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           # Report-only contract: this check warns but must never fail. The
-          # default Actions bash shell runs with -e (errexit), so disable it
-          # explicitly and end with an unconditional exit 0 — neither a
-          # transient gh/API error nor a future edit may turn this check red.
-          set -uo pipefail
+          # default Actions bash shell runs with -e (errexit); disable it and
+          # skip -u (nounset) — errexit aborts on any non-zero exit and
+          # nounset aborts on any unset variable, either of which could turn
+          # this check red after a future edit. Validate inputs defensively
+          # and end with an unconditional exit 0 instead.
           set +e
+          set -o pipefail
+          # The pull_request event always supplies these; guard anyway so a
+          # missing value warns and passes rather than aborting the job.
+          if [ -z "${PR:-}" ] || [ -z "${REPO:-}" ]; then
+            echo "::warning::PR number or repository unavailable; skipping the report-only release-label check."
+            exit 0
+          fi
           # Fail-soft: a transient gh/API error must not turn this report-only
           # check red. If the read fails, warn and pass.
           if ! labels=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name'); then

--- a/.github/workflows/verify-pr-release-label.yaml
+++ b/.github/workflows/verify-pr-release-label.yaml
@@ -12,8 +12,12 @@ on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize]
 
+# Least-privilege: the check only reads PR labels via `gh pr view`, so the
+# single job needs pull-requests:read and nothing else. Declared once at the
+# top level — adding a job-level block here would shadow this and read as a
+# different grant than the one in effect.
 permissions:
-  contents: read
+  pull-requests: read
 
 concurrency:
   group: verify-pr-release-label-${{ github.event.pull_request.number }}
@@ -23,8 +27,6 @@ jobs:
   verify-release-label:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    permissions:
-      pull-requests: read
     steps:
       - name: Verify exactly one release label (report-only)
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,13 +123,13 @@ Fix <issue> in <component>
    - Which area of the project is affected (documentation, scripts, templates, etc.)
    - How you validated the changes
 
-6. **Label the release impact.** Apply exactly one `release:` label:
-   - `release: major` — a breaking change
+6. **Label the release impact.** Apply exactly one `release:` label. The line between `patch` and `skip` is "does anything user-facing ship?":
+   - `release: major` — a breaking change to the shipped skill
    - `release: minor` — a new, backwards-compatible feature
-   - `release: patch` — a bug fix, docs, or internal change
-   - `release: skip` — no user-facing change (does not influence the next version)
+   - `release: patch` — a user-facing fix or change worth a release note (bug fix, corrected/clarified skill docs)
+   - `release: skip` — nothing user-facing ships, so it does not influence the next version (CI, tests, internal tooling, repo meta, contributor docs)
 
-   The next release version is computed from these labels across merged PRs, so each PR must declare its impact. The `verify-pr-release-label` check flags a missing or ambiguous label — currently report-only, becoming required once the labeling habit is established. Dependabot PRs are labeled automatically.
+   The next release version is computed from these labels across merged PRs, so each PR must declare its impact. The `verify-pr-release-label` check flags a missing or ambiguous label (currently report-only; it becomes required once the labeling habit is established). A follow-up will label Dependabot PRs automatically — until then, label them by hand.
 
 7. **Respond to feedback.** PRs may require revisions before merging.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ Fix <issue> in <component>
    - `release: patch` — a user-facing fix or change worth a release note (bug fix, corrected/clarified skill docs)
    - `release: skip` — nothing user-facing ships, so it does not influence the next version (CI, tests, internal tooling, repo meta, contributor docs)
 
-   The next release version is computed from these labels across merged PRs, so each PR must declare its impact. The `verify-pr-release-label` check flags a missing or ambiguous label (currently report-only; it becomes required once the labeling habit is established). A follow-up will label Dependabot PRs automatically — until then, label them by hand.
+   These labels are the planned input for label-driven release automation, so each PR must declare its impact before that check becomes blocking. The `verify-pr-release-label` check flags a missing or ambiguous label (currently report-only; it becomes required once the labeling habit is established). A follow-up will label Dependabot PRs automatically — until then, label them by hand.
 
 7. **Respond to feedback.** PRs may require revisions before merging.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ Fix <issue> in <component>
    - How you validated the changes
 
 6. **Label the release impact.** Apply exactly one `release:` label. The line between `patch` and `skip` is "does anything user-facing ship?":
-   - `release: major` — a breaking change to the shipped skill
+   - `release: major` — a breaking change to the published meta-skill (a removed or renamed capability or script, or a backwards-incompatible change to a validation rule or script interface)
    - `release: minor` — a new, backwards-compatible feature
    - `release: patch` — a user-facing fix or change worth a release note (bug fix, corrected/clarified skill docs)
    - `release: skip` — nothing user-facing ships, so it does not influence the next version (CI, tests, internal tooling, repo meta, contributor docs)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,15 @@ Fix <issue> in <component>
    - Which area of the project is affected (documentation, scripts, templates, etc.)
    - How you validated the changes
 
-6. **Respond to feedback.** PRs may require revisions before merging.
+6. **Label the release impact.** Apply exactly one `release:` label:
+   - `release: major` — a breaking change
+   - `release: minor` — a new, backwards-compatible feature
+   - `release: patch` — a bug fix, docs, or internal change
+   - `release: skip` — no user-facing change (does not influence the next version)
+
+   The next release version is computed from these labels across merged PRs, so each PR must declare its impact. The `verify-pr-release-label` check flags a missing or ambiguous label — currently report-only, becoming required once the labeling habit is established. Dependabot PRs are labeled automatically.
+
+7. **Respond to feedback.** PRs may require revisions before merging.
 
 ## What Happens Next
 


### PR DESCRIPTION
## Summary

Lays the **shared label foundation** that both the dependency auto-merge and the label-driven release version computation build on (WI-1 in `docs/automation-unification-plan.md`).

## Changes

- **`verify-pr-release-label.yaml`** — checks that each PR carries exactly one `release: major|minor|patch|skip` label. **Report-only**: it warns but never fails, so it cannot strand open PRs before the labeling habit and the Dependabot auto-labeler exist. A later change (WI-4) flips it to a required, blocking check.
- **`CONTRIBUTING.md`** — documents the taxonomy and the one-label-per-PR rule in the pull-request process, and notes that the next release version is computed from these labels.

## Why this first

The `release:` label is the single signal both phases consume — dependency PRs get auto-labeled and routed (auto-merge patch/minor, hold major), and the release version is derived from the labels of merged PRs. Landing it report-only now establishes the habit safely before anything depends on it.

## Not in this PR

The Dependabot auto-labeler (WI-2), the version computation (release WI-3), and making this check required (WI-4) are separate follow-ups.
