### PR TITLE
Add changelog verb mappings for Arm, Automate, Require, Correct

### DIFF
--- a/scripts/lib/changelog.yaml
+++ b/scripts/lib/changelog.yaml
@@ -25,6 +25,8 @@ changelog:
       - Suggest
       - Fail
       - Emit
+      - Arm
+      - Automate
     Changed:
       - Update
       - Refactor
@@ -43,6 +45,7 @@ changelog:
       - Move
       - Make
       - Recognize
+      - Require
     Deprecated:
       - Deprecate
     Removed:
@@ -54,6 +57,7 @@ changelog:
       - Catch
       - Resolve
       - Address
+      - Correct
     Security:
       - Patch
       - Secure

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -82,6 +82,8 @@ class LoadVerbMappingTests(unittest.TestCase):
             "Suggest": "Added",
             "Fail": "Added",
             "Emit": "Added",
+            "Arm": "Added",
+            "Automate": "Added",
             "Sync": "Changed",
             "Apply": "Changed",
             "Switch": "Changed",
@@ -89,7 +91,9 @@ class LoadVerbMappingTests(unittest.TestCase):
             "Move": "Changed",
             "Make": "Changed",
             "Recognize": "Changed",
+            "Require": "Changed",
             "Address": "Fixed",
+            "Correct": "Fixed",
         }
         for verb, section in expected.items():
             # assertIn first so a removed/renamed verb fails with an


### PR DESCRIPTION
## What

The release-automation work merged commit subjects whose first-word verbs were absent from the changelog generator's verb-to-section map, so `generate_changelog.py --in-place` refuses them with exit 3 and `release-prep` cannot assemble the changelog for the next release.

## Change

Map the four missing verbs in `scripts/lib/changelog.yaml`:

- `Arm`, `Automate` → Added
- `Require` → Changed
- `Correct` → Fixed

The `generate_changelog.py --since v1.2.1 --in-place --dry-run` probe is clean after this change (no `unmapped — review manually` lines).
