### PR TITLE
Add hands-off Dependabot auto-merge with security gates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,7 +2,25 @@
 # Bumps the SHA-pinned GitHub Actions (verify-action-pins.yaml requires SHA
 # pins; Dependabot understands them and rewrites both the pin and its version
 # comment) and the Python dev dependency declared in requirements-dev.txt.
-# Updates are grouped so each ecosystem opens at most one rolling PR per week.
+#
+# Each ecosystem opens one rolling group PR per week for minor + patch bumps.
+# Semver-major bumps split into standalone PRs so the auto-merge workflow's
+# semver-major gate can route them to manual review without holding unrelated
+# patch/minor bumps along with them.
+#
+# Trust-boundary actions that execute with secrets in scope are excluded from
+# the github-actions group so they always arrive as standalone PRs that the
+# auto-merge exclude-by-name guard holds for manual review, instead of one of
+# their bumps poisoning the whole group's auto-merge:
+#   - actions/create-github-app-token mints the App private key.
+#   - milanhorvatovic/codex-ai-code-review-action runs with OPENAI_API_KEY.
+# Extend exclude-patterns (and the auto-merge guard) when a new action-level
+# trust-boundary dependency is added to the repo.
+#
+# Static labels per ecosystem entry (applied to grouped and standalone PRs
+# alike): `dependencies` + the ecosystem + `release: patch`. The fast-path
+# `release: patch` default is corrected to `release: major` for standalone
+# semver-major PRs by dependabot-release-label.yaml.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -10,11 +28,23 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    # Raised from 5: majors and the two excluded trust-boundary actions now
+    # split into standalone PRs, structurally increasing the open-PR count.
+    open-pull-requests-limit: 10
     groups:
       github-actions:
         patterns:
           - "*"
+        exclude-patterns:
+          - "actions/create-github-app-token"
+          - "milanhorvatovic/codex-ai-code-review-action"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "release: patch"
 
   - package-ecosystem: pip
     directory: "/"
@@ -26,3 +56,10 @@ updates:
       python-dev:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "python"
+      - "release: patch"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -242,12 +242,20 @@ jobs:
               true)
                 echo "security-review label is now present; reverting auto-merge."
                 gh pr merge --disable-auto "$PR_URL" || true
-                verify_disarmed || true
+                # Hard-stop if the disarm cannot be confirmed: a still-armed
+                # security-review PR is a policy bypass. exit (not return) so the
+                # failure can't be swallowed by a caller's `|| true`. On a
+                # confirmed disarm, fall through to `return 1` to abort the merge.
+                verify_disarmed || exit 1
                 return 1 ;;
               unknown)
                 echo "::error::Failed to verify security-review label state after arming auto-merge. Defensively disabling auto-merge to avoid a possible policy bypass."
                 gh pr merge --disable-auto "$PR_URL" || true
-                verify_disarmed || true
+                # Hard-stop if the disarm cannot be confirmed: a still-armed
+                # security-review PR is a policy bypass. exit (not return) so the
+                # failure can't be swallowed by a caller's `|| true`. On a
+                # confirmed disarm, fall through to `return 1` to abort the merge.
+                verify_disarmed || exit 1
                 return 1 ;;
             esac
             return 0

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -210,10 +210,29 @@ jobs:
             esac
           }
 
+          # Confirm auto-merge is actually cleared after a --disable-auto call.
+          # A --disable-auto that reports success without taking effect would
+          # leave a security-review PR armed, so re-query and treat a still-armed
+          # (or unverifiable) PR as a failure — the same verify-it-took pattern as
+          # verify_auto_merge_or_terminal. Emits its own ::error on failure.
+          verify_disarmed() {
+            local am
+            if ! am=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest'); then
+              echo "::error::Failed to verify auto-merge was disabled after --disable-auto; cannot confirm the PR is disarmed. Investigate immediately."
+              return 1
+            fi
+            if [ "$am" != "null" ]; then
+              echo "::error::auto-merge is still enabled after --disable-auto. The PR may merge automatically despite the security-review hold. Investigate immediately."
+              return 1
+            fi
+            return 0
+          }
+
           # Enable GitHub auto-merge, verify it took, and revert it if a
           # security-review label is now present (or its state is unknown).
           # Disable-auto on a security-review PR is a hard failure: a silently
           # armed auto-merge on a must-stay-manual PR is worse than a noisy fail.
+          # Both revert paths verify the disarm actually cleared auto-merge.
           arm_auto_merge() {
             gh pr merge --auto --squash "$PR_URL" 2>&1 || true
             if ! verify_auto_merge_or_terminal; then
@@ -222,16 +241,13 @@ jobs:
             case "$(security_review_state)" in
               true)
                 echo "security-review label is now present; reverting auto-merge."
-                if ! gh pr merge --disable-auto "$PR_URL"; then
-                  echo "::error::Failed to disable auto-merge on a security-review PR. It may still merge automatically, bypassing required manual review. Investigate immediately."
-                  return 1
-                fi
+                gh pr merge --disable-auto "$PR_URL" || true
+                verify_disarmed || true
                 return 1 ;;
               unknown)
                 echo "::error::Failed to verify security-review label state after arming auto-merge. Defensively disabling auto-merge to avoid a possible policy bypass."
-                if ! gh pr merge --disable-auto "$PR_URL"; then
-                  echo "::error::Failed to defensively disable auto-merge on a possibly security-review-required PR. Investigate immediately."
-                fi
+                gh pr merge --disable-auto "$PR_URL" || true
+                verify_disarmed || true
                 return 1 ;;
             esac
             return 0
@@ -353,6 +369,7 @@ jobs:
     if: >-
       github.event.action == 'labeled' &&
       (github.event.label.name == 'trust-boundary' || github.event.label.name == 'security-review-required') &&
+      github.event.pull_request.state == 'open' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
@@ -376,3 +393,11 @@ jobs:
             exit 0
           fi
           gh pr merge --disable-auto "$PR_URL"
+          # Verify the disarm took: a --disable-auto that reports success without
+          # clearing the request would leave this security-review PR armed.
+          auto_merge=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest')
+          if [ "$auto_merge" != "null" ]; then
+            echo "::error::auto-merge is still enabled after --disable-auto. The PR may merge automatically despite the security-review hold. Investigate immediately."
+            exit 1
+          fi
+          echo "Auto-merge disabled."

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,356 @@
+name: Dependabot Auto-Merge
+
+# Auto-merges patch/minor Dependabot PRs hands-off; holds majors, the two
+# trust-boundary actions, and security-review-labeled PRs for manual review.
+#
+# Hold gate (any one holds the PR):
+#   - effective update-type is semver-major (majors split into standalone PRs);
+#   - the bump touches a trust-boundary action that runs with secrets in scope
+#     (actions/create-github-app-token, milanhorvatovic/codex-ai-code-review-action);
+#   - the PR carries `trust-boundary` or `security-review-required`.
+#
+# A repository variable DEPENDABOT_AUTOMERGE_ENABLED is the kill-switch: the job
+# always runs and logs the switch state, but the approve and merge steps only
+# act when it is exactly 'true'. Missing/unset disables auto-merge (PRs wait for
+# a manual merge) — a fail-safe default, surfaced in the log so a misconfigured
+# switch is not mistaken for a deliberate "disabled".
+#
+# Note on Copilot review: the `main` ruleset sets required_review_thread_resolution
+# with Copilot reviewing on push, so an unresolved Copilot comment blocks the
+# merge. The synchronous merge then fails and falls back to GitHub auto-merge,
+# which waits — a maintainer must resolve the threads (or `@dependabot recreate`)
+# to unstick such a PR. See CONTRIBUTING.md -> Dependency Updates.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# Serialize per PR so rapid synchronize/labeled events do not race the merge
+# against itself. Cancel for opened/reopened/synchronize (fresher state to merge
+# against) and for either security-review `labeled` event (stop the merge now).
+# Do NOT cancel for other `labeled` events: Dependabot adds dependencies/release
+# labels in rapid succession right after opening, and those replacement runs skip
+# the merge path per their `if:` guards, so canceling the in-flight merge run for
+# them would strand the PR. Letting them queue is harmless (they no-op the merge).
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'trust-boundary' || github.event.label.name == 'security-review-required' }}
+
+jobs:
+  auto-merge:
+    # Skip on label events — auto-merge is set once at open/synchronize time. A
+    # later security-review label is handled by disable-auto-merge-on-security-review.
+    if: >-
+      github.event.action != 'labeled' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    # `gh pr checks --watch` blocks until every required check is terminal. Cap
+    # well above typical required-check runtime (1-3 min) so a genuine hang
+    # surfaces as a failure without flaking on normal runs.
+    timeout-minutes: 30
+    # `checks: read` + `statuses: read` back `gh pr checks --required --watch`.
+    # With an explicit permissions block, unlisted scopes default to none.
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: write
+      statuses: read
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # @v3 as 3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Pick the most-severe update-type across the (possibly grouped) bump.
+      # Kept inline and identical to dependabot-release-label.yaml so the merge
+      # policy and the release label agree — the two copies MUST stay in sync.
+      - name: Derive effective update-type
+        id: effective
+        env:
+          UPDATED_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
+        run: |
+          set -euo pipefail
+          effective=$(jq -r '
+            [.[] | .updateType]
+            | if any(. == "version-update:semver-major") then "version-update:semver-major"
+              elif any(. == "version-update:semver-minor") then "version-update:semver-minor"
+              elif any(. == "version-update:semver-patch") then "version-update:semver-patch"
+              else "version-update:semver-patch"
+              end
+          ' <<<"$UPDATED_JSON")
+          echo "update-type=$effective" >> "$GITHUB_OUTPUT"
+
+      # Always-run observability for the kill-switch. A skipped job step is
+      # invisible; logging the resolved state here distinguishes "deliberately
+      # disabled" from "vars not resolving in Dependabot context".
+      - name: Report auto-merge switch state
+        env:
+          ENABLED: ${{ vars.DEPENDABOT_AUTOMERGE_ENABLED }}
+        run: |
+          set -euo pipefail
+          if [ "${ENABLED:-}" = "true" ]; then
+            echo "DEPENDABOT_AUTOMERGE_ENABLED=true; auto-merge path active."
+          else
+            echo "::notice::DEPENDABOT_AUTOMERGE_ENABLED is '${ENABLED:-<unset>}' (not 'true'); approve/merge steps are skipped. Set the repository variable to 'true' to enable. If it IS set to 'true' and you still see this, vars are not resolving in the Dependabot context."
+          fi
+
+      # Auto-approve before enabling/attempting merge so the required code-owner
+      # review is in place. GITHUB_TOKEN (and Dependabot) cannot approve PRs; a
+      # code-owner PAT stored as a *Dependabot* secret is required. When unset
+      # the step warns and skips — the merge step then falls back to GitHub
+      # auto-merge, which waits for a manual code-owner approval.
+      - name: Approve PR (so the required code-owner review passes)
+        if: >-
+          steps.effective.outputs.update-type != 'version-update:semver-major'
+          && !contains(steps.metadata.outputs.dependency-names, 'actions/create-github-app-token')
+          && !contains(steps.metadata.outputs.dependency-names, 'milanhorvatovic/codex-ai-code-review-action')
+          && !contains(github.event.pull_request.labels.*.name, 'trust-boundary')
+          && !contains(github.event.pull_request.labels.*.name, 'security-review-required')
+          && vars.DEPENDABOT_AUTOMERGE_ENABLED == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CODEOWNER_APPROVER_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        # Intentionally fail-open: any failure warns and exits 0. The merge step
+        # queries the authoritative reviewDecision and falls back when it is not
+        # APPROVED, so a later manual code-owner approval can still fire the merge.
+        # errexit is disabled explicitly; every external call is guarded with
+        # `if !` and warns before exit 0 — preserve that pattern when extending.
+        run: |
+          set +e
+          set -uo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::CODEOWNER_APPROVER_TOKEN is not set in the Dependabot secret store — skipping auto-approval. The merge step will fall back to GitHub auto-merge, which waits for a manual code-owner approval. Configure a fine-grained PAT (Pull requests: write) belonging to a code-owner under Settings -> Secrets and variables -> Dependabot."
+            exit 0
+          fi
+          if ! label_state=$(gh pr view "$PR_URL" --json labels --jq 'any(.labels[]; .name == "trust-boundary" or .name == "security-review-required")'); then
+            echo "::warning::Failed to query security-review label state; skipping auto-approval. The merge step will fall back to GitHub auto-merge."
+            exit 0
+          fi
+          if [ "$label_state" = "true" ]; then
+            echo "security-review label (trust-boundary or security-review-required) is now present (applied after workflow start); skipping auto-approval."
+            exit 0
+          fi
+          if ! gh pr review --approve --body "Auto-approved by the Dependabot Auto-Merge workflow (non-major, not a trust-boundary action, no security-review label)." "$PR_URL"; then
+            echo "::warning::Failed to post auto-approval review (likely a revoked or insufficiently-scoped CODEOWNER_APPROVER_TOKEN, or a transient GitHub API error). The merge step will fall back to GitHub auto-merge."
+            exit 0
+          fi
+
+      # Wait for required checks, then squash-merge synchronously when the PR has
+      # the required code-owner review; otherwise fall back to enabling GitHub
+      # auto-merge so a later manual approval (or rerun-to-green) can finish it.
+      # The synchronous path avoids the auto-merge worker's occasional dropped
+      # fire after the last required check goes green. The server-side ruleset is
+      # the safety boundary: a non-bypass merge is refused unless every required
+      # check has passed, so an early watch exit only causes a fallback, never an
+      # unsafe merge.
+      - name: Wait for required checks, then squash-merge
+        if: >-
+          steps.effective.outputs.update-type != 'version-update:semver-major'
+          && !contains(steps.metadata.outputs.dependency-names, 'actions/create-github-app-token')
+          && !contains(steps.metadata.outputs.dependency-names, 'milanhorvatovic/codex-ai-code-review-action')
+          && !contains(github.event.pull_request.labels.*.name, 'trust-boundary')
+          && !contains(github.event.pull_request.labels.*.name, 'security-review-required')
+          && vars.DEPENDABOT_AUTOMERGE_ENABLED == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+
+          # Tri-state security-review label query: "true"/"false" on success,
+          # "unknown" on a gh failure. Callers fail closed on "unknown".
+          security_review_state() {
+            local result
+            if ! result=$(gh pr view "$PR_URL" --json labels --jq 'any(.labels[]; .name == "trust-boundary" or .name == "security-review-required")'); then
+              echo "unknown"
+              return
+            fi
+            echo "$result"
+          }
+
+          # `gh pr merge --auto` may exit non-zero (already enabled, already
+          # merged/closed, transient error); verify the desired state actually
+          # holds (MERGED/CLOSED, or OPEN with auto-merge enabled) and surface a
+          # real failure as a workflow error instead of pretending success.
+          verify_auto_merge_or_terminal() {
+            local state_json pr_state has_auto
+            if ! state_json=$(gh pr view "$PR_URL" --json state,autoMergeRequest); then
+              echo "::error::Failed to verify PR state after gh pr merge --auto. Cannot confirm auto-merge was enabled; manual intervention required."
+              return 1
+            fi
+            pr_state=$(jq -r '.state' <<<"$state_json")
+            has_auto=$(jq -r '.autoMergeRequest != null' <<<"$state_json")
+            case "$pr_state" in
+              MERGED|CLOSED)
+                echo "PR is $pr_state; nothing more to do."
+                return 0 ;;
+              OPEN)
+                if [ "$has_auto" = "true" ]; then
+                  return 0
+                fi
+                echo "::error::gh pr merge --auto exited but autoMergeRequest is still null on an OPEN PR. The enable failed for a real reason — the bot lacks merge permission, the repository's Allow auto-merge setting is disabled, or a GitHub-side error. Investigate and re-run."
+                return 1 ;;
+              *)
+                echo "::error::Unexpected PR state '$pr_state' after auto-merge attempt; manual intervention required."
+                return 1 ;;
+            esac
+          }
+
+          # Enable GitHub auto-merge, verify it took, and revert it if a
+          # security-review label is now present (or its state is unknown).
+          # Disable-auto on a security-review PR is a hard failure: a silently
+          # armed auto-merge on a must-stay-manual PR is worse than a noisy fail.
+          arm_auto_merge() {
+            gh pr merge --auto --squash "$PR_URL" 2>&1 || true
+            if ! verify_auto_merge_or_terminal; then
+              return 1
+            fi
+            case "$(security_review_state)" in
+              true)
+                echo "security-review label is now present; reverting auto-merge."
+                if ! gh pr merge --disable-auto "$PR_URL"; then
+                  echo "::error::Failed to disable auto-merge on a security-review PR. It may still merge automatically, bypassing required manual review. Investigate immediately."
+                  return 1
+                fi
+                return 1 ;;
+              unknown)
+                echo "::error::Failed to verify security-review label state after arming auto-merge. Defensively disabling auto-merge to avoid a possible policy bypass."
+                if ! gh pr merge --disable-auto "$PR_URL"; then
+                  echo "::error::Failed to defensively disable auto-merge on a possibly security-review-required PR. Investigate immediately."
+                fi
+                return 1 ;;
+            esac
+            return 0
+          }
+
+          # Unhappy-path fallback (review not APPROVED, label state unknown):
+          # enable auto-merge so a later code-owner approval finishes the merge.
+          fall_back_to_auto_merge() {
+            echo "::warning::$1; enabling GitHub auto-merge so a later code-owner approval (or the reactive disable-auto-merge job for security-review labels) can finish or halt the merge."
+            if ! arm_auto_merge; then
+              exit 1
+            fi
+            exit 0
+          }
+
+          # Pre-poll security-review check. `unknown` fails closed: if a label is
+          # actually present, the reactive disable job may have already run, so
+          # arming auto-merge here could leave it active on a must-stay-manual PR.
+          case "$(security_review_state)" in
+            true)
+              echo "security-review label is present (applied after workflow start); skipping merge."
+              exit 0
+              ;;
+            unknown)
+              echo "::error::Failed to query security-review label state pre-poll. Refusing to arm auto-merge — investigate the gh pr view error above and re-run."
+              exit 1
+              ;;
+          esac
+
+          # Modest registration guard: wait until the required-check set is
+          # visible and stable across two reads before entering --watch. The
+          # required checks fire on the same pull_request event as this workflow
+          # and register within seconds, so a brief settle avoids --watch exiting
+          # "all passed" against an empty set on a freshly-opened PR. This is an
+          # optimization for the synchronous path, not a safety gate — the ruleset
+          # enforces the full required set server-side. `gh pr checks --required`
+          # exits 8 when checks are pending (count on stdout is still valid); any
+          # other non-zero is a real CLI error and is treated as "not yet visible".
+          prev=-1
+          deadline=$(($(date +%s) + 15))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            rc=0
+            count=$(gh pr checks "$PR_URL" --required --json name --jq 'length' 2>/dev/null) || rc=$?
+            if [ "$rc" -ne 0 ] && [ "$rc" -ne 8 ]; then
+              count=0
+            fi
+            count=${count:-0}
+            if [ "$count" -gt 0 ] && [ "$count" = "$prev" ]; then
+              break
+            fi
+            prev=$count
+            sleep 5
+          done
+
+          # `--required` filters to the ruleset's required_status_checks; `--watch`
+          # polls until each is terminal; `--fail-fast` aborts on the first
+          # failure. On failure, re-arm via auto-merge so a later rerun-to-green
+          # can fire the merge without a manual workflow re-trigger, then exit 1
+          # so the failure stays visible.
+          if ! gh pr checks "$PR_URL" --required --watch --fail-fast; then
+            echo "::warning::A required check failed during the wait; enabling GitHub auto-merge as a re-armed safety net so a later rerun-to-green can fire the merge."
+            arm_auto_merge || true
+            exit 1
+          fi
+
+          # Post-poll security-review re-check (same fail-closed treatment).
+          case "$(security_review_state)" in
+            true)
+              echo "security-review label was applied while waiting for checks; skipping merge."
+              exit 0
+              ;;
+            unknown)
+              echo "::error::Failed to query security-review label state post-poll. Refusing to arm auto-merge — investigate and re-run."
+              exit 1
+              ;;
+          esac
+
+          # reviewDecision is GitHub's authoritative answer to "is this PR
+          # sufficiently approved per the ruleset (incl. code-owner review)?",
+          # regardless of whether gh pr review --approve exited 0 above.
+          if ! review_decision=$(gh pr view "$PR_URL" --json reviewDecision --jq .reviewDecision); then
+            fall_back_to_auto_merge "Failed to query reviewDecision"
+          fi
+          if [ "$review_decision" != "APPROVED" ]; then
+            fall_back_to_auto_merge "reviewDecision is '${review_decision:-<empty>}' (need APPROVED for synchronous merge)"
+          fi
+
+          # Mergeability can change between the watch returning and this call (the
+          # ruleset sets strict_required_status_checks_policy, so BEHIND blocks the
+          # merge). This workflow does not re-trigger on base-branch updates, so a
+          # naked failure would strand the PR — fall back to verified auto-merge.
+          if ! gh pr merge --squash "$PR_URL"; then
+            fall_back_to_auto_merge "Synchronous squash merge failed (mergeability may have changed — base advanced, transient error, or branch is BEHIND)"
+          fi
+
+  # Reactive disable: if a maintainer applies a security-review label after
+  # auto-merge was already enabled, the label-guard `if:` above only prevents
+  # re-enabling — it does not revoke. This job runs on the `labeled` event and
+  # disables auto-merge so the PR stays open for manual review.
+  disable-auto-merge-on-security-review:
+    if: >-
+      github.event.action == 'labeled' &&
+      (github.event.label.name == 'trust-boundary' || github.event.label.name == 'security-review-required') &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Disable auto-merge if enabled
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        # Auto-merge may legitimately be unset (semver-major, excluded action, or
+        # the kill-switch was off), in which case --disable-auto errors; skip
+        # cleanly when there is nothing to disable.
+        run: |
+          set -euo pipefail
+          auto_merge=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest')
+          if [ "$auto_merge" = "null" ]; then
+            echo "Auto-merge is not enabled on this PR; nothing to disable."
+            exit 0
+          fi
+          gh pr merge --disable-auto "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -400,8 +400,13 @@ jobs:
             echo "Auto-merge is not enabled on this PR; nothing to disable."
             exit 0
           fi
-          gh pr merge --disable-auto "$PR_URL"
-          # Verify the disarm took: a --disable-auto that reports success without
+          # Tolerate a non-zero exit here: between the pre-check above and this
+          # call another run (or the merge landing) can clear auto-merge, and
+          # `--disable-auto` then errors with "no auto-merge to disable" even
+          # though the desired state is already reached. The authoritative check
+          # is the re-query below, not this call's exit code.
+          gh pr merge --disable-auto "$PR_URL" || true
+          # Verify the disarm took: a --disable-auto that reported success without
           # clearing the request would leave this security-review PR armed.
           auto_merge=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest')
           if [ "$auto_merge" != "null" ]; then

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -74,6 +74,10 @@ jobs:
       # Pick the most-severe update-type across the (possibly grouped) bump.
       # Kept inline and identical to dependabot-release-label.yaml so the merge
       # policy and the release label agree — the two copies MUST stay in sync.
+      # The `else` defaults to semver-major (not patch): an empty or unrecognized
+      # updateType is unclassifiable, and the merge gate excludes semver-major, so
+      # defaulting there fails closed — an unclassifiable bump is held for manual
+      # review instead of silently routed into the auto-merge path.
       - name: Derive effective update-type
         id: effective
         env:
@@ -85,7 +89,7 @@ jobs:
             | if any(. == "version-update:semver-major") then "version-update:semver-major"
               elif any(. == "version-update:semver-minor") then "version-update:semver-minor"
               elif any(. == "version-update:semver-patch") then "version-update:semver-patch"
-              else "version-update:semver-patch"
+              else "version-update:semver-major"
               end
           ' <<<"$UPDATED_JSON")
           echo "update-type=$effective" >> "$GITHUB_OUTPUT"
@@ -314,6 +318,24 @@ jobs:
           if [ "$review_decision" != "APPROVED" ]; then
             fall_back_to_auto_merge "reviewDecision is '${review_decision:-<empty>}' (need APPROVED for synchronous merge)"
           fi
+
+          # Final fail-closed security-review re-check, immediately before the
+          # merge call. The post-poll re-check above runs before the reviewDecision
+          # query, leaving a multi-second window in which a security-review label
+          # could be applied and then squashed before the concurrency-cancel or the
+          # reactive disable job intervenes — and a completed squash cannot be
+          # un-merged. This shrinks the TOCTOU window to the single merge API call.
+          # `unknown` fails closed, matching the pre/post-poll checks.
+          case "$(security_review_state)" in
+            true)
+              echo "security-review label was applied just before merge; skipping."
+              exit 0
+              ;;
+            unknown)
+              echo "::error::Failed to query security-review label state immediately before merge; refusing to merge."
+              exit 1
+              ;;
+          esac
 
           # Mergeability can change between the watch returning and this call (the
           # ruleset sets strict_required_status_checks_policy, so BEHIND blocks the

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -74,7 +74,10 @@ jobs:
       # Pick the most-severe update-type across the (possibly grouped) bump.
       # Kept inline and identical to dependabot-auto-merge.yaml so the label and
       # the merge policy agree on what a PR is — the two copies MUST stay in
-      # sync. The default `version-update:semver-patch` covers an empty array.
+      # sync. The `else` defaults to semver-major (not patch): an empty or
+      # unrecognized updateType is unclassifiable, so it labels `release: major`
+      # — the safe conservative default that matches the auto-merge gate, which
+      # holds an unclassifiable bump for manual review.
       - name: Derive effective update-type
         id: effective
         env:
@@ -86,7 +89,7 @@ jobs:
             | if any(. == "version-update:semver-major") then "version-update:semver-major"
               elif any(. == "version-update:semver-minor") then "version-update:semver-minor"
               elif any(. == "version-update:semver-patch") then "version-update:semver-patch"
-              else "version-update:semver-patch"
+              else "version-update:semver-major"
               end
           ' <<<"$UPDATED_JSON")
           echo "update-type=$effective" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -36,6 +36,20 @@ name: Dependabot Release Label
 # check-then-act window. The rollback only ever removes the label this workflow
 # just applied, so a maintainer applying the *same* label is a set-semantics
 # no-op and no rollback fires.
+#
+# Trigger scope is `opened`/`reopened` only. `synchronize` is deliberately
+# omitted: a rebase/force-push does not change a bump's update-type, so the
+# desired label is unchanged and re-running would only risk re-fighting a
+# maintainer override. Known limitation: Dependabot applies the static
+# `release: patch` label at PR creation, but if it is not yet visible when the
+# `opened` run queries (labels can surface as separate events just after open),
+# the absent-label branch can add the metadata-derived label and the static
+# `release: patch` can then land too, leaving a standalone semver-major PR with
+# two release labels for manual triage. This is accepted rather than papered
+# over with a `labeled` trigger — that would only re-surface the conflict as a
+# warning, not resolve it, since the >1-label case is left for the maintainer —
+# and it is bounded: the labels are not yet consumed for version computation
+# (groundwork) and `verify-pr-release-label` is report-only.
 
 on:
   pull_request:

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -50,11 +50,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
-# `pull-requests: write` covers `gh pr edit --add-label/--remove-label` for
-# *existing* labels. The four release labels already exist on the repo, so we
-# never hit the create-label path that would also require `issues: write`.
+# `gh pr edit --add-label/--remove-label` mutates labels through GitHub's
+# issue-labels API (PRs are issues for labeling), which can require
+# `issues: write` — `pull-requests: write` alone is not reliably sufficient
+# across gh's REST/GraphQL label paths. Grant both so the reconcile write
+# cannot 403 at runtime; `pull-requests: write` also covers the `gh pr view`
+# / `gh pr edit` PR context. The four `release:` labels already exist, so the
+# create-label path is never exercised either.
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -121,10 +121,16 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Map the effective update-type to the desired release label.
+          # Map the effective update-type to the desired release label. Grouped
+          # patch/minor bumps release as patch (project policy), so semver-minor
+          # maps to `release: patch` here too — the workflow never *assigns*
+          # `release: minor` itself; that label only ever survives as a maintainer
+          # override (preserved by the keep-current branch below). This keeps the
+          # absent-label backstop policy-consistent: a grouped minor with no static
+          # label yet is labeled `release: patch`, not `release: minor`. Only a
+          # standalone semver-major maps to `release: major`.
           case "$UPDATE_TYPE" in
             version-update:semver-major) desired="release: major" ;;
-            version-update:semver-minor) desired="release: minor" ;;
             *)                            desired="release: patch" ;;
           esac
 
@@ -168,14 +174,17 @@ jobs:
             exit 0
           fi
 
-          # Post-edit recheck closes the check-then-act window. If a maintainer
-          # applied a different `release: *` label between the state query and the
-          # `gh pr edit` call, the PR now carries two release labels; roll back
-          # the label this workflow just applied so the manual override wins. We
-          # only ever remove `$desired` (the one we just added).
+          # Post-edit recheck: if the PR now carries more than one release label,
+          # a second label raced in after our state query — either a maintainer
+          # override or Dependabot's static `release: patch` landing late. We do
+          # NOT blind-remove `$desired` here: when the racer is the static patch
+          # and `$desired` is `release: major`, removing `$desired` would delete
+          # the *correct* label and leave the wrong one. Leave both and warn for
+          # manual triage instead; `verify-pr-release-label` surfaces the
+          # ambiguity, and the labels are groundwork (not yet consumed for
+          # version computation), so a transient two-label state is recoverable.
           post_count=$(gh pr view "$PR_URL" --json labels \
             --jq '[.labels[].name | select(startswith("release: "))] | length')
           if [ "$post_count" -gt 1 ]; then
-            echo "::warning::A different release label appears to have been applied during the edit window; removing the workflow-applied '$desired' so the manual override wins."
-            gh pr edit "$PR_URL" --remove-label "$desired"
+            echo "::warning::PR now carries multiple release labels (a maintainer override or Dependabot's static label raced into the edit window); leaving them for manual triage rather than risk removing the correct one."
           fi

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -1,0 +1,159 @@
+name: Dependabot Release Label
+
+# Reconciles the `release: <level>` label on every Dependabot PR to match the
+# effective update-type derived from Dependabot's metadata.
+#
+# Groundwork for label-driven release automation (WI-3): `verify-pr-release-label`
+# is report-only today and nothing computes the next version from labels yet, so
+# these labels are not consumed for versioning at the moment. The workflow ships
+# now so the labels are correct from day one when the compute-from-labels layer
+# lands — and so the auto-merge policy and the release label agree on what a PR is.
+#
+# Two scenarios it addresses:
+#
+#   1. Backstop for absent labels. A Dependabot PR that does not inherit the
+#      static label list from `.github/dependabot.yaml` (e.g. a built-in
+#      security-update group) would otherwise carry no `release:` label.
+#
+#   2. Corrector for the standalone-semver-major case. `.github/dependabot.yaml`
+#      applies `release: patch` statically to every PR from the configured
+#      ecosystems, but since those groups carry `update-types: [minor, patch]`,
+#      semver-major bumps split out of the group and arrive as standalone PRs.
+#      A standalone semver-major PR inherits `release: patch` from the static
+#      config, which mis-classifies it. This workflow recomputes the effective
+#      update-type and REPLACES `release: patch` with `release: major` only for
+#      that specific static-default mismatch (`current == "release: patch"` +
+#      effective type semver-major). Grouped patch/minor PRs keep the static
+#      `release: patch` even when the group's effective update-type rolls up to
+#      `version-update:semver-minor`, because the static label encodes the
+#      project's policy that grouped patch/minor bumps release as patch.
+#      Maintainer-applied overrides (`release: skip`, `release: minor`, etc.)
+#      are preserved on the same principle.
+#
+# Race protection: the edit combines `--remove-label` and `--add-label` in one
+# `gh pr edit` call where applicable, and a post-edit recheck rolls back the
+# workflow-applied label if a maintainer's manual `release: *` raced into the
+# check-then-act window. The rollback only ever removes the label this workflow
+# just applied, so a maintainer applying the *same* label is a set-semantics
+# no-op and no rollback fires.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+# Queue concurrent runs on the same PR rather than cancel them. Label edits are
+# idempotent and run in 1-2 s; the post-edit recheck + rollback step should not
+# be interrupted mid-flight by the next `opened`/`reopened` event.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+# `pull-requests: write` covers `gh pr edit --add-label/--remove-label` for
+# *existing* labels. The four release labels already exist on the repo, so we
+# never hit the create-label path that would also require `issues: write`.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  add-release-label:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # @v3 as 3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Pick the most-severe update-type across the (possibly grouped) bump.
+      # Kept inline and identical to dependabot-auto-merge.yaml so the label and
+      # the merge policy agree on what a PR is — the two copies MUST stay in
+      # sync. The default `version-update:semver-patch` covers an empty array.
+      - name: Derive effective update-type
+        id: effective
+        env:
+          UPDATED_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
+        run: |
+          set -euo pipefail
+          effective=$(jq -r '
+            [.[] | .updateType]
+            | if any(. == "version-update:semver-major") then "version-update:semver-major"
+              elif any(. == "version-update:semver-minor") then "version-update:semver-minor"
+              elif any(. == "version-update:semver-patch") then "version-update:semver-patch"
+              else "version-update:semver-patch"
+              end
+          ' <<<"$UPDATED_JSON")
+          echo "update-type=$effective" >> "$GITHUB_OUTPUT"
+
+      - name: Reconcile release label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          UPDATE_TYPE: ${{ steps.effective.outputs.update-type }}
+        run: |
+          set -euo pipefail
+
+          # Map the effective update-type to the desired release label.
+          case "$UPDATE_TYPE" in
+            version-update:semver-major) desired="release: major" ;;
+            version-update:semver-minor) desired="release: minor" ;;
+            *)                            desired="release: patch" ;;
+          esac
+
+          # Inventory the current release labels on the PR. Sorted JSON array so
+          # `jq -r '.[0]'` is deterministic when exactly one is present.
+          list_release_labels() {
+            gh pr view "$PR_URL" --json labels \
+              --jq '[.labels[].name | select(startswith("release: "))] | sort'
+          }
+
+          current_json="$(list_release_labels)"
+          current_count=$(jq 'length' <<<"$current_json")
+
+          # Decision tree:
+          #   - 0 release labels -> add `desired` (absent-label backstop).
+          #   - 1 label matching `desired` -> no-op (static label already right).
+          #   - 1 label not matching `desired`:
+          #       - desired == "release: major" AND current == "release: patch"
+          #         -> replace (the standalone-semver-major correction, narrowly
+          #         scoped to the known static-default mismatch).
+          #       - otherwise -> keep current (grouped-intent for patch/minor, or
+          #         a deliberate maintainer override).
+          #   - >1 labels -> leave for verify-pr-release-label and the maintainer.
+          if [ "$current_count" = "0" ]; then
+            echo "No release label present; adding '$desired'."
+            gh pr edit "$PR_URL" --add-label "$desired"
+          elif [ "$current_count" = "1" ]; then
+            current=$(jq -r '.[0]' <<<"$current_json")
+            if [ "$current" = "$desired" ]; then
+              echo "Release label '$desired' already correct; nothing to do."
+              exit 0
+            fi
+            if [ "$desired" != "release: major" ] || [ "$current" != "release: patch" ]; then
+              echo "Keeping '$current' (effective update-type: $UPDATE_TYPE). Auto-correction only fires for the known static-default mismatch (current 'release: patch' + standalone semver-major); anything else is grouped-intent or a manual override."
+              exit 0
+            fi
+            echo "Replacing '$current' with '$desired' (standalone semver-major correction; effective update-type: $UPDATE_TYPE)."
+            gh pr edit "$PR_URL" --add-label "$desired" --remove-label "$current"
+          else
+            echo "::warning::PR has multiple release labels ($(jq -c '.' <<<"$current_json")); leaving as-is for manual triage."
+            exit 0
+          fi
+
+          # Post-edit recheck closes the check-then-act window. If a maintainer
+          # applied a different `release: *` label between the state query and the
+          # `gh pr edit` call, the PR now carries two release labels; roll back
+          # the label this workflow just applied so the manual override wins. We
+          # only ever remove `$desired` (the one we just added).
+          post_count=$(gh pr view "$PR_URL" --json labels \
+            --jq '[.labels[].name | select(startswith("release: "))] | length')
+          if [ "$post_count" -gt 1 ]; then
+            echo "::warning::A different release label appears to have been applied during the edit window; removing the workflow-applied '$desired' so the manual override wins."
+            gh pr edit "$PR_URL" --remove-label "$desired"
+          fi

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -31,11 +31,13 @@ name: Dependabot Release Label
 #      are preserved on the same principle.
 #
 # Race protection: the edit combines `--remove-label` and `--add-label` in one
-# `gh pr edit` call where applicable, and a post-edit recheck rolls back the
-# workflow-applied label if a maintainer's manual `release: *` raced into the
-# check-then-act window. The rollback only ever removes the label this workflow
-# just applied, so a maintainer applying the *same* label is a set-semantics
-# no-op and no rollback fires.
+# `gh pr edit` call where applicable, and a post-edit recheck warns — without
+# removing anything — when more than one `release: *` label is present after the
+# edit (a second label can race in from a maintainer or from Dependabot's static
+# `release: patch` landing late). The recheck deliberately does NOT roll back
+# the workflow-applied label: blind removal could delete the correct label (e.g.
+# drop `release: major` and leave the static `release: patch`), so the ambiguous
+# state is left for manual triage and `verify-pr-release-label` to flag.
 #
 # Trigger scope is `opened`/`reopened` only. `synchronize` is deliberately
 # omitted: a rebase/force-push does not change a bump's update-type, so the
@@ -58,8 +60,8 @@ on:
       - reopened
 
 # Queue concurrent runs on the same PR rather than cancel them. Label edits are
-# idempotent and run in 1-2 s; the post-edit recheck + rollback step should not
-# be interrupted mid-flight by the next `opened`/`reopened` event.
+# idempotent and run in 1-2 s; the post-edit recheck should not be interrupted
+# mid-flight by the next `opened`/`reopened` event.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,13 +129,31 @@ Fix <issue> in <component>
    - `release: patch` — a user-facing fix or change worth a release note (bug fix, corrected/clarified skill docs)
    - `release: skip` — nothing user-facing ships, so it does not influence the next version (CI, tests, internal tooling, repo meta, contributor docs)
 
-   These labels are the planned input for label-driven release automation, so each PR must declare its impact before that check becomes blocking. The `verify-pr-release-label` check flags a missing or ambiguous label (currently report-only; it becomes required once the labeling habit is established). A follow-up will label Dependabot PRs automatically — until then, label them by hand.
+   These labels are the planned input for label-driven release automation, so each PR must declare its impact before that check becomes blocking. The `verify-pr-release-label` check flags a missing or ambiguous label (currently report-only; it becomes required once the labeling habit is established). Dependabot PRs are labeled automatically by `dependabot-release-label.yaml` (see [Dependency Updates](#dependency-updates)); label human-authored PRs by hand.
 
 7. **Respond to feedback.** PRs may require revisions before merging.
 
 ## What Happens Next
 
 Maintainers review PRs on a best-effort basis. Smaller, focused PRs are reviewed faster than large ones. If your PR has not received feedback after a reasonable time, a polite ping in the PR comments is welcome.
+
+## Dependency Updates
+
+Dependabot opens grouped pull requests weekly for the GitHub Actions and Python dev dependencies. Each ecosystem groups minor and patch bumps into one rolling PR; semver-major bumps split into standalone PRs. Every Dependabot PR is labeled automatically — `dependencies`, its ecosystem, and a `release:` level reconciled by `dependabot-release-label.yaml`.
+
+### Auto-merge
+
+`dependabot-auto-merge.yaml` merges a Dependabot PR hands-off once its required checks pass and a code-owner approval is in place. It deliberately **holds** a PR for manual review when any of the following is true:
+
+- the effective update-type is **semver-major** (these arrive as standalone PRs);
+- the bump touches a **trust-boundary action** that runs with secrets in scope — currently `actions/create-github-app-token` (mints the App private key) and `milanhorvatovic/codex-ai-code-review-action` (runs with `OPENAI_API_KEY`). When a new action-level trust-boundary dependency is added, extend the exclude list in both `.github/dependabot.yaml` and `.github/workflows/dependabot-auto-merge.yaml`;
+- the PR carries **`trust-boundary`** or **`security-review-required`**. Apply either to any dependency PR you want a human to review before it merges; applying one to an already-armed PR disarms the pending auto-merge.
+
+The repository variable **`DEPENDABOT_AUTOMERGE_ENABLED`** is the kill-switch: auto-merge acts only when it is exactly `true`. Unset or any other value disables it, and the PR waits for a manual merge.
+
+A held PR is merged the normal way after review. Note that an unresolved **Copilot review comment** parks a PR — the `main` ruleset requires review-thread resolution — so resolve the threads (or comment `@dependabot recreate`) to let auto-merge proceed.
+
+When the grouping or label configuration changes, existing open Dependabot PRs keep their old shape until recreated — comment `@dependabot recreate` (or close them) so they adopt the new configuration.
 
 ## Scope
 


### PR DESCRIPTION
## Summary

Brings the repository's dependency phase onto the label-driven, code-owner-approved auto-merge model. Patch and minor Dependabot updates merge hands-off once required checks pass; semver-major bumps, bumps of actions that run with secrets in scope, and any PR a maintainer flags for security review are held for manual review.

## What changed

- **`.github/dependabot.yaml`** — each ecosystem now groups only `minor` + `patch` updates, so semver-major bumps split into standalone PRs. The github-actions group excludes `actions/create-github-app-token` and `milanhorvatovic/codex-ai-code-review-action` (both run with secrets), so they always arrive as standalone, manually-reviewed PRs rather than poisoning the group's auto-merge. Every PR gets static labels (`dependencies`, ecosystem, `release: patch`); the github-actions PR limit is raised to 10 to absorb the extra standalone PRs.
- **`.github/workflows/dependabot-auto-merge.yaml`** (new) — derives the effective update-type from `fetch-metadata`, gates on it plus the exclude-by-name list and the `trust-boundary` / `security-review-required` labels, approves with the code-owner PAT, waits for required checks, then squash-merges synchronously when `reviewDecision` is `APPROVED` (falling back to GitHub auto-merge otherwise). A reactive job disarms a pending auto-merge if a security-review label lands later.
- **`.github/workflows/dependabot-release-label.yaml`** (new) — corrects the static `release: patch` to `release: major` on standalone semver-major PRs. Groundwork: the labels are not consumed for version computation yet, but ship correct from day one.
- **`CONTRIBUTING.md`** — adds a Dependency Updates section (the hold gate, the `DEPENDABOT_AUTOMERGE_ENABLED` kill-switch, the Copilot-thread-resolution stranding and its unstick, and the `@dependabot recreate` migration for in-flight PRs); refreshes the now-automated release-label note.

## Guardrails

- **Holds** semver-major bumps, secret-handling-action bumps, and security-labeled PRs — never auto-merged.
- **Code-owner approval** is the only approval path (`CODEOWNER_APPROVER_TOKEN`, a code-owner PAT; GitHub Apps cannot satisfy code-owner review).
- **Required checks** gate every merge; the synchronous merge is backstopped by the branch ruleset, so an early check-wait exit can only fall back to GitHub auto-merge, never merge unsafely.
- **Fail-closed**: an unclassifiable update-type defaults to `semver-major` (held), and security-review label state is re-checked immediately before the merge call.
- **Kill-switch**: `DEPENDABOT_AUTOMERGE_ENABLED` must be `true`; unset/anything-else disables auto-merge (the state is logged so a misconfiguration is visible).

## Operator prerequisites (provisioned, behavior activates on merge)

- Label `github-actions` created; variable `DEPENDABOT_AUTOMERGE_ENABLED=true` set.
- `verify` added to the `main` ruleset's required checks.
- `CODEOWNER_APPROVER_TOKEN` present in the Dependabot secret store.

## Validation

`actionlint` clean on both workflows; `verify-action-pins.py` passes (the new `fetch-metadata` action is SHA-pinned). The change set also went through a cross-model review; the resulting hardening (fail-closed update-type default + pre-merge security re-check) is included.
