### PR TITLE
Fix stale manifest/tag drift claim in release-on-merge comment

### DIFF
--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -5,9 +5,9 @@ name: Release on merge
 # event triggers release.yaml — a ``GITHUB_TOKEN``-authored tag push would not.
 #
 # Keying off the head ref + ``merged == true`` ties tagging to an actual merged
-# release PR, so it never mis-fires on the manifest/tag drift the repo currently
-# carries (manifests at 1.2.0, published tag v1.2.1) the way a bare
-# "manifest version has no tag" trigger would.
+# release PR, so it never mis-fires on transient manifest/tag drift (e.g. a
+# manifest bumped for a release whose tag failed or was abandoned) the way a
+# bare "manifest version has no tag" trigger would.
 
 on:
   pull_request:


### PR DESCRIPTION
## What

Reword the rationale comment in `release-on-merge.yaml` so it no longer asserts the repo *currently* carries manifest/tag drift (`manifests at 1.2.0, published tag v1.2.1`). That drift was resolved when the v1.2.1 release commit bumped the three manifests from `1.2.0` to `1.2.1` — they now match the published `v1.2.1` tag, and the repo-root audit's version-consistency rule passes.

## Why

The comment described a transient state that no longer exists, so a reader would conclude the repo is mid-drift when it is not. The *design rationale* it documents — keying the tag trigger off the merged release PR's head ref rather than a naive "manifest version has no tag" heuristic — is still valid and is preserved. The wording now frames the drift hazard hypothetically (a manifest bumped for a release whose tag failed or was abandoned), which is exactly the failure mode the head-ref trigger guards against.

## Scope

Comment-only change to one workflow file. No behavioral change; the trigger condition (`merged == true` + `release/v` head ref) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)