### PR TITLE
Add --dry-run flag to scaffold.py

### DIFF
--- a/skill-system-foundry/scripts/lib/dry_run.py
+++ b/skill-system-foundry/scripts/lib/dry_run.py
@@ -1,0 +1,31 @@
+"""Dry-run helpers for the scaffold entry point.
+
+Scaffold's ``--dry-run`` flag previews every filesystem mutation without
+touching disk.  The two write primitives (``write_file`` and
+``create_dir_with_gitkeep``) consult :data:`DRY_RUN_VERB` only for the
+human-readable verb; the suppression itself is driven by the ``dry_run``
+argument threaded through them.  Keeping the verb constant and the
+``Would create:`` formatter here means the entry point stays a thin
+wrapper and the wording lives in one place.
+
+No filesystem state is held in this module — the caller owns the list of
+planned paths (scaffold already accumulates them in ``created_paths``).
+This module is pure formatting so it carries no ``print`` or
+``sys.exit`` (those belong to the entry point and ``reporting.py``).
+"""
+
+from .reporting import to_posix
+
+# Verb used in the human-readable line for a path that *would* be
+# created in dry-run mode, mirroring the real-run "Created:" verb.
+DRY_RUN_VERB = "Would create"
+
+
+def planned_line(path: str) -> str:
+    """Return the indented human-readable line for a *planned* path.
+
+    Normalises *path* through ``to_posix`` for the same
+    platform-independence reason ``write_file`` does for its
+    ``Created:`` line.
+    """
+    return f"  {DRY_RUN_VERB}: {to_posix(path)}"

--- a/skill-system-foundry/scripts/lib/dry_run.py
+++ b/skill-system-foundry/scripts/lib/dry_run.py
@@ -20,12 +20,34 @@ from .reporting import to_posix
 # created in dry-run mode, mirroring the real-run "Created:" verb.
 DRY_RUN_VERB = "Would create"
 
+# Verb for an existing file a real run would modify in place rather than
+# create — e.g. an existing manifest.yaml that an append updates. Mirrors
+# the real-run "Updated:" verb so a dry run never claims a file that
+# already exists would be created.
+DRY_RUN_UPDATE_VERB = "Would update"
 
-def planned_line(path: str) -> str:
-    """Return the indented human-readable line for a *planned* path.
+
+def _planned_line(verb: str, path: str) -> str:
+    """Return the indented ``  <verb>: <path>`` line for *path*.
 
     Normalises *path* through ``to_posix`` for the same
     platform-independence reason ``write_file`` does for its
     ``Created:`` line.
     """
-    return f"  {DRY_RUN_VERB}: {to_posix(path)}"
+    return f"  {verb}: {to_posix(path)}"
+
+
+def planned_line(path: str) -> str:
+    """Return the indented human-readable line for a *planned* path."""
+    return _planned_line(DRY_RUN_VERB, path)
+
+
+def planned_update_line(path: str) -> str:
+    """Return the indented line for a path a real run would *update*.
+
+    Used for an existing manifest under ``--dry-run``: a real run
+    appends to it and reports ``Updated:`` instead of ``Created:``, so
+    the preview must report it as an update and must not list it among
+    the paths a real run would create.
+    """
+    return _planned_line(DRY_RUN_UPDATE_VERB, path)

--- a/skill-system-foundry/scripts/lib/frontmatter.py
+++ b/skill-system-foundry/scripts/lib/frontmatter.py
@@ -42,23 +42,16 @@ def split_frontmatter(content: str) -> tuple[str | None, str | None]:
     return "".join(lines[1:]), None
 
 
-def load_frontmatter(filepath: str) -> tuple[dict | None, str, list[str]]:
-    """Extract YAML frontmatter from a SKILL.md file.
+def parse_frontmatter(content: str) -> tuple[dict | None, str, list[str]]:
+    """Extract YAML frontmatter from in-memory *content*.
 
-    Returns ``(frontmatter_dict, body_string, scalar_findings)``.
-    *scalar_findings* contains plain-scalar divergence findings
-    (FAIL and WARN level) collected during parsing (empty list when
-    none).  If no frontmatter is found, returns
-    ``(None, full_content, [])``.  Parse errors are returned as a dict
-    with a ``_parse_error`` key.
-
-    Input line endings are normalized to LF before any further
-    processing, so both the frontmatter and the returned ``body`` use
-    LF-only terminators (see module docstring).
+    Same return contract as :func:`load_frontmatter`
+    (``(frontmatter_dict, body_string, scalar_findings)``) but operating
+    on a string rather than a file path, so callers can validate rendered
+    content without writing it to disk — scaffold's ``--dry-run`` uses
+    this to report the same frontmatter findings a real run would surface
+    after writing. Input line endings are normalized to LF first.
     """
-    with open(filepath, "r", encoding="utf-8") as f:
-        content = f.read()
-
     content = content.replace("\r\n", "\n").replace("\r", "\n")
 
     frontmatter_raw, body_raw = split_frontmatter(content)
@@ -81,6 +74,26 @@ def load_frontmatter(filepath: str) -> tuple[dict | None, str, list[str]]:
         return {"_parse_error": str(e)}, body, []
 
     return frontmatter, body, findings
+
+
+def load_frontmatter(filepath: str) -> tuple[dict | None, str, list[str]]:
+    """Extract YAML frontmatter from a SKILL.md file.
+
+    Returns ``(frontmatter_dict, body_string, scalar_findings)``.
+    *scalar_findings* contains plain-scalar divergence findings
+    (FAIL and WARN level) collected during parsing (empty list when
+    none).  If no frontmatter is found, returns
+    ``(None, full_content, [])``.  Parse errors are returned as a dict
+    with a ``_parse_error`` key.
+
+    Reads the file and delegates to :func:`parse_frontmatter`; input line
+    endings are normalized to LF before any further processing, so both
+    the frontmatter and the returned ``body`` use LF-only terminators
+    (see module docstring).
+    """
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+    return parse_frontmatter(content)
 
 
 def strip_frontmatter_for_scan(content: str) -> str:

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -8,6 +8,7 @@ empty manifest.
 import os
 
 from .yaml_parser import parse_yaml_subset
+from .reporting import to_posix
 from .constants import (
     DIR_SKILLS,
     DIR_ROLES,
@@ -327,7 +328,7 @@ def _non_file_manifest_warning(manifest_path: str) -> str | None:
     """
     if os.path.exists(manifest_path) and not os.path.isfile(manifest_path):
         return (
-            f"Manifest path {manifest_path} is not a regular file "
+            f"Manifest path {to_posix(manifest_path)} is not a regular file "
             f"— skipping manifest update"
         )
     return None

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -294,6 +294,24 @@ def append_role_entry(
     return _collect_emit_findings(manifest_path)
 
 
+def manifest_needs_scaffold(manifest_path: str) -> bool:
+    """Return True when *manifest_path* must be seeded before an append.
+
+    A manifest needs scaffolding when it does not exist or when it
+    exists but holds only whitespace — both states a fresh append has to
+    seed with an empty manifest skeleton first, so both are reported as a
+    newly *created* manifest. The check is read-only: it stats the path
+    and, for an existing file, reads its bytes without parsing or
+    mutating it. That lets callers ask "would a real run create this
+    file?" without side effects — scaffold's ``--dry-run`` preview relies
+    on it to mirror the real run's created-vs-updated split.
+    """
+    if not os.path.isfile(manifest_path):
+        return True
+    with open(manifest_path, "r", encoding="utf-8") as fh:
+        return not fh.read().strip()
+
+
 def _collect_emit_findings(manifest_path: str) -> list[str]:
     """Re-validate the post-write manifest for divergences and shape.
 
@@ -338,11 +356,7 @@ def update_manifest_for_skill(
     """
     created_manifest = False
     # Treat non-existent or empty/whitespace-only files as missing.
-    needs_scaffold = not os.path.isfile(manifest_path)
-    if not needs_scaffold:
-        with open(manifest_path, "r", encoding="utf-8") as fh:
-            needs_scaffold = not fh.read().strip()
-    if needs_scaffold:
+    if manifest_needs_scaffold(manifest_path):
         scaffold_empty_manifest(manifest_path)
         created_manifest = True
 
@@ -394,11 +408,7 @@ def update_manifest_for_role(
     """
     created_manifest = False
     # Treat non-existent or empty/whitespace-only files as missing.
-    needs_scaffold = not os.path.isfile(manifest_path)
-    if not needs_scaffold:
-        with open(manifest_path, "r", encoding="utf-8") as fh:
-            needs_scaffold = not fh.read().strip()
-    if needs_scaffold:
+    if manifest_needs_scaffold(manifest_path):
         scaffold_empty_manifest(manifest_path)
         created_manifest = True
 

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -301,10 +301,11 @@ def manifest_needs_scaffold(manifest_path: str) -> bool:
     exists but holds only whitespace — both states a fresh append has to
     seed with an empty manifest skeleton first, so both are reported as a
     newly *created* manifest. The check is read-only: it stats the path
-    and, for an existing file, reads its bytes without parsing or
-    mutating it. That lets callers ask "would a real run create this
-    file?" without side effects — scaffold's ``--dry-run`` preview relies
-    on it to mirror the real run's created-vs-updated split.
+    and, for an existing file, reads its contents as text (text mode,
+    UTF-8) without parsing the YAML or mutating the file. That lets
+    callers ask "would a real run create this file?" without side
+    effects — scaffold's ``--dry-run`` preview relies on it to mirror the
+    real run's created-vs-updated split.
     """
     if not os.path.isfile(manifest_path):
         return True

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -302,15 +302,20 @@ def manifest_needs_scaffold(manifest_path: str) -> bool:
     A manifest needs scaffolding when it does not exist or when it
     exists but holds only whitespace — both states a fresh append has to
     seed with an empty manifest skeleton first, so both are reported as a
-    newly *created* manifest. The check is read-only: it stats the path
-    and, for an existing file, reads its contents as text (text mode,
-    UTF-8) without parsing the YAML or mutating the file. That lets
-    callers ask "would a real run create this file?" without side
-    effects — scaffold's ``--dry-run`` preview relies on it to mirror the
-    real run's created-vs-updated split.
+    newly *created* manifest. A path that exists but is not a regular
+    file (most often a directory) returns False: a real run cannot seed
+    ``manifest.yaml`` there, so it does not "need scaffold" — that case
+    is a skip, surfaced separately via :func:`_non_file_manifest_warning`.
+    The check is read-only: it stats the path and, for an existing file,
+    reads its contents as text (text mode, UTF-8) without parsing the
+    YAML or mutating the file. That lets callers ask "would a real run
+    create this file?" without side effects — scaffold's ``--dry-run``
+    preview relies on it to mirror the real run's created-vs-updated split.
     """
-    if not os.path.isfile(manifest_path):
+    if not os.path.exists(manifest_path):
         return True
+    if not os.path.isfile(manifest_path):
+        return False
     with open(manifest_path, "r", encoding="utf-8") as fh:
         return not fh.read().strip()
 

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -325,11 +325,13 @@ def _non_file_manifest_warning(manifest_path: str) -> str | None:
 
     A real ``update_manifest_*`` run would try to write ``manifest.yaml``
     at this path and fail when something other than a regular file (most
-    often a directory) already occupies it — ``manifest_needs_scaffold``
-    reports any non-file as "needs scaffold", so without this guard the
-    run would crash mid-write and the ``--dry-run`` preview would claim a
-    bogus create/update. Detecting it up front lets both the real run and
-    the read-only preview report a graceful skip. Returns None for the
+    often a directory) already occupies it. ``manifest_needs_scaffold``
+    returns False for that case — a non-file does not "need scaffold"
+    because a real run cannot seed it — so this guard runs first in the
+    update path to surface the skip explicitly; without it the run would
+    crash mid-write and the ``--dry-run`` preview would claim a bogus
+    create/update. Detecting it up front lets both the real run and the
+    read-only preview report a graceful skip. Returns None for the
     normal cases (path absent, or a regular file).
     """
     if os.path.exists(manifest_path) and not os.path.isfile(manifest_path):

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -337,6 +337,7 @@ def update_manifest_for_skill(
     name: str,
     *,
     router: bool = False,
+    preview: bool = False,
 ) -> tuple[bool, str | None, bool, list[str]]:
     """Ensure *manifest_path* exists and append a skill entry.
 
@@ -353,12 +354,29 @@ def update_manifest_for_skill(
     manifest fails to parse, *updated* is False even though bytes were
     written to disk, and *warning* describes the corruption so callers
     that ignore *findings* still see the failure.
+
+    When *preview* is True the function performs no writes — it neither
+    scaffolds a missing manifest nor appends the entry — but runs the
+    same read-only validation a real run does so the returned tuple
+    reflects what a real run *would* do: an absent/empty manifest yields
+    ``created_manifest=True`` with ``updated=True``; an existing manifest
+    that fails to parse or already contains *name* yields
+    ``updated=False`` with the matching *warning*; an existing, parseable,
+    conflict-free manifest yields ``updated=True``. Emit-corruption
+    cannot be previewed (it is a property of the write), so the preview
+    assumes a clean append in the conflict-free case. Used by scaffold's
+    ``--dry-run`` to report an accurate manifest plan without touching
+    disk.
     """
-    created_manifest = False
+    created_manifest = manifest_needs_scaffold(manifest_path)
     # Treat non-existent or empty/whitespace-only files as missing.
-    if manifest_needs_scaffold(manifest_path):
+    if created_manifest and preview:
+        # A real run would seed a fresh manifest and append the first
+        # entry; an empty skeleton can hold no conflict and cannot fail
+        # to parse, so the append always succeeds.
+        return True, None, True, []
+    if created_manifest:
         scaffold_empty_manifest(manifest_path)
-        created_manifest = True
 
     findings: list[str] = []
     try:
@@ -373,6 +391,11 @@ def update_manifest_for_skill(
             f"{manifest_path} — skipping manifest update"
         )
         return False, warning, created_manifest, findings
+
+    if preview:
+        # Existing manifest parses and has no conflicting entry, so a real
+        # run would append successfully. Report the update without writing.
+        return True, None, created_manifest, findings
 
     emit_findings = append_skill_entry(manifest_path, name, router=router)
     findings.extend(emit_findings)
@@ -389,6 +412,8 @@ def update_manifest_for_role(
     manifest_path: str,
     group: str,
     name: str,
+    *,
+    preview: bool = False,
 ) -> tuple[bool, str | None, bool, list[str]]:
     """Ensure *manifest_path* exists and append a role entry.
 
@@ -405,12 +430,29 @@ def update_manifest_for_role(
     manifest fails to parse, *updated* is False even though bytes were
     written to disk, and *warning* describes the corruption so callers
     that ignore *findings* still see the failure.
+
+    When *preview* is True the function performs no writes — it neither
+    scaffolds a missing manifest nor appends the entry — but runs the
+    same read-only validation a real run does so the returned tuple
+    reflects what a real run *would* do: an absent/empty manifest yields
+    ``created_manifest=True`` with ``updated=True``; an existing manifest
+    that fails to parse or already contains the *group*/*name* role
+    yields ``updated=False`` with the matching *warning*; an existing,
+    parseable, conflict-free manifest yields ``updated=True``.
+    Emit-corruption cannot be previewed (it is a property of the write),
+    so the preview assumes a clean append in the conflict-free case. Used
+    by scaffold's ``--dry-run`` to report an accurate manifest plan
+    without touching disk.
     """
-    created_manifest = False
+    created_manifest = manifest_needs_scaffold(manifest_path)
     # Treat non-existent or empty/whitespace-only files as missing.
-    if manifest_needs_scaffold(manifest_path):
+    if created_manifest and preview:
+        # A real run would seed a fresh manifest and append the first
+        # entry; an empty skeleton can hold no conflict and cannot fail
+        # to parse, so the append always succeeds.
+        return True, None, True, []
+    if created_manifest:
         scaffold_empty_manifest(manifest_path)
-        created_manifest = True
 
     findings: list[str] = []
     try:
@@ -425,6 +467,11 @@ def update_manifest_for_role(
             f"{manifest_path} — skipping manifest update"
         )
         return False, warning, created_manifest, findings
+
+    if preview:
+        # Existing manifest parses and has no conflicting entry, so a real
+        # run would append successfully. Report the update without writing.
+        return True, None, created_manifest, findings
 
     emit_findings = append_role_entry(manifest_path, group, name)
     findings.extend(emit_findings)

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -24,6 +24,7 @@ __all__ = [
     "has_role_conflict",
     "append_skill_entry",
     "append_role_entry",
+    "manifest_needs_scaffold",
     "update_manifest_for_skill",
     "update_manifest_for_role",
     "scaffold_empty_manifest",

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -415,13 +415,17 @@ def update_manifest_for_skill(
     try:
         manifest = read_manifest(manifest_path, findings)
     except ManifestParseError as exc:
-        warning = f"{exc} — skipping manifest update"
+        # Normalize any embedded path inside the exception message so the
+        # warning carries posix separators across platforms (the parser
+        # raises with the raw path it was handed).
+        msg = str(exc).replace(manifest_path, to_posix(manifest_path))
+        warning = f"{msg} — skipping manifest update"
         return False, warning, created_manifest, findings
 
     if has_skill_conflict(manifest, name):
         warning = (
             f"Skill '{name}' already exists in "
-            f"{manifest_path} — skipping manifest update"
+            f"{to_posix(manifest_path)} — skipping manifest update"
         )
         return False, warning, created_manifest, findings
 
@@ -434,8 +438,8 @@ def update_manifest_for_skill(
     findings.extend(emit_findings)
     if has_emit_corruption(emit_findings):
         warning = (
-            f"Manifest update wrote an invalid manifest at {manifest_path} "
-            f"— inspect findings and repair the file"
+            f"Manifest update wrote an invalid manifest at "
+            f"{to_posix(manifest_path)} — inspect findings and repair the file"
         )
         return False, warning, created_manifest, findings
     return True, None, created_manifest, findings
@@ -494,13 +498,17 @@ def update_manifest_for_role(
     try:
         manifest = read_manifest(manifest_path, findings)
     except ManifestParseError as exc:
-        warning = f"{exc} — skipping manifest update"
+        # Normalize any embedded path inside the exception message so the
+        # warning carries posix separators across platforms (the parser
+        # raises with the raw path it was handed).
+        msg = str(exc).replace(manifest_path, to_posix(manifest_path))
+        warning = f"{msg} — skipping manifest update"
         return False, warning, created_manifest, findings
 
     if has_role_conflict(manifest, group, name):
         warning = (
             f"Role '{name}' in group '{group}' already exists in "
-            f"{manifest_path} — skipping manifest update"
+            f"{to_posix(manifest_path)} — skipping manifest update"
         )
         return False, warning, created_manifest, findings
 
@@ -513,8 +521,8 @@ def update_manifest_for_role(
     findings.extend(emit_findings)
     if has_emit_corruption(emit_findings):
         warning = (
-            f"Manifest update wrote an invalid manifest at {manifest_path} "
-            f"— inspect findings and repair the file"
+            f"Manifest update wrote an invalid manifest at "
+            f"{to_posix(manifest_path)} — inspect findings and repair the file"
         )
         return False, warning, created_manifest, findings
     return True, None, created_manifest, findings

--- a/skill-system-foundry/scripts/lib/manifest.py
+++ b/skill-system-foundry/scripts/lib/manifest.py
@@ -313,6 +313,26 @@ def manifest_needs_scaffold(manifest_path: str) -> bool:
         return not fh.read().strip()
 
 
+def _non_file_manifest_warning(manifest_path: str) -> str | None:
+    """Return a skip warning when *manifest_path* exists but is not a file.
+
+    A real ``update_manifest_*`` run would try to write ``manifest.yaml``
+    at this path and fail when something other than a regular file (most
+    often a directory) already occupies it — ``manifest_needs_scaffold``
+    reports any non-file as "needs scaffold", so without this guard the
+    run would crash mid-write and the ``--dry-run`` preview would claim a
+    bogus create/update. Detecting it up front lets both the real run and
+    the read-only preview report a graceful skip. Returns None for the
+    normal cases (path absent, or a regular file).
+    """
+    if os.path.exists(manifest_path) and not os.path.isfile(manifest_path):
+        return (
+            f"Manifest path {manifest_path} is not a regular file "
+            f"— skipping manifest update"
+        )
+    return None
+
+
 def _collect_emit_findings(manifest_path: str) -> list[str]:
     """Re-validate the post-write manifest for divergences and shape.
 
@@ -369,6 +389,9 @@ def update_manifest_for_skill(
     ``--dry-run`` to report an accurate manifest plan without touching
     disk.
     """
+    non_file_warning = _non_file_manifest_warning(manifest_path)
+    if non_file_warning is not None:
+        return False, non_file_warning, False, []
     created_manifest = manifest_needs_scaffold(manifest_path)
     # Treat non-existent or empty/whitespace-only files as missing.
     if created_manifest and preview:
@@ -445,6 +468,9 @@ def update_manifest_for_role(
     by scaffold's ``--dry-run`` to report an accurate manifest plan
     without touching disk.
     """
+    non_file_warning = _non_file_manifest_warning(manifest_path)
+    if non_file_warning is not None:
+        return False, non_file_warning, False, []
     created_manifest = manifest_needs_scaffold(manifest_path)
     # Treat non-existent or empty/whitespace-only files as missing.
     if created_manifest and preview:

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -183,13 +183,15 @@ def _collect_frontmatter_findings(
 
 
 def _print_created(path: str, *, dry_run: bool) -> None:
-    """Print the human-mode created/planned line for a directory *path*.
+    """Print the human-mode created/planned line for a filesystem *path*.
 
-    Mirrors ``write_file``'s own line for the file case: a real run
-    prints ``Created: <path>`` while a dry run prints
-    ``Would create: <path>``.  Centralises the verb switch so the three
-    scaffold functions stay free of dry-run branching at each
-    directory-creation site.
+    Handles both directory and file paths — used at every site that
+    records a planned or created entry outside ``write_file`` itself
+    (container directories, the manifest in ``_report_planned_manifest``,
+    etc.). Mirrors ``write_file``'s own line: a real run prints
+    ``Created: <path>`` while a dry run prints ``Would create: <path>``.
+    Centralises the verb switch so callers stay free of dry-run
+    branching at each recording site.
     """
     if dry_run:
         print(planned_line(path))

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -204,7 +204,7 @@ def _print_dir_created(dir_path: str, gitkeep_path: str, *, dry_run: bool) -> No
 
 def _record_planned_dirs(
     target_dir: str, created_paths: list[str], *, quiet: bool, dry_run: bool
-) -> None:
+) -> str | None:
     """Record the directories ``os.makedirs(target_dir)`` would newly create.
 
     ``write_file`` and ``create_dir_with_gitkeep`` create their parent
@@ -217,10 +217,19 @@ def _record_planned_dirs(
     in both modes because dry-run writes nothing. Call it once per
     scaffold function before the first write, while the filesystem is
     still pristine, so an absent ancestor is counted exactly once.
+
+    If an ancestor exists but is not a directory, ``os.makedirs`` cannot
+    create through it and a real run would fail. In that case nothing is
+    recorded and the blocking path is returned so the caller can surface
+    an error instead of a bogus planned create. Returns None on success.
     """
     missing: list[str] = []
     cur = target_dir
     while cur and not os.path.isdir(cur):
+        if os.path.exists(cur):
+            # cur exists but is not a directory: os.makedirs would fail
+            # here, so the chain cannot be created.
+            return cur
         missing.append(cur)
         parent = os.path.dirname(cur)
         if parent == cur:
@@ -230,6 +239,20 @@ def _record_planned_dirs(
         created_paths.append(d)
         if not quiet:
             _print_created(d, dry_run=dry_run)
+    return None
+
+
+def _blocking_dir_error(blocking: str) -> str:
+    """Human-readable error for a non-directory ancestor that blocks makedirs.
+
+    Surfaced — in both real and dry-run mode — when ``_record_planned_dirs``
+    finds a path component that exists but is not a directory, so a real
+    run's ``os.makedirs`` could not create the component tree through it.
+    """
+    return (
+        f"Cannot create directory: {to_posix(blocking)} exists and is "
+        f"not a directory"
+    )
 
 
 def read_template(template_name: str) -> str:
@@ -393,9 +416,20 @@ def scaffold_skill(
     # directories, and their .gitkeep sentinel files. Exposed as the
     # ``"created"`` list in JSON output.
     created_paths: list[str] = []
-    _record_planned_dirs(
+    blocking = _record_planned_dirs(
         skill_path, created_paths, quiet=json_output, dry_run=dry_run,
     )
+    if blocking is not None:
+        if json_output:
+            return {
+                "tool": "scaffold",
+                "component": "skill",
+                "name": name,
+                "success": False,
+                "error": _blocking_dir_error(blocking),
+            }
+        print(f"{LEVEL_FAIL}: {_blocking_dir_error(blocking)}")
+        sys.exit(1)
 
     if router:
         try:
@@ -663,9 +697,21 @@ def scaffold_capability(
     # ancestors it needs, content files (e.g. capability.md), optional
     # directories, and their .gitkeep files.
     created_paths: list[str] = []
-    _record_planned_dirs(
+    blocking = _record_planned_dirs(
         cap_path, created_paths, quiet=json_output, dry_run=dry_run,
     )
+    if blocking is not None:
+        if json_output:
+            return {
+                "tool": "scaffold",
+                "component": "capability",
+                "name": name,
+                "domain": domain,
+                "success": False,
+                "error": _blocking_dir_error(blocking),
+            }
+        print(f"{LEVEL_FAIL}: {_blocking_dir_error(blocking)}")
+        sys.exit(1)
 
     try:
         template = read_template(TEMPLATE_CAPABILITY)
@@ -831,10 +877,22 @@ def scaffold_role(
     # any ancestors it needs, plus the role file and group/top-level
     # READMEs.
     created_paths: list[str] = []
-    _record_planned_dirs(
+    blocking = _record_planned_dirs(
         os.path.dirname(role_path), created_paths,
         quiet=json_output, dry_run=dry_run,
     )
+    if blocking is not None:
+        if json_output:
+            return {
+                "tool": "scaffold",
+                "component": "role",
+                "name": name,
+                "group": group,
+                "success": False,
+                "error": _blocking_dir_error(blocking),
+            }
+        print(f"{LEVEL_FAIL}: {_blocking_dir_error(blocking)}")
+        sys.exit(1)
 
     try:
         template = read_template(TEMPLATE_ROLE)

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -274,7 +274,7 @@ def _blocking_dir_error(blocking: str) -> str:
 
 
 def _scaffold_error(
-    component: str,
+    component: str | None,
     error: str,
     *,
     dry_run: bool,
@@ -283,22 +283,24 @@ def _scaffold_error(
 ) -> dict:
     """Build a scaffold error result with the stable JSON schema.
 
-    Every scaffold JSON payload — success or failure — carries the same
-    top-level keys so consumers parse one shape: ``tool``, ``component``,
-    ``success``, ``dry_run``, the component-specific identifiers in
-    *fields* (``name`` / ``domain`` / ``group``), ``error``, an empty
+    Every scaffold JSON payload — success or failure, component-level or
+    CLI-level — carries the same top-level keys so consumers parse one
+    shape: ``tool``, ``success``, ``dry_run``, ``error``, and an empty
     path list under the run-mode key (``planned`` under dry-run,
-    ``created`` otherwise — empty because an error path records nothing),
-    and ``details`` when supplied. Carrying ``dry_run`` and the path-list
-    key on errors too keeps the schema identical to the success payload.
+    ``created`` otherwise — empty because an error path records nothing).
+    ``component`` is included when known and omitted for pre-dispatch CLI
+    errors that have no component yet (pass ``None``). *fields* supplies
+    the component-specific identifiers (``name`` / ``domain`` / ``group``)
+    and ``details`` is added when supplied. Carrying ``dry_run`` and the
+    path-list key on every error keeps the schema identical to the
+    success payload.
     """
-    result: dict = {
-        "tool": "scaffold",
-        "component": component,
-        "success": False,
-        "dry_run": dry_run,
-        "error": error,
-    }
+    result: dict = {"tool": "scaffold"}
+    if component is not None:
+        result["component"] = component
+    result["success"] = False
+    result["dry_run"] = dry_run
+    result["error"] = error
     result.update(fields)
     result["planned" if dry_run else "created"] = []
     if details is not None:
@@ -1072,16 +1074,11 @@ def _validate_flags(
     if unknown:
         if json_mode:
             allowed = ", ".join(sorted(known)) or "(none)"
-            print(to_json_output({
-                "tool": "scaffold",
-                "component": component,
-                "success": False,
-                "dry_run": dry_run,
-                "error": (
-                    f"Unknown flag(s): {', '.join(unknown)}. "
-                    f"Allowed: {allowed}"
-                ),
-            }))
+            print(to_json_output(_scaffold_error(
+                component,
+                f"Unknown flag(s): {', '.join(unknown)}. Allowed: {allowed}",
+                dry_run=dry_run,
+            )))
         else:
             print(
                 f"{LEVEL_FAIL}: Unknown flag(s) for '{component}': "
@@ -1127,12 +1124,9 @@ def main() -> None:
         idx = args.index("--root")
         if idx + 1 >= len(args) or args[idx + 1].startswith("--"):
             if json_output:
-                print(to_json_output({
-                    "tool": "scaffold",
-                    "success": False,
-                    "dry_run": dry_run,
-                    "error": "--root requires a path argument",
-                }))
+                print(to_json_output(_scaffold_error(
+                    None, "--root requires a path argument", dry_run=dry_run,
+                )))
             else:
                 print(f"{LEVEL_FAIL}: --root requires a path argument")
             sys.exit(1)
@@ -1141,12 +1135,9 @@ def main() -> None:
 
     if len(args) < 3:
         if json_output:
-            print(to_json_output({
-                "tool": "scaffold",
-                "success": False,
-                "dry_run": dry_run,
-                "error": "Insufficient arguments",
-            }))
+            print(to_json_output(_scaffold_error(
+                None, "Insufficient arguments", dry_run=dry_run,
+            )))
         else:
             print(__doc__)
         sys.exit(1)
@@ -1158,13 +1149,9 @@ def main() -> None:
         flags = [a for a in args[2:] if a.startswith("--")]
         if not positional:
             if json_output:
-                print(to_json_output({
-                    "tool": "scaffold",
-                    "component": "skill",
-                    "success": False,
-                    "dry_run": dry_run,
-                    "error": "Missing skill name",
-                }))
+                print(to_json_output(_scaffold_error(
+                    "skill", "Missing skill name", dry_run=dry_run,
+                )))
             else:
                 print("Usage: python scripts/scaffold.py skill <name> [--router] [--root <path>] [--with-references] [--with-scripts] [--with-assets] [--update-manifest] [--dry-run] [--json]")
             sys.exit(1)
@@ -1181,14 +1168,10 @@ def main() -> None:
             )
         except Exception as exc:
             if json_output:
-                print(to_json_output({
-                    "tool": "scaffold",
-                    "component": "skill",
-                    "name": name,
-                    "success": False,
-                    "dry_run": dry_run,
-                    "error": f"{exc.__class__.__name__}: {exc}",
-                }))
+                print(to_json_output(_scaffold_error(
+                    "skill", f"{exc.__class__.__name__}: {exc}",
+                    dry_run=dry_run, name=name,
+                )))
                 sys.exit(1)
             raise
         if json_output and result is not None:
@@ -1200,13 +1183,10 @@ def main() -> None:
         flags = [a for a in args[2:] if a.startswith("--")]
         if len(positional) < 2:
             if json_output:
-                print(to_json_output({
-                    "tool": "scaffold",
-                    "component": "capability",
-                    "success": False,
-                    "dry_run": dry_run,
-                    "error": "Missing domain or capability name",
-                }))
+                print(to_json_output(_scaffold_error(
+                    "capability", "Missing domain or capability name",
+                    dry_run=dry_run,
+                )))
             else:
                 print("Usage: python scripts/scaffold.py capability <domain> <name> [--root <path>] [--with-references] [--update-manifest] [--dry-run] [--json]")
             sys.exit(1)
@@ -1221,15 +1201,10 @@ def main() -> None:
             )
         except Exception as exc:
             if json_output:
-                print(to_json_output({
-                    "tool": "scaffold",
-                    "component": "capability",
-                    "name": positional[1],
-                    "domain": positional[0],
-                    "success": False,
-                    "dry_run": dry_run,
-                    "error": f"{exc.__class__.__name__}: {exc}",
-                }))
+                print(to_json_output(_scaffold_error(
+                    "capability", f"{exc.__class__.__name__}: {exc}",
+                    dry_run=dry_run, name=positional[1], domain=positional[0],
+                )))
                 sys.exit(1)
             raise
         if json_output and result is not None:
@@ -1241,13 +1216,9 @@ def main() -> None:
         flags = [a for a in args[2:] if a.startswith("--")]
         if len(positional) < 2:
             if json_output:
-                print(to_json_output({
-                    "tool": "scaffold",
-                    "component": "role",
-                    "success": False,
-                    "dry_run": dry_run,
-                    "error": "Missing group or role name",
-                }))
+                print(to_json_output(_scaffold_error(
+                    "role", "Missing group or role name", dry_run=dry_run,
+                )))
             else:
                 print("Usage: python scripts/scaffold.py role <group> <name> [--root <path>] [--update-manifest] [--dry-run] [--json]")
             sys.exit(1)
@@ -1261,15 +1232,10 @@ def main() -> None:
             )
         except Exception as exc:
             if json_output:
-                print(to_json_output({
-                    "tool": "scaffold",
-                    "component": "role",
-                    "name": positional[1],
-                    "group": positional[0],
-                    "success": False,
-                    "dry_run": dry_run,
-                    "error": f"{exc.__class__.__name__}: {exc}",
-                }))
+                print(to_json_output(_scaffold_error(
+                    "role", f"{exc.__class__.__name__}: {exc}",
+                    dry_run=dry_run, name=positional[1], group=positional[0],
+                )))
                 sys.exit(1)
             raise
         if json_output and result is not None:
@@ -1278,12 +1244,9 @@ def main() -> None:
 
     else:
         if json_output:
-            print(to_json_output({
-                "tool": "scaffold",
-                "success": False,
-                "dry_run": dry_run,
-                "error": f"Unknown component type: {component}",
-            }))
+            print(to_json_output(_scaffold_error(
+                None, f"Unknown component type: {component}", dry_run=dry_run,
+            )))
         else:
             print(f"{LEVEL_FAIL}: Unknown component type: {component}")
             print("  Valid types: skill, capability, role")

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -50,7 +50,6 @@ from lib.validation import validate_name as _validate_name_detailed
 from lib.manifest import (
     update_manifest_for_skill,
     update_manifest_for_role,
-    manifest_needs_scaffold,
     has_emit_corruption,
 )
 from lib.constants import (
@@ -265,33 +264,42 @@ def create_dir_with_gitkeep(path: str, *, dry_run: bool = False) -> str:
     return gitkeep
 
 
-def _plan_manifest_update(
-    manifest_path: str, created_paths: list[str], *, quiet: bool
-) -> bool:
-    """Record and report the manifest action a real ``--update-manifest``
-    run would take, without reading or mutating the file.
+def _report_planned_manifest(
+    manifest_path: str,
+    preview: tuple[bool, str | None, bool, list[str]],
+    created_paths: list[str],
+    *,
+    quiet: bool,
+) -> tuple[bool, str | None, list[str]]:
+    """Apply a read-only manifest *preview* to the dry-run plan.
 
-    Mirrors the real run's created-vs-updated split: an absent (or
-    empty) manifest would be scaffolded, so it joins *created_paths* and
-    is reported as a planned create; an existing manifest would be
-    appended to in place, so it is reported as a planned update and is
-    *not* added to *created_paths* (the real run excludes it from
-    ``created`` too). Conflict detection is intentionally skipped — a dry
-    run never parses the manifest — so the return mirrors the happy-path
-    append.
+    *preview* is the ``(updated, warning, created_manifest, findings)``
+    tuple from ``update_manifest_for_skill`` / ``update_manifest_for_role``
+    run in ``preview=True`` mode — those helpers read and validate the
+    manifest without writing, so this function can report exactly what a
+    real run would do. A manifest that would be newly created joins
+    *created_paths* and is shown as a planned create; one that would be
+    updated in place is shown as a planned update and kept out of
+    *created_paths* (the real run excludes an existing manifest from its
+    ``created`` set); a name conflict or parse failure is surfaced as a
+    warning and claims no update.
 
     Returns:
-        True, matching the ``manifest_updated`` a real run reports when
-        the entry is appended (whether the manifest was created first or
-        updated in place).
+        ``(updated, warning, findings)`` for the caller's JSON payload.
     """
-    if manifest_needs_scaffold(manifest_path):
+    updated, warning, created_manifest, findings = preview
+    if created_manifest:
         created_paths.append(manifest_path)
-        if not quiet:
+    if not quiet:
+        if created_manifest:
             _print_created(manifest_path, dry_run=True)
-    elif not quiet:
-        print(planned_update_line(manifest_path))
-    return True
+        elif updated:
+            print(planned_update_line(manifest_path))
+        if warning:
+            print(f"  {LEVEL_WARN}: {warning}")
+        for f in _dedupe_preserving_order(list(findings)):
+            print(f"  {f}")
+    return updated, warning, findings
 
 
 def scaffold_skill(
@@ -447,14 +455,20 @@ def scaffold_skill(
     manifest_emit_corrupted = False
 
     if update_manifest and dry_run:
-        # Preview only: the manifest is never parsed or mutated. A
-        # read-only existence check decides whether a real run would
-        # create the file (absent/empty → planned create, listed in
-        # created_paths) or append to it in place (present → planned
-        # update, reported separately and kept out of created_paths so
-        # the plan mirrors the real run's created set).
-        manifest_updated = _plan_manifest_update(
-            manifest_path, created_paths, quiet=json_output,
+        # Preview only: read and validate the manifest without writing.
+        # The read-only preview reports whether a real run would create
+        # the file, update it in place, or skip it (name conflict or
+        # parse failure), so the dry-run plan mirrors real-run semantics
+        # without touching disk.
+        manifest_updated, manifest_warning, manifest_findings = (
+            _report_planned_manifest(
+                manifest_path,
+                update_manifest_for_skill(
+                    manifest_path, name, router=router, preview=True,
+                ),
+                created_paths,
+                quiet=json_output,
+            )
         )
     elif update_manifest:
         (
@@ -842,14 +856,20 @@ def scaffold_role(
     manifest_emit_corrupted = False
 
     if update_manifest and dry_run:
-        # Preview only: the manifest is never parsed or mutated. A
-        # read-only existence check decides whether a real run would
-        # create the file (absent/empty → planned create, listed in
-        # created_paths) or append to it in place (present → planned
-        # update, reported separately and kept out of created_paths so
-        # the plan mirrors the real run's created set).
-        manifest_updated = _plan_manifest_update(
-            manifest_path, created_paths, quiet=json_output,
+        # Preview only: read and validate the manifest without writing.
+        # The read-only preview reports whether a real run would create
+        # the file, update it in place, or skip it (name conflict or
+        # parse failure), so the dry-run plan mirrors real-run semantics
+        # without touching disk.
+        manifest_updated, manifest_warning, manifest_findings = (
+            _report_planned_manifest(
+                manifest_path,
+                update_manifest_for_role(
+                    manifest_path, group, name, preview=True,
+                ),
+                created_paths,
+                quiet=json_output,
+            )
         )
     elif update_manifest:
         (

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -1048,11 +1048,14 @@ _WITH_FLAG_MAP = {
 
 # All flags recognised per component type.  --root and --json are
 # stripped before component dispatch and are not included here.
-# --update-manifest is included so it appears in "Allowed:" error messages.
+# --update-manifest and --dry-run are also stripped, but are included so
+# they appear in the "Allowed:" error message when a user mistypes a
+# flag — leaving valid flags out of the diagnostic misleads consumers
+# troubleshooting arguments.
 _KNOWN_FLAGS = {
-    "skill": {"--router", "--with-references", "--with-scripts", "--with-assets", "--update-manifest"},
-    "capability": {"--with-references", "--update-manifest"},
-    "role": {"--update-manifest"},
+    "skill": {"--router", "--with-references", "--with-scripts", "--with-assets", "--update-manifest", "--dry-run"},
+    "capability": {"--with-references", "--update-manifest", "--dry-run"},
+    "role": {"--update-manifest", "--dry-run"},
 }
 
 

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -45,11 +45,12 @@ if _scripts_dir not in sys.path:
 
 from lib.frontmatter import load_frontmatter
 from lib.reporting import to_json_output, to_posix
-from lib.dry_run import planned_line
+from lib.dry_run import planned_line, planned_update_line
 from lib.validation import validate_name as _validate_name_detailed
 from lib.manifest import (
     update_manifest_for_skill,
     update_manifest_for_role,
+    manifest_needs_scaffold,
     has_emit_corruption,
 )
 from lib.constants import (
@@ -249,6 +250,35 @@ def create_dir_with_gitkeep(path: str, *, dry_run: bool = False) -> str:
     return gitkeep
 
 
+def _plan_manifest_update(
+    manifest_path: str, created_paths: list[str], *, quiet: bool
+) -> bool:
+    """Record and report the manifest action a real ``--update-manifest``
+    run would take, without reading or mutating the file.
+
+    Mirrors the real run's created-vs-updated split: an absent (or
+    empty) manifest would be scaffolded, so it joins *created_paths* and
+    is reported as a planned create; an existing manifest would be
+    appended to in place, so it is reported as a planned update and is
+    *not* added to *created_paths* (the real run excludes it from
+    ``created`` too). Conflict detection is intentionally skipped — a dry
+    run never parses the manifest — so the return mirrors the happy-path
+    append.
+
+    Returns:
+        True, matching the ``manifest_updated`` a real run reports when
+        the entry is appended (whether the manifest was created first or
+        updated in place).
+    """
+    if manifest_needs_scaffold(manifest_path):
+        created_paths.append(manifest_path)
+        if not quiet:
+            _print_created(manifest_path, dry_run=True)
+    elif not quiet:
+        print(planned_update_line(manifest_path))
+    return True
+
+
 def scaffold_skill(
     name: str,
     router: bool = False,
@@ -402,12 +432,15 @@ def scaffold_skill(
     manifest_emit_corrupted = False
 
     if update_manifest and dry_run:
-        # Preview only: the manifest is never read or mutated. Report it
-        # as a planned path so the dry-run plan mirrors the real run's
-        # created set without touching disk.
-        created_paths.append(manifest_path)
-        if not json_output:
-            _print_created(manifest_path, dry_run=True)
+        # Preview only: the manifest is never parsed or mutated. A
+        # read-only existence check decides whether a real run would
+        # create the file (absent/empty → planned create, listed in
+        # created_paths) or append to it in place (present → planned
+        # update, reported separately and kept out of created_paths so
+        # the plan mirrors the real run's created set).
+        manifest_updated = _plan_manifest_update(
+            manifest_path, created_paths, quiet=json_output,
+        )
     elif update_manifest:
         (
             manifest_updated,
@@ -794,11 +827,15 @@ def scaffold_role(
     manifest_emit_corrupted = False
 
     if update_manifest and dry_run:
-        # Preview only: the manifest is never read or mutated. Report it
-        # as a planned path so the dry-run plan mirrors the real run.
-        created_paths.append(manifest_path)
-        if not json_output:
-            _print_created(manifest_path, dry_run=True)
+        # Preview only: the manifest is never parsed or mutated. A
+        # read-only existence check decides whether a real run would
+        # create the file (absent/empty → planned create, listed in
+        # created_paths) or append to it in place (present → planned
+        # update, reported separately and kept out of created_paths so
+        # the plan mirrors the real run's created set).
+        manifest_updated = _plan_manifest_update(
+            manifest_path, created_paths, quiet=json_output,
+        )
     elif update_manifest:
         (
             manifest_updated,

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -188,6 +188,21 @@ def _print_created(path: str, *, dry_run: bool) -> None:
         print(f"  Created: {to_posix(path)}")
 
 
+def _print_dir_created(dir_path: str, gitkeep_path: str, *, dry_run: bool) -> None:
+    """Print the human-mode line(s) for a directory and its ``.gitkeep``.
+
+    A real run narrates only the directory — the ``.gitkeep`` is a git
+    tracking sentinel, an implementation detail of how an otherwise empty
+    directory is persisted. A dry run is a complete preview of every
+    filesystem entry the command would create, so it also lists the
+    ``.gitkeep`` that already appears in the JSON ``planned`` set, keeping
+    human and JSON dry-run output enumerating the same paths.
+    """
+    _print_created(dir_path, dry_run=dry_run)
+    if dry_run:
+        print(planned_line(gitkeep_path))
+
+
 def read_template(template_name: str) -> str:
     """Read a template file from assets/."""
     template_path = os.path.join(ASSETS_DIR, template_name)
@@ -369,14 +384,14 @@ def scaffold_skill(
         created_paths.append(caps_dir)
         created_paths.append(gitkeep)
         if not json_output:
-            _print_created(caps_dir, dry_run=dry_run)
+            _print_dir_created(caps_dir, gitkeep, dry_run=dry_run)
         for d in optional_dirs:
             opt_dir = os.path.join(skill_path, d)
             gitkeep = create_dir_with_gitkeep(opt_dir, dry_run=dry_run)
             created_paths.append(opt_dir)
             created_paths.append(gitkeep)
             if not json_output:
-                _print_created(opt_dir, dry_run=dry_run)
+                _print_dir_created(opt_dir, gitkeep, dry_run=dry_run)
         if not json_output:
             print(f"  Note: Add shared/ when 2+ capabilities exist (see directory-structure.md)")
     else:
@@ -408,7 +423,7 @@ def scaffold_skill(
             created_paths.append(opt_dir)
             created_paths.append(gitkeep)
             if not json_output:
-                _print_created(opt_dir, dry_run=dry_run)
+                _print_dir_created(opt_dir, gitkeep, dry_run=dry_run)
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
@@ -629,7 +644,7 @@ def scaffold_capability(
         created_paths.append(opt_dir)
         created_paths.append(gitkeep)
         if not json_output:
-            _print_created(opt_dir, dry_run=dry_run)
+            _print_dir_created(opt_dir, gitkeep, dry_run=dry_run)
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -793,6 +793,11 @@ def scaffold_capability(
     cap_md_path = os.path.join(cap_path, FILE_CAPABILITY_MD)
     if dry_run:
         print("  Dry run: no files were written.")
+        # The manifest guidance applies in dry-run too: a real run would
+        # not touch manifest.yaml for a capability, and the JSON output
+        # reports it as manifest_warning, so keep the human line in sync.
+        if update_manifest:
+            print(f"  {LEVEL_INFO}: {cap_manifest_msg}")
     else:
         print(f"  Next: edit {to_posix(cap_md_path)}")
         print(

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -202,6 +202,36 @@ def _print_dir_created(dir_path: str, gitkeep_path: str, *, dry_run: bool) -> No
         print(planned_line(gitkeep_path))
 
 
+def _record_planned_dirs(
+    target_dir: str, created_paths: list[str], *, quiet: bool, dry_run: bool
+) -> None:
+    """Record the directories ``os.makedirs(target_dir)`` would newly create.
+
+    ``write_file`` and ``create_dir_with_gitkeep`` create their parent
+    directories implicitly via ``os.makedirs(..., exist_ok=True)``; a
+    real run leaves those on disk, so the dry-run plan must list the same
+    set to stay complete and to keep ``planned`` equal to a real run's
+    ``created``. This appends every not-yet-existing ancestor of
+    *target_dir* (outermost first) — the chain a real run would
+    materialise — based on the current on-disk state, which is identical
+    in both modes because dry-run writes nothing. Call it once per
+    scaffold function before the first write, while the filesystem is
+    still pristine, so an absent ancestor is counted exactly once.
+    """
+    missing: list[str] = []
+    cur = target_dir
+    while cur and not os.path.isdir(cur):
+        missing.append(cur)
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+    for d in reversed(missing):
+        created_paths.append(d)
+        if not quiet:
+            _print_created(d, dry_run=dry_run)
+
+
 def read_template(template_name: str) -> str:
     """Read a template file from assets/."""
     template_path = os.path.join(ASSETS_DIR, template_name)
@@ -358,10 +388,14 @@ def scaffold_skill(
         print(f"{LEVEL_FAIL}: Directory already exists: {to_posix(skill_path)}")
         sys.exit(1)
 
-    # Tracks created filesystem entries: content files (e.g. SKILL.md),
-    # optional directories, and their .gitkeep sentinel files.
-    # Exposed as the ``"created"`` list in JSON output.
+    # Tracks created filesystem entries: the skill directory and any
+    # ancestors it needs, content files (e.g. SKILL.md), optional
+    # directories, and their .gitkeep sentinel files. Exposed as the
+    # ``"created"`` list in JSON output.
     created_paths: list[str] = []
+    _record_planned_dirs(
+        skill_path, created_paths, quiet=json_output, dry_run=dry_run,
+    )
 
     if router:
         try:
@@ -625,9 +659,13 @@ def scaffold_capability(
         print(f"{LEVEL_FAIL}: Parent skill not found: {to_posix(router_skill)}")
         sys.exit(1)
 
-    # Tracks created filesystem entries: content files (e.g.
-    # capability.md), optional directories, and their .gitkeep files.
+    # Tracks created filesystem entries: the capability directory and any
+    # ancestors it needs, content files (e.g. capability.md), optional
+    # directories, and their .gitkeep files.
     created_paths: list[str] = []
+    _record_planned_dirs(
+        cap_path, created_paths, quiet=json_output, dry_run=dry_run,
+    )
 
     try:
         template = read_template(TEMPLATE_CAPABILITY)
@@ -789,8 +827,14 @@ def scaffold_role(
         print(f"{LEVEL_FAIL}: File already exists: {to_posix(role_path)}")
         sys.exit(1)
 
-    # Tracks all filesystem entries created (files only for roles).
+    # Tracks all filesystem entries created: the role-group directory and
+    # any ancestors it needs, plus the role file and group/top-level
+    # READMEs.
     created_paths: list[str] = []
+    _record_planned_dirs(
+        os.path.dirname(role_path), created_paths,
+        quiet=json_output, dry_run=dry_run,
+    )
 
     try:
         template = read_template(TEMPLATE_ROLE)

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -218,6 +218,14 @@ def _record_planned_dirs(
     scaffold function before the first write, while the filesystem is
     still pristine, so an absent ancestor is counted exactly once.
 
+    The directories are recorded in *created_paths* in both modes (so the
+    JSON ``planned``/``created`` set is complete), but narrated only
+    under dry-run. A real run does not print them here because they are
+    not on disk yet — they are materialised by the file writes that
+    follow, which print their own ``Created:`` lines; narrating them now
+    would claim directories the run might never reach if a later step
+    (e.g. a missing template) fails before the first write.
+
     If an ancestor exists but is not a directory, ``os.makedirs`` cannot
     create through it and a real run would fail. In that case nothing is
     recorded and the blocking path is returned so the caller can surface
@@ -237,8 +245,8 @@ def _record_planned_dirs(
         cur = parent
     for d in reversed(missing):
         created_paths.append(d)
-        if not quiet:
-            _print_created(d, dry_run=dry_run)
+        if dry_run and not quiet:
+            print(planned_line(d))
     return None
 
 

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -273,6 +273,39 @@ def _blocking_dir_error(blocking: str) -> str:
     )
 
 
+def _scaffold_error(
+    component: str,
+    error: str,
+    *,
+    dry_run: bool,
+    details: list[str] | None = None,
+    **fields: str,
+) -> dict:
+    """Build a scaffold error result with the stable JSON schema.
+
+    Every scaffold JSON payload — success or failure — carries the same
+    top-level keys so consumers parse one shape: ``tool``, ``component``,
+    ``success``, ``dry_run``, the component-specific identifiers in
+    *fields* (``name`` / ``domain`` / ``group``), ``error``, an empty
+    path list under the run-mode key (``planned`` under dry-run,
+    ``created`` otherwise — empty because an error path records nothing),
+    and ``details`` when supplied. Carrying ``dry_run`` and the path-list
+    key on errors too keeps the schema identical to the success payload.
+    """
+    result: dict = {
+        "tool": "scaffold",
+        "component": component,
+        "success": False,
+        "dry_run": dry_run,
+        "error": error,
+    }
+    result.update(fields)
+    result["planned" if dry_run else "created"] = []
+    if details is not None:
+        result["details"] = details
+    return result
+
+
 def read_template(template_name: str) -> str:
     """Read a template file from assets/."""
     template_path = os.path.join(ASSETS_DIR, template_name)
@@ -408,26 +441,21 @@ def scaffold_skill(
         optional_dirs = []
     if not validate_name(name, json_output=json_output):
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "skill",
-                "name": name,
-                "success": False,
-                "error": f"Invalid name: '{name}'",
-                "details": _name_validation_details(name),
-            }
+            return _scaffold_error(
+                "skill", f"Invalid name: '{name}'",
+                dry_run=dry_run, name=name,
+                details=_name_validation_details(name),
+            )
         sys.exit(1)
 
     skill_path = os.path.join(root, DIR_SKILLS, name) if root else os.path.join(DIR_SKILLS, name)
     if os.path.exists(skill_path):
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "skill",
-                "name": name,
-                "success": False,
-                "error": f"Directory already exists: {to_posix(skill_path)}",
-            }
+            return _scaffold_error(
+                "skill",
+                f"Directory already exists: {to_posix(skill_path)}",
+                dry_run=dry_run, name=name,
+            )
         print(f"{LEVEL_FAIL}: Directory already exists: {to_posix(skill_path)}")
         sys.exit(1)
 
@@ -441,13 +469,10 @@ def scaffold_skill(
     )
     if blocking is not None:
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "skill",
-                "name": name,
-                "success": False,
-                "error": _blocking_dir_error(blocking),
-            }
+            return _scaffold_error(
+                "skill", _blocking_dir_error(blocking),
+                dry_run=dry_run, name=name,
+            )
         print(f"{LEVEL_FAIL}: {_blocking_dir_error(blocking)}")
         sys.exit(1)
 
@@ -456,13 +481,9 @@ def scaffold_skill(
             template = read_template(TEMPLATE_SKILL_ROUTER)
         except FileNotFoundError as e:
             if json_output:
-                return {
-                    "tool": "scaffold",
-                    "component": "skill",
-                    "name": name,
-                    "success": False,
-                    "error": str(e),
-                }
+                return _scaffold_error(
+                    "skill", str(e), dry_run=dry_run, name=name,
+                )
             print(f"{LEVEL_FAIL}: {e}")
             sys.exit(1)
         # Replace placeholders
@@ -495,13 +516,9 @@ def scaffold_skill(
             template = read_template(TEMPLATE_SKILL_STANDALONE)
         except FileNotFoundError as e:
             if json_output:
-                return {
-                    "tool": "scaffold",
-                    "component": "skill",
-                    "name": name,
-                    "success": False,
-                    "error": str(e),
-                }
+                return _scaffold_error(
+                    "skill", str(e), dry_run=dry_run, name=name,
+                )
             print(f"{LEVEL_FAIL}: {e}")
             sys.exit(1)
         title = name.replace("-", " ").title()
@@ -665,54 +682,40 @@ def scaffold_capability(
         optional_dirs = []
     if not validate_name(domain, json_output=json_output):
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "capability",
-                "name": name,
-                "domain": domain,
-                "success": False,
-                "error": f"Invalid domain name: '{domain}'",
-                "details": _name_validation_details(domain),
-            }
+            return _scaffold_error(
+                "capability", f"Invalid domain name: '{domain}'",
+                dry_run=dry_run, name=name, domain=domain,
+                details=_name_validation_details(domain),
+            )
         sys.exit(1)
     if not validate_name(name, json_output=json_output):
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "capability",
-                "name": name,
-                "domain": domain,
-                "success": False,
-                "error": f"Invalid name: '{name}'",
-                "details": _name_validation_details(name),
-            }
+            return _scaffold_error(
+                "capability", f"Invalid name: '{name}'",
+                dry_run=dry_run, name=name, domain=domain,
+                details=_name_validation_details(name),
+            )
         sys.exit(1)
 
     cap_path = os.path.join(root, DIR_SKILLS, domain, DIR_CAPABILITIES, name) if root else os.path.join(DIR_SKILLS, domain, DIR_CAPABILITIES, name)
     if os.path.exists(cap_path):
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "capability",
-                "name": name,
-                "domain": domain,
-                "success": False,
-                "error": f"Directory already exists: {to_posix(cap_path)}",
-            }
+            return _scaffold_error(
+                "capability",
+                f"Directory already exists: {to_posix(cap_path)}",
+                dry_run=dry_run, name=name, domain=domain,
+            )
         print(f"{LEVEL_FAIL}: Directory already exists: {to_posix(cap_path)}")
         sys.exit(1)
 
     router_skill = os.path.join(root, DIR_SKILLS, domain, FILE_SKILL_MD) if root else os.path.join(DIR_SKILLS, domain, FILE_SKILL_MD)
     if not os.path.exists(router_skill):
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "capability",
-                "name": name,
-                "domain": domain,
-                "success": False,
-                "error": f"Parent skill not found: {to_posix(router_skill)}",
-            }
+            return _scaffold_error(
+                "capability",
+                f"Parent skill not found: {to_posix(router_skill)}",
+                dry_run=dry_run, name=name, domain=domain,
+            )
         print(f"{LEVEL_FAIL}: Parent skill not found: {to_posix(router_skill)}")
         sys.exit(1)
 
@@ -725,14 +728,10 @@ def scaffold_capability(
     )
     if blocking is not None:
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "capability",
-                "name": name,
-                "domain": domain,
-                "success": False,
-                "error": _blocking_dir_error(blocking),
-            }
+            return _scaffold_error(
+                "capability", _blocking_dir_error(blocking),
+                dry_run=dry_run, name=name, domain=domain,
+            )
         print(f"{LEVEL_FAIL}: {_blocking_dir_error(blocking)}")
         sys.exit(1)
 
@@ -740,14 +739,10 @@ def scaffold_capability(
         template = read_template(TEMPLATE_CAPABILITY)
     except FileNotFoundError as e:
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "capability",
-                "name": name,
-                "domain": domain,
-                "success": False,
-                "error": str(e),
-            }
+            return _scaffold_error(
+                "capability", str(e),
+                dry_run=dry_run, name=name, domain=domain,
+            )
         print(f"{LEVEL_FAIL}: {e}")
         sys.exit(1)
     title = name.replace("-", " ").title()
@@ -855,49 +850,39 @@ def scaffold_role(
             after scaffolding.
         dry_run: If True, write nothing to disk. The same set of paths a
             real run would create — the role file and any not-yet-present
-            README files — is reported as planned actions, the manifest
-            is left untouched, and the post-write frontmatter re-parse is
-            skipped.
+            README files — is reported as planned actions; the manifest
+            may be read to preview a conflict or parse error but is never
+            written; and the rendered frontmatter is validated in memory
+            so the preview reports the same findings and success/exit
+            status a real run would.
 
     Returns:
         A result dict when *json_output* is True, otherwise None.
     """
     if not validate_name(group, json_output=json_output):
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "role",
-                "name": name,
-                "group": group,
-                "success": False,
-                "error": f"Invalid group name: '{group}'",
-                "details": _name_validation_details(group),
-            }
+            return _scaffold_error(
+                "role", f"Invalid group name: '{group}'",
+                dry_run=dry_run, name=name, group=group,
+                details=_name_validation_details(group),
+            )
         sys.exit(1)
     if not validate_name(name, json_output=json_output):
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "role",
-                "name": name,
-                "group": group,
-                "success": False,
-                "error": f"Invalid name: '{name}'",
-                "details": _name_validation_details(name),
-            }
+            return _scaffold_error(
+                "role", f"Invalid name: '{name}'",
+                dry_run=dry_run, name=name, group=group,
+                details=_name_validation_details(name),
+            )
         sys.exit(1)
 
     role_path = os.path.join(root, DIR_ROLES, group, f"{name}{EXT_MARKDOWN}") if root else os.path.join(DIR_ROLES, group, f"{name}{EXT_MARKDOWN}")
     if os.path.exists(role_path):
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "role",
-                "name": name,
-                "group": group,
-                "success": False,
-                "error": f"File already exists: {to_posix(role_path)}",
-            }
+            return _scaffold_error(
+                "role", f"File already exists: {to_posix(role_path)}",
+                dry_run=dry_run, name=name, group=group,
+            )
         print(f"{LEVEL_FAIL}: File already exists: {to_posix(role_path)}")
         sys.exit(1)
 
@@ -911,14 +896,10 @@ def scaffold_role(
     )
     if blocking is not None:
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "role",
-                "name": name,
-                "group": group,
-                "success": False,
-                "error": _blocking_dir_error(blocking),
-            }
+            return _scaffold_error(
+                "role", _blocking_dir_error(blocking),
+                dry_run=dry_run, name=name, group=group,
+            )
         print(f"{LEVEL_FAIL}: {_blocking_dir_error(blocking)}")
         sys.exit(1)
 
@@ -926,14 +907,9 @@ def scaffold_role(
         template = read_template(TEMPLATE_ROLE)
     except FileNotFoundError as e:
         if json_output:
-            return {
-                "tool": "scaffold",
-                "component": "role",
-                "name": name,
-                "group": group,
-                "success": False,
-                "error": str(e),
-            }
+            return _scaffold_error(
+                "role", str(e), dry_run=dry_run, name=name, group=group,
+            )
         print(f"{LEVEL_FAIL}: {e}")
         sys.exit(1)
     title = name.replace("-", " ").title()
@@ -1082,12 +1058,17 @@ _KNOWN_FLAGS = {
 }
 
 
-def _validate_flags(flags: list[str], component: str, *, json_mode: bool = False) -> None:
+def _validate_flags(
+    flags: list[str], component: str, *, json_mode: bool = False,
+    dry_run: bool = False,
+) -> None:
     """Validate *flags* against the known set for *component*.
 
     Exits with an error message listing the unrecognised flags.
     When *json_mode* is ``True`` the error is emitted as a JSON object
-    instead of human-readable text.  Duplicates are silently ignored.
+    instead of human-readable text.  *dry_run* is carried into that JSON
+    so every scaffold response, success or failure, exposes the flag.
+    Duplicates are silently ignored.
     """
     known = _KNOWN_FLAGS.get(component, set())
     unique_flags = list(dict.fromkeys(flags))
@@ -1099,6 +1080,7 @@ def _validate_flags(flags: list[str], component: str, *, json_mode: bool = False
                 "tool": "scaffold",
                 "component": component,
                 "success": False,
+                "dry_run": dry_run,
                 "error": (
                     f"Unknown flag(s): {', '.join(unknown)}. "
                     f"Allowed: {allowed}"
@@ -1152,6 +1134,7 @@ def main() -> None:
                 print(to_json_output({
                     "tool": "scaffold",
                     "success": False,
+                    "dry_run": dry_run,
                     "error": "--root requires a path argument",
                 }))
             else:
@@ -1165,6 +1148,7 @@ def main() -> None:
             print(to_json_output({
                 "tool": "scaffold",
                 "success": False,
+                "dry_run": dry_run,
                 "error": "Insufficient arguments",
             }))
         else:
@@ -1182,12 +1166,13 @@ def main() -> None:
                     "tool": "scaffold",
                     "component": "skill",
                     "success": False,
+                    "dry_run": dry_run,
                     "error": "Missing skill name",
                 }))
             else:
                 print("Usage: python scripts/scaffold.py skill <name> [--router] [--root <path>] [--with-references] [--with-scripts] [--with-assets] [--update-manifest] [--dry-run] [--json]")
             sys.exit(1)
-        _validate_flags(flags, "skill", json_mode=json_output)
+        _validate_flags(flags, "skill", json_mode=json_output, dry_run=dry_run)
         name = positional[0]
         router = "--router" in flags
         optional_dirs = _parse_optional_dirs(flags)
@@ -1205,6 +1190,7 @@ def main() -> None:
                     "component": "skill",
                     "name": name,
                     "success": False,
+                    "dry_run": dry_run,
                     "error": f"{exc.__class__.__name__}: {exc}",
                 }))
                 sys.exit(1)
@@ -1222,12 +1208,13 @@ def main() -> None:
                     "tool": "scaffold",
                     "component": "capability",
                     "success": False,
+                    "dry_run": dry_run,
                     "error": "Missing domain or capability name",
                 }))
             else:
                 print("Usage: python scripts/scaffold.py capability <domain> <name> [--root <path>] [--with-references] [--update-manifest] [--dry-run] [--json]")
             sys.exit(1)
-        _validate_flags(flags, "capability", json_mode=json_output)
+        _validate_flags(flags, "capability", json_mode=json_output, dry_run=dry_run)
         optional_dirs = _parse_optional_dirs(flags)
         try:
             result = scaffold_capability(
@@ -1244,6 +1231,7 @@ def main() -> None:
                     "name": positional[1],
                     "domain": positional[0],
                     "success": False,
+                    "dry_run": dry_run,
                     "error": f"{exc.__class__.__name__}: {exc}",
                 }))
                 sys.exit(1)
@@ -1261,12 +1249,13 @@ def main() -> None:
                     "tool": "scaffold",
                     "component": "role",
                     "success": False,
+                    "dry_run": dry_run,
                     "error": "Missing group or role name",
                 }))
             else:
                 print("Usage: python scripts/scaffold.py role <group> <name> [--root <path>] [--update-manifest] [--dry-run] [--json]")
             sys.exit(1)
-        _validate_flags(flags, "role", json_mode=json_output)
+        _validate_flags(flags, "role", json_mode=json_output, dry_run=dry_run)
         try:
             result = scaffold_role(
                 positional[0], positional[1], root,
@@ -1282,6 +1271,7 @@ def main() -> None:
                     "name": positional[1],
                     "group": positional[0],
                     "success": False,
+                    "dry_run": dry_run,
                     "error": f"{exc.__class__.__name__}: {exc}",
                 }))
                 sys.exit(1)
@@ -1295,6 +1285,7 @@ def main() -> None:
             print(to_json_output({
                 "tool": "scaffold",
                 "success": False,
+                "dry_run": dry_run,
                 "error": f"Unknown component type: {component}",
             }))
         else:

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -464,6 +464,21 @@ def scaffold_skill(
     # directories, and their .gitkeep sentinel files. Exposed as the
     # ``"created"`` list in JSON output.
     created_paths: list[str] = []
+
+    # Load the template before recording planned directories. A missing
+    # template is a pre-write failure, so the dry-run plan must not
+    # advertise directories for a command that cannot proceed — recording
+    # after this keeps the human preview and JSON ``planned`` set
+    # consistent on the failure path.
+    template_name = TEMPLATE_SKILL_ROUTER if router else TEMPLATE_SKILL_STANDALONE
+    try:
+        template = read_template(template_name)
+    except FileNotFoundError as e:
+        if json_output:
+            return _scaffold_error("skill", str(e), dry_run=dry_run, name=name)
+        print(f"{LEVEL_FAIL}: {e}")
+        sys.exit(1)
+
     blocking = _record_planned_dirs(
         skill_path, created_paths, quiet=json_output, dry_run=dry_run,
     )
@@ -476,67 +491,36 @@ def scaffold_skill(
         print(f"{LEVEL_FAIL}: {_blocking_dir_error(blocking)}")
         sys.exit(1)
 
+    title = name.replace("-", " ").title()
     if router:
-        try:
-            template = read_template(TEMPLATE_SKILL_ROUTER)
-        except FileNotFoundError as e:
-            if json_output:
-                return _scaffold_error(
-                    "skill", str(e), dry_run=dry_run, name=name,
-                )
-            print(f"{LEVEL_FAIL}: {e}")
-            sys.exit(1)
-        # Replace placeholders
-        title = name.replace("-", " ").title()
         content = template.replace(PH_DOMAIN_NAME, name).replace(
             PH_DOMAIN_TITLE, title
         )
-        write_file(
-            os.path.join(skill_path, FILE_SKILL_MD), content,
-            quiet=json_output, dry_run=dry_run,
+    else:
+        content = template.replace(PH_SKILL_NAME, name).replace(
+            PH_SKILL_TITLE, title
         )
-        created_paths.append(os.path.join(skill_path, FILE_SKILL_MD))
+    write_file(
+        os.path.join(skill_path, FILE_SKILL_MD), content,
+        quiet=json_output, dry_run=dry_run,
+    )
+    created_paths.append(os.path.join(skill_path, FILE_SKILL_MD))
+    if router:
         caps_dir = os.path.join(skill_path, DIR_CAPABILITIES)
         gitkeep = create_dir_with_gitkeep(caps_dir, dry_run=dry_run)
         created_paths.append(caps_dir)
         created_paths.append(gitkeep)
         if not json_output:
             _print_dir_created(caps_dir, gitkeep, dry_run=dry_run)
-        for d in optional_dirs:
-            opt_dir = os.path.join(skill_path, d)
-            gitkeep = create_dir_with_gitkeep(opt_dir, dry_run=dry_run)
-            created_paths.append(opt_dir)
-            created_paths.append(gitkeep)
-            if not json_output:
-                _print_dir_created(opt_dir, gitkeep, dry_run=dry_run)
+    for d in optional_dirs:
+        opt_dir = os.path.join(skill_path, d)
+        gitkeep = create_dir_with_gitkeep(opt_dir, dry_run=dry_run)
+        created_paths.append(opt_dir)
+        created_paths.append(gitkeep)
         if not json_output:
-            print(f"  Note: Add shared/ when 2+ capabilities exist (see directory-structure.md)")
-    else:
-        try:
-            template = read_template(TEMPLATE_SKILL_STANDALONE)
-        except FileNotFoundError as e:
-            if json_output:
-                return _scaffold_error(
-                    "skill", str(e), dry_run=dry_run, name=name,
-                )
-            print(f"{LEVEL_FAIL}: {e}")
-            sys.exit(1)
-        title = name.replace("-", " ").title()
-        content = template.replace(PH_SKILL_NAME, name).replace(
-            PH_SKILL_TITLE, title
-        )
-        write_file(
-            os.path.join(skill_path, FILE_SKILL_MD), content,
-            quiet=json_output, dry_run=dry_run,
-        )
-        created_paths.append(os.path.join(skill_path, FILE_SKILL_MD))
-        for d in optional_dirs:
-            opt_dir = os.path.join(skill_path, d)
-            gitkeep = create_dir_with_gitkeep(opt_dir, dry_run=dry_run)
-            created_paths.append(opt_dir)
-            created_paths.append(gitkeep)
-            if not json_output:
-                _print_dir_created(opt_dir, gitkeep, dry_run=dry_run)
+            _print_dir_created(opt_dir, gitkeep, dry_run=dry_run)
+    if router and not json_output:
+        print(f"  Note: Add shared/ when 2+ capabilities exist (see directory-structure.md)")
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
@@ -723,6 +707,22 @@ def scaffold_capability(
     # ancestors it needs, content files (e.g. capability.md), optional
     # directories, and their .gitkeep files.
     created_paths: list[str] = []
+
+    # Load the template before recording planned directories so a missing
+    # template (a pre-write failure) does not advertise directories the
+    # command cannot create — keeps human and JSON output consistent on
+    # the failure path.
+    try:
+        template = read_template(TEMPLATE_CAPABILITY)
+    except FileNotFoundError as e:
+        if json_output:
+            return _scaffold_error(
+                "capability", str(e),
+                dry_run=dry_run, name=name, domain=domain,
+            )
+        print(f"{LEVEL_FAIL}: {e}")
+        sys.exit(1)
+
     blocking = _record_planned_dirs(
         cap_path, created_paths, quiet=json_output, dry_run=dry_run,
     )
@@ -735,16 +735,6 @@ def scaffold_capability(
         print(f"{LEVEL_FAIL}: {_blocking_dir_error(blocking)}")
         sys.exit(1)
 
-    try:
-        template = read_template(TEMPLATE_CAPABILITY)
-    except FileNotFoundError as e:
-        if json_output:
-            return _scaffold_error(
-                "capability", str(e),
-                dry_run=dry_run, name=name, domain=domain,
-            )
-        print(f"{LEVEL_FAIL}: {e}")
-        sys.exit(1)
     title = name.replace("-", " ").title()
     content = template.replace(PH_CAPABILITY_NAME, name).replace(
         PH_CAPABILITY_TITLE, title
@@ -890,6 +880,21 @@ def scaffold_role(
     # any ancestors it needs, plus the role file and group/top-level
     # READMEs.
     created_paths: list[str] = []
+
+    # Load the template before recording planned directories so a missing
+    # template (a pre-write failure) does not advertise directories the
+    # command cannot create — keeps human and JSON output consistent on
+    # the failure path.
+    try:
+        template = read_template(TEMPLATE_ROLE)
+    except FileNotFoundError as e:
+        if json_output:
+            return _scaffold_error(
+                "role", str(e), dry_run=dry_run, name=name, group=group,
+            )
+        print(f"{LEVEL_FAIL}: {e}")
+        sys.exit(1)
+
     blocking = _record_planned_dirs(
         os.path.dirname(role_path), created_paths,
         quiet=json_output, dry_run=dry_run,
@@ -903,15 +908,6 @@ def scaffold_role(
         print(f"{LEVEL_FAIL}: {_blocking_dir_error(blocking)}")
         sys.exit(1)
 
-    try:
-        template = read_template(TEMPLATE_ROLE)
-    except FileNotFoundError as e:
-        if json_output:
-            return _scaffold_error(
-                "role", str(e), dry_run=dry_run, name=name, group=group,
-            )
-        print(f"{LEVEL_FAIL}: {e}")
-        sys.exit(1)
     title = name.replace("-", " ").title()
     content = template.replace(PH_ROLE_TITLE, title)
     write_file(role_path, content, quiet=json_output, dry_run=dry_run)

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -3,9 +3,9 @@
 Scaffold new skill system components from templates.
 
 Usage:
-    python scripts/scaffold.py skill <name> [--router] [--root <path>] [--with-references] [--with-scripts] [--with-assets] [--update-manifest] [--json]
-    python scripts/scaffold.py capability <domain> <name> [--root <path>] [--with-references] [--update-manifest] [--json]
-    python scripts/scaffold.py role <group> <name> [--root <path>] [--update-manifest] [--json]
+    python scripts/scaffold.py skill <name> [--router] [--root <path>] [--with-references] [--with-scripts] [--with-assets] [--update-manifest] [--dry-run] [--json]
+    python scripts/scaffold.py capability <domain> <name> [--root <path>] [--with-references] [--update-manifest] [--dry-run] [--json]
+    python scripts/scaffold.py role <group> <name> [--root <path>] [--update-manifest] [--dry-run] [--json]
 
 Options:
     --root <path>        Base directory for output (default: current working
@@ -19,6 +19,9 @@ Options:
                          to the parent skill's capabilities list, not directly
                          to manifest.yaml). Creates a minimal manifest if none
                          exists. Detects name conflicts and warns without overwriting.
+    --dry-run            Preview what would be created without writing anything to
+                         disk. No files or directories are created and no manifest
+                         is modified; planned paths are reported instead.
     --json               Output results as machine-readable JSON.
 
 Examples:
@@ -27,6 +30,7 @@ Examples:
     python scripts/scaffold.py skill my-skill --with-references --with-scripts
     python scripts/scaffold.py skill my-domain --router
     python scripts/scaffold.py skill my-skill --update-manifest
+    python scripts/scaffold.py skill my-skill --dry-run
     python scripts/scaffold.py capability my-domain my-capability
     python scripts/scaffold.py role my-group my-role
     python scripts/scaffold.py skill my-skill --json
@@ -41,6 +45,7 @@ if _scripts_dir not in sys.path:
 
 from lib.frontmatter import load_frontmatter
 from lib.reporting import to_json_output, to_posix
+from lib.dry_run import planned_line
 from lib.validation import validate_name as _validate_name_detailed
 from lib.manifest import (
     update_manifest_for_skill,
@@ -167,6 +172,21 @@ def _collect_frontmatter_findings(path: str) -> list[str]:
     return findings
 
 
+def _print_created(path: str, *, dry_run: bool) -> None:
+    """Print the human-mode created/planned line for a directory *path*.
+
+    Mirrors ``write_file``'s own line for the file case: a real run
+    prints ``Created: <path>`` while a dry run prints
+    ``Would create: <path>``.  Centralises the verb switch so the three
+    scaffold functions stay free of dry-run branching at each
+    directory-creation site.
+    """
+    if dry_run:
+        print(planned_line(path))
+    else:
+        print(f"  Created: {to_posix(path)}")
+
+
 def read_template(template_name: str) -> str:
     """Read a template file from assets/."""
     template_path = os.path.join(ASSETS_DIR, template_name)
@@ -176,7 +196,9 @@ def read_template(template_name: str) -> str:
         return f.read()
 
 
-def write_file(path: str, content: str, *, quiet: bool = False) -> None:
+def write_file(
+    path: str, content: str, *, quiet: bool = False, dry_run: bool = False
+) -> None:
     """Write content to a file, creating directories as needed.
 
     The human-mode "Created:" line normalises *path* through
@@ -188,7 +210,15 @@ def write_file(path: str, content: str, *, quiet: bool = False) -> None:
     normalisation the line would render with backslashes on
     Windows and forward slashes on POSIX, diverging from
     ``validate_skill.py`` / ``bundle.py`` / ``stats.py``.
+
+    When *dry_run* is True, nothing is written to disk; the path is
+    reported as a planned action ("Would create: <path>") instead, so
+    the caller can preview the scaffold without side effects.
     """
+    if dry_run:
+        if not quiet:
+            print(planned_line(path))
+        return
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w", encoding="utf-8", newline="\n") as f:
         f.write(content)
@@ -196,15 +226,23 @@ def write_file(path: str, content: str, *, quiet: bool = False) -> None:
         print(f"  Created: {to_posix(path)}")
 
 
-def create_dir_with_gitkeep(path: str) -> str:
+def create_dir_with_gitkeep(path: str, *, dry_run: bool = False) -> str:
     """Create directory with .gitkeep so it tracks in git.
+
+    When *dry_run* is True, nothing is written to disk; the directory
+    and its ``.gitkeep`` are recorded as planned actions only.  The
+    return value (the ``.gitkeep`` path) is identical in both modes so
+    callers can accumulate the same planned-path list they would
+    accumulate for a real run.
 
     Returns:
         The path to the ``.gitkeep`` file (relative or absolute,
         matching the input *path*).
     """
-    os.makedirs(path, exist_ok=True)
     gitkeep = os.path.join(path, FILE_GITKEEP)
+    if dry_run:
+        return gitkeep
+    os.makedirs(path, exist_ok=True)
     if not os.path.exists(gitkeep):
         with open(gitkeep, "w", encoding="utf-8", newline="\n") as f:
             pass
@@ -218,6 +256,7 @@ def scaffold_skill(
     optional_dirs: list[str] | None = None,
     json_output: bool = False,
     update_manifest: bool = False,
+    dry_run: bool = False,
 ) -> dict | None:
     """Create a new skill directory.
 
@@ -231,6 +270,10 @@ def scaffold_skill(
             result dict instead.
         update_manifest: If True, validate and update manifest.yaml
             after scaffolding.
+        dry_run: If True, write nothing to disk. The same set of paths a
+            real run would create is reported as planned actions, the
+            manifest is left untouched, and the post-write frontmatter
+            re-parse is skipped (there is no file on disk to re-parse).
 
     Returns:
         A result dict when *json_output* is True, otherwise None.
@@ -286,21 +329,24 @@ def scaffold_skill(
         content = template.replace(PH_DOMAIN_NAME, name).replace(
             PH_DOMAIN_TITLE, title
         )
-        write_file(os.path.join(skill_path, FILE_SKILL_MD), content, quiet=json_output)
+        write_file(
+            os.path.join(skill_path, FILE_SKILL_MD), content,
+            quiet=json_output, dry_run=dry_run,
+        )
         created_paths.append(os.path.join(skill_path, FILE_SKILL_MD))
         caps_dir = os.path.join(skill_path, DIR_CAPABILITIES)
-        gitkeep = create_dir_with_gitkeep(caps_dir)
+        gitkeep = create_dir_with_gitkeep(caps_dir, dry_run=dry_run)
         created_paths.append(caps_dir)
         created_paths.append(gitkeep)
         if not json_output:
-            print(f"  Created: {to_posix(caps_dir)}")
+            _print_created(caps_dir, dry_run=dry_run)
         for d in optional_dirs:
             opt_dir = os.path.join(skill_path, d)
-            gitkeep = create_dir_with_gitkeep(opt_dir)
+            gitkeep = create_dir_with_gitkeep(opt_dir, dry_run=dry_run)
             created_paths.append(opt_dir)
             created_paths.append(gitkeep)
             if not json_output:
-                print(f"  Created: {to_posix(opt_dir)}")
+                _print_created(opt_dir, dry_run=dry_run)
         if not json_output:
             print(f"  Note: Add shared/ when 2+ capabilities exist (see directory-structure.md)")
     else:
@@ -321,25 +367,33 @@ def scaffold_skill(
         content = template.replace(PH_SKILL_NAME, name).replace(
             PH_SKILL_TITLE, title
         )
-        write_file(os.path.join(skill_path, FILE_SKILL_MD), content, quiet=json_output)
+        write_file(
+            os.path.join(skill_path, FILE_SKILL_MD), content,
+            quiet=json_output, dry_run=dry_run,
+        )
         created_paths.append(os.path.join(skill_path, FILE_SKILL_MD))
         for d in optional_dirs:
             opt_dir = os.path.join(skill_path, d)
-            gitkeep = create_dir_with_gitkeep(opt_dir)
+            gitkeep = create_dir_with_gitkeep(opt_dir, dry_run=dry_run)
             created_paths.append(opt_dir)
             created_paths.append(gitkeep)
             if not json_output:
-                print(f"  Created: {to_posix(opt_dir)}")
+                _print_created(opt_dir, dry_run=dry_run)
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
     # --- Frontmatter re-parse of the written entry file ---
-    skill_md_full_path = os.path.join(skill_path, FILE_SKILL_MD)
-    frontmatter_findings = _collect_frontmatter_findings(skill_md_full_path)
-    frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
-    if frontmatter_findings and not json_output:
-        for f in frontmatter_findings:
-            print(f"  {f}")
+    # Skipped under dry-run: no file was written, so there is nothing to
+    # re-parse and no parse error can arise from this run.
+    frontmatter_findings: list[str] = []
+    frontmatter_parse_error = False
+    if not dry_run:
+        skill_md_full_path = os.path.join(skill_path, FILE_SKILL_MD)
+        frontmatter_findings = _collect_frontmatter_findings(skill_md_full_path)
+        frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
+        if frontmatter_findings and not json_output:
+            for f in frontmatter_findings:
+                print(f"  {f}")
 
     # --- Manifest update ---
     manifest_updated = False
@@ -347,7 +401,14 @@ def scaffold_skill(
     manifest_findings: list[str] = []
     manifest_emit_corrupted = False
 
-    if update_manifest:
+    if update_manifest and dry_run:
+        # Preview only: the manifest is never read or mutated. Report it
+        # as a planned path so the dry-run plan mirrors the real run's
+        # created set without touching disk.
+        created_paths.append(manifest_path)
+        if not json_output:
+            _print_created(manifest_path, dry_run=True)
+    elif update_manifest:
         (
             manifest_updated,
             manifest_warning,
@@ -373,13 +434,18 @@ def scaffold_skill(
     hard_failure = manifest_emit_corrupted or frontmatter_parse_error
 
     if json_output:
+        # In dry-run mode ``created`` reports the paths a real run would
+        # create — none exist on disk. ``dry_run`` lets consumers tell
+        # the two apart.
+        created_key = "planned" if dry_run else "created"
         result_dict: dict = {
             "tool": "scaffold",
             "component": "skill",
             "name": name,
             "success": not hard_failure,
+            "dry_run": dry_run,
             "path": to_posix(os.path.abspath(skill_path)),
-            "created": [to_posix(os.path.abspath(p)) for p in created_paths],
+            created_key: [to_posix(os.path.abspath(p)) for p in created_paths],
             "router": router,
         }
         # All plain-scalar divergence findings merge into a single
@@ -397,9 +463,12 @@ def scaffold_skill(
                 result_dict["manifest_warning"] = manifest_warning
         return result_dict
 
-    print(f"\n\u2713 Skill '{name}' scaffolded at {to_posix(skill_path)}")
+    verb = "would be scaffolded" if dry_run else "scaffolded"
+    print(f"\n\u2713 Skill '{name}' {verb} at {to_posix(skill_path)}")
     skill_md_path = os.path.join(skill_path, FILE_SKILL_MD)
-    if not update_manifest:
+    if dry_run:
+        print("  Dry run: no files were written.")
+    elif not update_manifest:
         print(
             f"  Next: edit {to_posix(skill_md_path)} and update "
             f"{to_posix(manifest_path)}"
@@ -418,6 +487,7 @@ def scaffold_capability(
     optional_dirs: list[str] | None = None,
     json_output: bool = False,
     update_manifest: bool = False,
+    dry_run: bool = False,
 ) -> dict | None:
     """Create a new capability under an existing router skill.
 
@@ -431,6 +501,9 @@ def scaffold_capability(
             result dict instead.
         update_manifest: If True, print a message that capabilities
             should be added to the parent skill's manifest entry.
+        dry_run: If True, write nothing to disk. The same set of paths a
+            real run would create is reported as planned actions and the
+            post-write frontmatter re-parse is skipped.
 
     Returns:
         A result dict when *json_output* is True, otherwise None.
@@ -512,25 +585,32 @@ def scaffold_capability(
     content = template.replace(PH_CAPABILITY_NAME, name).replace(
         PH_CAPABILITY_TITLE, title
     )
-    write_file(os.path.join(cap_path, FILE_CAPABILITY_MD), content, quiet=json_output)
+    write_file(
+        os.path.join(cap_path, FILE_CAPABILITY_MD), content,
+        quiet=json_output, dry_run=dry_run,
+    )
     created_paths.append(os.path.join(cap_path, FILE_CAPABILITY_MD))
     for d in optional_dirs:
         opt_dir = os.path.join(cap_path, d)
-        gitkeep = create_dir_with_gitkeep(opt_dir)
+        gitkeep = create_dir_with_gitkeep(opt_dir, dry_run=dry_run)
         created_paths.append(opt_dir)
         created_paths.append(gitkeep)
         if not json_output:
-            print(f"  Created: {to_posix(opt_dir)}")
+            _print_created(opt_dir, dry_run=dry_run)
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
     # --- Frontmatter re-parse of the written entry file ---
-    cap_md_full_path = os.path.join(cap_path, FILE_CAPABILITY_MD)
-    frontmatter_findings = _collect_frontmatter_findings(cap_md_full_path)
-    frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
-    if frontmatter_findings and not json_output:
-        for f in frontmatter_findings:
-            print(f"  {f}")
+    # Skipped under dry-run: no file was written to re-parse.
+    frontmatter_findings: list[str] = []
+    frontmatter_parse_error = False
+    if not dry_run:
+        cap_md_full_path = os.path.join(cap_path, FILE_CAPABILITY_MD)
+        frontmatter_findings = _collect_frontmatter_findings(cap_md_full_path)
+        frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
+        if frontmatter_findings and not json_output:
+            for f in frontmatter_findings:
+                print(f"  {f}")
 
     # Capabilities are not added to the manifest directly — they
     # belong under their parent skill's ``capabilities:`` list.
@@ -541,14 +621,19 @@ def scaffold_capability(
     )
 
     if json_output:
+        # In dry-run mode the path list reports what a real run would
+        # create \u2014 none exist on disk. ``dry_run`` lets consumers tell
+        # the two apart.
+        created_key = "planned" if dry_run else "created"
         result_dict: dict = {
             "tool": "scaffold",
             "component": "capability",
             "name": name,
             "domain": domain,
             "success": not frontmatter_parse_error,
+            "dry_run": dry_run,
             "path": to_posix(os.path.abspath(cap_path)),
-            "created": [to_posix(os.path.abspath(p)) for p in created_paths],
+            created_key: [to_posix(os.path.abspath(p)) for p in created_paths],
         }
         if frontmatter_findings:
             result_dict["warnings"] = list(frontmatter_findings)
@@ -557,16 +642,20 @@ def scaffold_capability(
             result_dict["manifest_warning"] = cap_manifest_msg
         return result_dict
 
-    print(f"\n\u2713 Capability '{name}' scaffolded at {to_posix(cap_path)}")
+    verb = "would be scaffolded" if dry_run else "scaffolded"
+    print(f"\n\u2713 Capability '{name}' {verb} at {to_posix(cap_path)}")
     cap_md_path = os.path.join(cap_path, FILE_CAPABILITY_MD)
-    print(f"  Next: edit {to_posix(cap_md_path)}")
-    print(
-        f"  Next: add capability to {to_posix(router_skill)} routing table"
-    )
-    if update_manifest:
-        print(f"  {LEVEL_INFO}: {cap_manifest_msg}")
+    if dry_run:
+        print("  Dry run: no files were written.")
     else:
-        print(f"  Next: update {to_posix(manifest_path)}")
+        print(f"  Next: edit {to_posix(cap_md_path)}")
+        print(
+            f"  Next: add capability to {to_posix(router_skill)} routing table"
+        )
+        if update_manifest:
+            print(f"  {LEVEL_INFO}: {cap_manifest_msg}")
+        else:
+            print(f"  Next: update {to_posix(manifest_path)}")
     if frontmatter_parse_error:
         sys.exit(1)
     return None
@@ -578,6 +667,7 @@ def scaffold_role(
     root: str = "",
     json_output: bool = False,
     update_manifest: bool = False,
+    dry_run: bool = False,
 ) -> dict | None:
     """Create a new role file.
 
@@ -589,6 +679,11 @@ def scaffold_role(
             result dict instead.
         update_manifest: If True, validate and update manifest.yaml
             after scaffolding.
+        dry_run: If True, write nothing to disk. The same set of paths a
+            real run would create — the role file and any not-yet-present
+            README files — is reported as planned actions, the manifest
+            is left untouched, and the post-write frontmatter re-parse is
+            skipped.
 
     Returns:
         A result dict when *json_output* is True, otherwise None.
@@ -651,10 +746,12 @@ def scaffold_role(
         sys.exit(1)
     title = name.replace("-", " ").title()
     content = template.replace(PH_ROLE_TITLE, title)
-    write_file(role_path, content, quiet=json_output)
+    write_file(role_path, content, quiet=json_output, dry_run=dry_run)
     created_paths.append(role_path)
 
-    # Create top-level roles README if it doesn't exist
+    # Create top-level roles README if it doesn't exist. Under dry-run
+    # nothing is written, so os.path.exists reflects the true on-disk
+    # state and the planned set matches what a real run would create.
     roles_readme = os.path.join(root, DIR_ROLES, FILE_README) if root else os.path.join(DIR_ROLES, FILE_README)
     if not os.path.exists(roles_readme):
         write_file(
@@ -662,6 +759,7 @@ def scaffold_role(
             "# Roles\n\nOrchestration patterns that compose skills into workflows.\n\n"
             "See subdirectories for role groups.\n",
             quiet=json_output,
+            dry_run=dry_run,
         )
         created_paths.append(roles_readme)
 
@@ -672,17 +770,22 @@ def scaffold_role(
             readme_path,
             f"# {group.replace('-', ' ').title()}\n\nRoles:\n- {name}\n",
             quiet=json_output,
+            dry_run=dry_run,
         )
         created_paths.append(readme_path)
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
     # --- Frontmatter re-parse of the written role file ---
-    frontmatter_findings = _collect_frontmatter_findings(role_path)
-    frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
-    if frontmatter_findings and not json_output:
-        for f in frontmatter_findings:
-            print(f"  {f}")
+    # Skipped under dry-run: no file was written to re-parse.
+    frontmatter_findings: list[str] = []
+    frontmatter_parse_error = False
+    if not dry_run:
+        frontmatter_findings = _collect_frontmatter_findings(role_path)
+        frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
+        if frontmatter_findings and not json_output:
+            for f in frontmatter_findings:
+                print(f"  {f}")
 
     # --- Manifest update ---
     manifest_updated = False
@@ -690,7 +793,13 @@ def scaffold_role(
     manifest_findings: list[str] = []
     manifest_emit_corrupted = False
 
-    if update_manifest:
+    if update_manifest and dry_run:
+        # Preview only: the manifest is never read or mutated. Report it
+        # as a planned path so the dry-run plan mirrors the real run.
+        created_paths.append(manifest_path)
+        if not json_output:
+            _print_created(manifest_path, dry_run=True)
+    elif update_manifest:
         (
             manifest_updated,
             manifest_warning,
@@ -716,14 +825,19 @@ def scaffold_role(
     hard_failure = manifest_emit_corrupted or frontmatter_parse_error
 
     if json_output:
+        # In dry-run mode the path list reports what a real run would
+        # create \u2014 none exist on disk. ``dry_run`` lets consumers tell
+        # the two apart.
+        created_key = "planned" if dry_run else "created"
         result_dict: dict = {
             "tool": "scaffold",
             "component": "role",
             "name": name,
             "group": group,
             "success": not hard_failure,
+            "dry_run": dry_run,
             "path": to_posix(os.path.abspath(role_path)),
-            "created": [to_posix(os.path.abspath(p)) for p in created_paths],
+            created_key: [to_posix(os.path.abspath(p)) for p in created_paths],
         }
         combined_warnings = _dedupe_preserving_order(
             list(frontmatter_findings) + list(manifest_findings)
@@ -736,10 +850,14 @@ def scaffold_role(
                 result_dict["manifest_warning"] = manifest_warning
         return result_dict
 
-    print(f"\n\u2713 Role '{name}' scaffolded at {to_posix(role_path)}")
-    print(f"  Next: edit {to_posix(role_path)}")
-    if not update_manifest:
-        print(f"  Next: update {to_posix(manifest_path)}")
+    verb = "would be scaffolded" if dry_run else "scaffolded"
+    print(f"\n\u2713 Role '{name}' {verb} at {to_posix(role_path)}")
+    if dry_run:
+        print("  Dry run: no files were written.")
+    else:
+        print(f"  Next: edit {to_posix(role_path)}")
+        if not update_manifest:
+            print(f"  Next: update {to_posix(manifest_path)}")
     if hard_failure:
         sys.exit(1)
     return None
@@ -816,6 +934,13 @@ def main() -> None:
     if update_manifest:
         args = [a for a in args if a != "--update-manifest"]
 
+    # Parse --dry-run flag. Stripped before component dispatch (like
+    # --json / --update-manifest) so it applies to every component
+    # without entering the per-component _KNOWN_FLAGS validation.
+    dry_run = "--dry-run" in args
+    if dry_run:
+        args = [a for a in args if a != "--dry-run"]
+
     # Parse --root option
     root = ""
     if "--root" in args:
@@ -858,7 +983,7 @@ def main() -> None:
                     "error": "Missing skill name",
                 }))
             else:
-                print("Usage: python scripts/scaffold.py skill <name> [--router] [--root <path>] [--with-references] [--with-scripts] [--with-assets] [--update-manifest] [--json]")
+                print("Usage: python scripts/scaffold.py skill <name> [--router] [--root <path>] [--with-references] [--with-scripts] [--with-assets] [--update-manifest] [--dry-run] [--json]")
             sys.exit(1)
         _validate_flags(flags, "skill", json_mode=json_output)
         name = positional[0]
@@ -869,6 +994,7 @@ def main() -> None:
                 name, router, root, optional_dirs,
                 json_output=json_output,
                 update_manifest=update_manifest,
+                dry_run=dry_run,
             )
         except Exception as exc:
             if json_output:
@@ -897,7 +1023,7 @@ def main() -> None:
                     "error": "Missing domain or capability name",
                 }))
             else:
-                print("Usage: python scripts/scaffold.py capability <domain> <name> [--root <path>] [--with-references] [--update-manifest] [--json]")
+                print("Usage: python scripts/scaffold.py capability <domain> <name> [--root <path>] [--with-references] [--update-manifest] [--dry-run] [--json]")
             sys.exit(1)
         _validate_flags(flags, "capability", json_mode=json_output)
         optional_dirs = _parse_optional_dirs(flags)
@@ -906,6 +1032,7 @@ def main() -> None:
                 positional[0], positional[1], root, optional_dirs,
                 json_output=json_output,
                 update_manifest=update_manifest,
+                dry_run=dry_run,
             )
         except Exception as exc:
             if json_output:
@@ -935,7 +1062,7 @@ def main() -> None:
                     "error": "Missing group or role name",
                 }))
             else:
-                print("Usage: python scripts/scaffold.py role <group> <name> [--root <path>] [--update-manifest] [--json]")
+                print("Usage: python scripts/scaffold.py role <group> <name> [--root <path>] [--update-manifest] [--dry-run] [--json]")
             sys.exit(1)
         _validate_flags(flags, "role", json_mode=json_output)
         try:
@@ -943,6 +1070,7 @@ def main() -> None:
                 positional[0], positional[1], root,
                 json_output=json_output,
                 update_manifest=update_manifest,
+                dry_run=dry_run,
             )
         except Exception as exc:
             if json_output:

--- a/skill-system-foundry/scripts/scaffold.py
+++ b/skill-system-foundry/scripts/scaffold.py
@@ -43,7 +43,7 @@ _scripts_dir = os.path.dirname(os.path.abspath(__file__))
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
 
-from lib.frontmatter import load_frontmatter
+from lib.frontmatter import load_frontmatter, parse_frontmatter
 from lib.reporting import to_json_output, to_posix
 from lib.dry_run import planned_line, planned_update_line
 from lib.validation import validate_name as _validate_name_detailed
@@ -145,20 +145,30 @@ def _has_frontmatter_parse_error(findings: list[str]) -> bool:
     return any(f.startswith(marker) for f in findings)
 
 
-def _collect_frontmatter_findings(path: str) -> list[str]:
-    """Return frontmatter findings from the written entry file.
+def _collect_frontmatter_findings(
+    path: str, content: str | None = None
+) -> list[str]:
+    """Return frontmatter findings for the entry file.
 
     Re-parses the rendered frontmatter so post-write divergences surface
     even when they would otherwise bypass validate_name's gate (template
-    changes, programmatic callers, etc.).  Missing files and files
-    without frontmatter yield an empty list.  Frontmatter structural
-    parse failures are surfaced as a FAIL finding tagged with
-    ``_FRONTMATTER_PARSE_ERROR_MARKER`` so callers can promote them to
-    a hard failure via :func:`_has_frontmatter_parse_error`.
+    changes, programmatic callers, etc.).  When *content* is given the
+    rendered text is validated in memory — scaffold's ``--dry-run`` uses
+    this so its preview reports the same frontmatter findings a real run
+    would, without writing anything; *path* then only labels a
+    parse-error finding.  Without *content* the file at *path* is read
+    (real run); a missing file or a file without frontmatter yields an
+    empty list.  Frontmatter structural parse failures are surfaced as a
+    FAIL finding tagged with ``_FRONTMATTER_PARSE_ERROR_MARKER`` so
+    callers can promote them to a hard failure via
+    :func:`_has_frontmatter_parse_error`.
     """
-    if not os.path.isfile(path):
-        return []
-    frontmatter, _body, findings = load_frontmatter(path)
+    if content is not None:
+        frontmatter, _body, findings = parse_frontmatter(content)
+    else:
+        if not os.path.isfile(path):
+            return []
+        frontmatter, _body, findings = load_frontmatter(path)
     parse_error = (
         frontmatter.get("_parse_error")
         if isinstance(frontmatter, dict)
@@ -385,9 +395,11 @@ def scaffold_skill(
         update_manifest: If True, validate and update manifest.yaml
             after scaffolding.
         dry_run: If True, write nothing to disk. The same set of paths a
-            real run would create is reported as planned actions, the
-            manifest is left untouched, and the post-write frontmatter
-            re-parse is skipped (there is no file on disk to re-parse).
+            real run would create is reported as planned actions; the
+            manifest may be read to preview a conflict or parse error but
+            is never written; and the rendered frontmatter is validated
+            in memory so the preview reports the same findings and
+            success/exit status a real run would.
 
     Returns:
         A result dict when *json_output* is True, otherwise None.
@@ -511,18 +523,19 @@ def scaffold_skill(
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
-    # --- Frontmatter re-parse of the written entry file ---
-    # Skipped under dry-run: no file was written, so there is nothing to
-    # re-parse and no parse error can arise from this run.
-    frontmatter_findings: list[str] = []
-    frontmatter_parse_error = False
-    if not dry_run:
-        skill_md_full_path = os.path.join(skill_path, FILE_SKILL_MD)
-        frontmatter_findings = _collect_frontmatter_findings(skill_md_full_path)
-        frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
-        if frontmatter_findings and not json_output:
-            for f in frontmatter_findings:
-                print(f"  {f}")
+    # --- Frontmatter validation of the rendered entry file ---
+    # Validated in both modes: a real run re-parses the written file; a
+    # dry run validates the rendered content in memory, so the preview
+    # reports the same findings and success/exit status a real run would
+    # without writing anything.
+    skill_md_full_path = os.path.join(skill_path, FILE_SKILL_MD)
+    frontmatter_findings = _collect_frontmatter_findings(
+        skill_md_full_path, content=content if dry_run else None,
+    )
+    frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
+    if frontmatter_findings and not json_output:
+        for f in frontmatter_findings:
+            print(f"  {f}")
 
     # --- Manifest update ---
     manifest_updated = False
@@ -641,7 +654,9 @@ def scaffold_capability(
             should be added to the parent skill's manifest entry.
         dry_run: If True, write nothing to disk. The same set of paths a
             real run would create is reported as planned actions and the
-            post-write frontmatter re-parse is skipped.
+            rendered frontmatter is validated in memory so the preview
+            reports the same findings and success/exit status a real run
+            would.
 
     Returns:
         A result dict when *json_output* is True, otherwise None.
@@ -754,17 +769,17 @@ def scaffold_capability(
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
-    # --- Frontmatter re-parse of the written entry file ---
-    # Skipped under dry-run: no file was written to re-parse.
-    frontmatter_findings: list[str] = []
-    frontmatter_parse_error = False
-    if not dry_run:
-        cap_md_full_path = os.path.join(cap_path, FILE_CAPABILITY_MD)
-        frontmatter_findings = _collect_frontmatter_findings(cap_md_full_path)
-        frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
-        if frontmatter_findings and not json_output:
-            for f in frontmatter_findings:
-                print(f"  {f}")
+    # --- Frontmatter validation of the rendered entry file ---
+    # Validated in both modes (in memory under dry-run) so the preview
+    # reports the same findings and success/exit status a real run would.
+    cap_md_full_path = os.path.join(cap_path, FILE_CAPABILITY_MD)
+    frontmatter_findings = _collect_frontmatter_findings(
+        cap_md_full_path, content=content if dry_run else None,
+    )
+    frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
+    if frontmatter_findings and not json_output:
+        for f in frontmatter_findings:
+            print(f"  {f}")
 
     # Capabilities are not added to the manifest directly — they
     # belong under their parent skill's ``capabilities:`` list.
@@ -953,16 +968,16 @@ def scaffold_role(
 
     manifest_path = os.path.join(root, FILE_MANIFEST) if root else FILE_MANIFEST
 
-    # --- Frontmatter re-parse of the written role file ---
-    # Skipped under dry-run: no file was written to re-parse.
-    frontmatter_findings: list[str] = []
-    frontmatter_parse_error = False
-    if not dry_run:
-        frontmatter_findings = _collect_frontmatter_findings(role_path)
-        frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
-        if frontmatter_findings and not json_output:
-            for f in frontmatter_findings:
-                print(f"  {f}")
+    # --- Frontmatter validation of the rendered role file ---
+    # Validated in both modes (in memory under dry-run) so the preview
+    # reports the same findings and success/exit status a real run would.
+    frontmatter_findings = _collect_frontmatter_findings(
+        role_path, content=content if dry_run else None,
+    )
+    frontmatter_parse_error = _has_frontmatter_parse_error(frontmatter_findings)
+    if frontmatter_findings and not json_output:
+        for f in frontmatter_findings:
+            print(f"  {f}")
 
     # --- Manifest update ---
     manifest_updated = False

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,40 @@
+"""Tests for lib/dry_run.py — scaffold's dry-run formatting helpers."""
+
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "skill-system-foundry", "scripts")
+)
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.dry_run import DRY_RUN_VERB, planned_line
+
+
+# ===================================================================
+# planned_line()
+# ===================================================================
+
+
+class PlannedLineTests(unittest.TestCase):
+    """Tests for planned_line()."""
+
+    def test_uses_dry_run_verb(self) -> None:
+        """The line begins with the indented dry-run verb."""
+        line = planned_line("a/b/c.md")
+        self.assertEqual(line, f"  {DRY_RUN_VERB}: a/b/c.md")
+
+    def test_normalises_backslashes_to_posix(self) -> None:
+        """Windows-style separators are rewritten to forward slashes."""
+        line = planned_line("a\\b\\c.md")
+        self.assertEqual(line, f"  {DRY_RUN_VERB}: a/b/c.md")
+
+    def test_verb_is_would_create(self) -> None:
+        """The verb constant matches scaffold's documented wording."""
+        self.assertEqual(DRY_RUN_VERB, "Would create")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -10,7 +10,12 @@ SCRIPTS_DIR = os.path.abspath(
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
-from lib.dry_run import DRY_RUN_VERB, planned_line
+from lib.dry_run import (
+    DRY_RUN_VERB,
+    DRY_RUN_UPDATE_VERB,
+    planned_line,
+    planned_update_line,
+)
 
 
 # ===================================================================
@@ -34,6 +39,29 @@ class PlannedLineTests(unittest.TestCase):
     def test_verb_is_would_create(self) -> None:
         """The verb constant matches scaffold's documented wording."""
         self.assertEqual(DRY_RUN_VERB, "Would create")
+
+
+# ===================================================================
+# planned_update_line()
+# ===================================================================
+
+
+class PlannedUpdateLineTests(unittest.TestCase):
+    """Tests for planned_update_line()."""
+
+    def test_uses_update_verb(self) -> None:
+        """The line begins with the indented update verb."""
+        line = planned_update_line("a/b/manifest.yaml")
+        self.assertEqual(line, f"  {DRY_RUN_UPDATE_VERB}: a/b/manifest.yaml")
+
+    def test_normalises_backslashes_to_posix(self) -> None:
+        """Windows-style separators are rewritten to forward slashes."""
+        line = planned_update_line("a\\b\\manifest.yaml")
+        self.assertEqual(line, f"  {DRY_RUN_UPDATE_VERB}: a/b/manifest.yaml")
+
+    def test_verb_is_would_update(self) -> None:
+        """The update verb constant matches scaffold's documented wording."""
+        self.assertEqual(DRY_RUN_UPDATE_VERB, "Would update")
 
 
 if __name__ == "__main__":

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -17,7 +17,11 @@ SCRIPTS_DIR = os.path.abspath(
 if SCRIPTS_DIR not in sys.path:
     sys.path.insert(0, SCRIPTS_DIR)
 
-from lib.frontmatter import count_body_lines, load_frontmatter  # noqa: E402
+from lib.frontmatter import (  # noqa: E402
+    count_body_lines,
+    load_frontmatter,
+    parse_frontmatter,
+)
 
 
 def _write_bytes(content_bytes: bytes) -> str:
@@ -68,6 +72,43 @@ class LoadFrontmatterLineEndingsTests(unittest.TestCase):
     def test_body_contains_no_carriage_returns(self) -> None:
         _, body, _ = self._load_with_endings("\r\n")
         self.assertNotIn("\r", body)
+
+
+class ParseFrontmatterTests(unittest.TestCase):
+    """``parse_frontmatter`` validates in-memory content (no file read)."""
+
+    def test_valid_content_parses(self) -> None:
+        fm, body, findings = parse_frontmatter(
+            "---\nname: example\n---\nBody line\n"
+        )
+        self.assertEqual(fm, {"name": "example"})
+        self.assertEqual(body, "Body line")
+        self.assertEqual(findings, [])
+
+    def test_missing_closing_delimiter_is_parse_error(self) -> None:
+        fm, _body, _findings = parse_frontmatter("---\nname: example\n")
+        self.assertIsInstance(fm, dict)
+        self.assertIn("_parse_error", fm)
+
+    def test_no_frontmatter_returns_none(self) -> None:
+        fm, body, findings = parse_frontmatter("# Just a heading\n")
+        self.assertIsNone(fm)
+        self.assertEqual(body, "# Just a heading\n")
+        self.assertEqual(findings, [])
+
+    def test_crlf_normalized(self) -> None:
+        fm, body, _ = parse_frontmatter("---\r\nname: x\r\n---\r\nBody\r\n")
+        self.assertEqual(fm, {"name": "x"})
+        self.assertNotIn("\r", body)
+
+    def test_matches_load_frontmatter(self) -> None:
+        content = "---\nname: example\ndescription: text\n---\nBody\n"
+        path = _write_bytes(content.encode("utf-8"))
+        try:
+            from_file = load_frontmatter(path)
+        finally:
+            os.unlink(path)
+        self.assertEqual(parse_frontmatter(content), from_file)
 
 
 class CountBodyLinesTests(unittest.TestCase):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -23,6 +23,7 @@ from lib.manifest import (
     has_role_conflict,
     append_skill_entry,
     append_role_entry,
+    manifest_needs_scaffold,
     scaffold_empty_manifest,
     update_manifest_for_skill,
     update_manifest_for_role,
@@ -1145,6 +1146,43 @@ class UpdateManifestPreviewTests(unittest.TestCase):
             self.assertFalse(created)
             with open(path, "r", encoding="utf-8") as f:
                 self.assertEqual(f.read(), SAMPLE_MANIFEST)
+
+
+class ManifestNeedsScaffoldTests(unittest.TestCase):
+    """manifest_needs_scaffold matches its docstring for every path state."""
+
+    def test_absent_path_needs_scaffold(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            self.assertTrue(manifest_needs_scaffold(path))
+
+    def test_empty_file_needs_scaffold(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("")
+            self.assertTrue(manifest_needs_scaffold(path))
+
+    def test_whitespace_only_file_needs_scaffold(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("   \n\n")
+            self.assertTrue(manifest_needs_scaffold(path))
+
+    def test_nonempty_file_does_not_need_scaffold(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(SAMPLE_MANIFEST)
+            self.assertFalse(manifest_needs_scaffold(path))
+
+    def test_directory_does_not_need_scaffold(self) -> None:
+        """A non-regular-file path returns False: a real run can't seed it."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            os.mkdir(path)
+            self.assertFalse(manifest_needs_scaffold(path))
 
 
 class NonFileManifestPathTests(unittest.TestCase):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1060,6 +1060,93 @@ class UpdateManifestForRoleTests(unittest.TestCase):
             self.assertIn("roles:", text)
 
 
+class UpdateManifestPreviewTests(unittest.TestCase):
+    """preview=True reports the planned action without writing anything."""
+
+    def test_skill_preview_absent_manifest_plans_create(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            updated, warning, created, findings = update_manifest_for_skill(
+                path, "my-skill", preview=True,
+            )
+            self.assertTrue(updated)
+            self.assertIsNone(warning)
+            self.assertTrue(created)
+            self.assertEqual(findings, [])
+            # No write: the manifest is not created on disk.
+            self.assertFalse(os.path.exists(path))
+
+    def test_skill_preview_existing_manifest_plans_update(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(SAMPLE_MANIFEST)
+            updated, warning, created, _findings = update_manifest_for_skill(
+                path, "brand-new-skill", preview=True,
+            )
+            self.assertTrue(updated)
+            self.assertIsNone(warning)
+            self.assertFalse(created)
+            # No write: the existing manifest is left byte-for-byte intact.
+            with open(path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), SAMPLE_MANIFEST)
+
+    def test_skill_preview_conflict_reports_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(SAMPLE_MANIFEST)
+            updated, warning, created, _findings = update_manifest_for_skill(
+                path, "existing-skill", preview=True,
+            )
+            self.assertFalse(updated)
+            self.assertIsNotNone(warning)
+            self.assertIn("already exists", warning)
+            self.assertFalse(created)
+            with open(path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), SAMPLE_MANIFEST)
+
+    def test_skill_preview_malformed_reports_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("skills:\n  - item1\n  - item2\n")
+            updated, warning, created, _findings = update_manifest_for_skill(
+                path, "x", preview=True,
+            )
+            self.assertFalse(updated)
+            self.assertIsNotNone(warning)
+            self.assertIn("skipping manifest update", warning)
+            self.assertFalse(created)
+
+    def test_role_preview_absent_manifest_plans_create(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            updated, warning, created, findings = update_manifest_for_role(
+                path, "grp", "my-role", preview=True,
+            )
+            self.assertTrue(updated)
+            self.assertIsNone(warning)
+            self.assertTrue(created)
+            self.assertEqual(findings, [])
+            self.assertFalse(os.path.exists(path))
+
+    def test_role_preview_conflict_reports_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "manifest.yaml")
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(SAMPLE_MANIFEST)
+            updated, warning, created, _findings = update_manifest_for_role(
+                path, "dev-group", "existing-role", preview=True,
+            )
+            self.assertFalse(updated)
+            self.assertIsNotNone(warning)
+            self.assertIn("already exists", warning)
+            self.assertFalse(created)
+            with open(path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), SAMPLE_MANIFEST)
+
+
 class ReadManifestFindingsTests(unittest.TestCase):
     """``read_manifest`` threads divergence findings to the caller."""
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1147,6 +1147,60 @@ class UpdateManifestPreviewTests(unittest.TestCase):
                 self.assertEqual(f.read(), SAMPLE_MANIFEST)
 
 
+class NonFileManifestPathTests(unittest.TestCase):
+    """A non-file at manifest_path is a graceful skip, not a mid-write crash."""
+
+    @staticmethod
+    def _dir_at_manifest(tmpdir: str) -> str:
+        path = os.path.join(tmpdir, "manifest.yaml")
+        os.mkdir(path)
+        return path
+
+    def test_skill_real_run_skips_with_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._dir_at_manifest(tmpdir)
+            updated, warning, created, findings = update_manifest_for_skill(
+                path, "x",
+            )
+            self.assertFalse(updated)
+            self.assertIn("not a regular file", warning)
+            self.assertFalse(created)
+            self.assertEqual(findings, [])
+            self.assertTrue(os.path.isdir(path))  # left untouched
+
+    def test_skill_preview_skips_with_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._dir_at_manifest(tmpdir)
+            updated, warning, created, _findings = update_manifest_for_skill(
+                path, "x", preview=True,
+            )
+            self.assertFalse(updated)
+            self.assertIn("not a regular file", warning)
+            self.assertFalse(created)
+
+    def test_role_real_run_skips_with_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._dir_at_manifest(tmpdir)
+            updated, warning, created, findings = update_manifest_for_role(
+                path, "grp", "rl",
+            )
+            self.assertFalse(updated)
+            self.assertIn("not a regular file", warning)
+            self.assertFalse(created)
+            self.assertEqual(findings, [])
+            self.assertTrue(os.path.isdir(path))
+
+    def test_role_preview_skips_with_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._dir_at_manifest(tmpdir)
+            updated, warning, created, _findings = update_manifest_for_role(
+                path, "grp", "rl", preview=True,
+            )
+            self.assertFalse(updated)
+            self.assertIn("not a regular file", warning)
+            self.assertFalse(created)
+
+
 class ReadManifestFindingsTests(unittest.TestCase):
     """``read_manifest`` threads divergence findings to the caller."""
 

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3343,6 +3343,12 @@ class CliErrorSchemaTests(unittest.TestCase):
         self.assertTrue(data["dry_run"])
         self.assertIn("planned", data)
 
+    def test_unknown_flag_allowed_message_lists_dry_run(self) -> None:
+        """The 'Allowed:' diagnostic includes --dry-run as a valid flag."""
+        proc = _run(["skill", "demo", "--bogus"], cwd=REPO_ROOT)
+        self.assertEqual(proc.returncode, 1, msg=proc.stdout + proc.stderr)
+        self.assertIn("--dry-run", proc.stdout)
+
 
 class DryRunJsonShapeTests(unittest.TestCase):
     """JSON payload shape for --dry-run runs."""

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3027,6 +3027,53 @@ class DryRunHumanOutputTests(unittest.TestCase):
             self.assertIn("Would create:", output)
             self.assertNotIn("  Created:", output)
 
+    def test_router_dry_run_lists_gitkeep_in_human_output(self) -> None:
+        """Human dry-run output enumerates the .gitkeep, matching JSON planned."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_skill(
+                    "demo", router=True,
+                    optional_dirs=[DIR_REFERENCES],
+                    root=tmpdir, dry_run=True,
+                )
+            output = buf.getvalue()
+        # Both the directory and its .gitkeep sentinel appear in the preview.
+        self.assertIn(f"{DIR_CAPABILITIES}/{FILE_GITKEEP}", output)
+        self.assertIn(f"{DIR_REFERENCES}/{FILE_GITKEEP}", output)
+
+    def test_capability_dry_run_lists_gitkeep_in_human_output(self) -> None:
+        """The capability path also previews the .gitkeep, not just the dir."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scaffold_skill("dom", router=True, root=tmpdir, json_output=True)
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_capability(
+                    "dom", "cap", optional_dirs=[DIR_REFERENCES],
+                    root=tmpdir, dry_run=True,
+                )
+            output = buf.getvalue()
+        self.assertIn(f"{DIR_REFERENCES}/{FILE_GITKEEP}", output)
+
+    def test_real_run_human_output_omits_gitkeep(self) -> None:
+        """Contrast case: a real run narrates only the directory.
+
+        The .gitkeep is a git tracking sentinel, so real-run human output
+        stays unchanged — only dry-run gives the complete file-by-file
+        preview.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_skill(
+                    "demo", router=True,
+                    optional_dirs=[DIR_REFERENCES],
+                    root=tmpdir,
+                )
+            output = buf.getvalue()
+        self.assertIn(DIR_CAPABILITIES, output)
+        self.assertNotIn(FILE_GITKEEP, output)
+
 
 class DryRunDocstringTests(unittest.TestCase):
     """The usage docstring advertises --dry-run."""

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3105,6 +3105,75 @@ class NonFileManifestScaffoldTests(unittest.TestCase):
         self.assertTrue(result["success"])
 
 
+class BlockingDirAncestorTests(unittest.TestCase):
+    """A non-directory path component is an error, not a planned create.
+
+    ``os.makedirs`` cannot create a directory tree through a path
+    component that exists as a regular file, so both a real run and the
+    dry-run preview report an error rather than a (real run) crash or a
+    (dry-run) bogus zero-exit plan.
+    """
+
+    @staticmethod
+    def _root_file(tmpdir: str) -> str:
+        rootfile = os.path.join(tmpdir, "out")
+        with open(rootfile, "w", encoding="utf-8") as f:
+            f.write("")
+        return rootfile
+
+    def test_skill_dry_run_errors_on_file_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_skill(
+                "demo", root=self._root_file(tmpdir),
+                json_output=True, dry_run=True,
+            )
+        self.assertFalse(result["success"])
+        self.assertIn("is not a directory", result["error"])
+
+    def test_skill_real_run_errors_on_file_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_skill(
+                "demo", root=self._root_file(tmpdir), json_output=True,
+            )
+        self.assertFalse(result["success"])
+        self.assertIn("is not a directory", result["error"])
+
+    def test_role_dry_run_errors_on_file_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_role(
+                "grp", "rl", root=self._root_file(tmpdir),
+                json_output=True, dry_run=True,
+            )
+        self.assertFalse(result["success"])
+        self.assertIn("is not a directory", result["error"])
+
+    def test_capability_dry_run_errors_on_file_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Parent skill exists, but a regular file occupies the
+            # capabilities/ slot, blocking the capability subtree.
+            dom_dir = os.path.join(tmpdir, "skills", "dom")
+            os.makedirs(dom_dir)
+            with open(os.path.join(dom_dir, "SKILL.md"), "w", encoding="utf-8") as f:
+                f.write("---\nname: dom\n---\n")
+            with open(os.path.join(dom_dir, "capabilities"), "w", encoding="utf-8") as f:
+                f.write("")
+            result = scaffold_capability(
+                "dom", "cap", root=tmpdir, json_output=True, dry_run=True,
+            )
+        self.assertFalse(result["success"])
+        self.assertIn("is not a directory", result["error"])
+
+    def test_cli_human_mode_errors_on_file_ancestor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rootfile = self._root_file(tmpdir)
+            proc = _run(
+                ["skill", "demo", "--root", rootfile, "--dry-run"],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 1, msg=proc.stdout + proc.stderr)
+            self.assertIn("is not a directory", proc.stdout)
+
+
 class DryRunJsonShapeTests(unittest.TestCase):
     """JSON payload shape for --dry-run runs."""
 

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3253,6 +3253,20 @@ class DryRunHumanOutputTests(unittest.TestCase):
             self.assertIn("Dry run: no files were written.", output)
             self.assertNotIn("routing table", output)
 
+    def test_capability_dry_run_shows_manifest_guidance(self) -> None:
+        """--update-manifest guidance stays visible in capability dry-run."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scaffold_skill("dom", router=True, root=tmpdir, json_output=True)
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_capability(
+                    "dom", "cap", root=tmpdir,
+                    update_manifest=True, dry_run=True,
+                )
+            output = buf.getvalue()
+        self.assertIn("Dry run: no files were written.", output)
+        self.assertIn("not added to manifest.yaml directly", output)
+
     def test_role_summary_says_would_be_scaffolded(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             buf = io.StringIO()

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3301,6 +3301,49 @@ class ErrorSchemaTests(unittest.TestCase):
         self.assertTrue(role["dry_run"])
 
 
+class CliErrorSchemaTests(unittest.TestCase):
+    """CLI-level JSON errors share the stable schema (dry_run + path list).
+
+    These failure paths live in main() / _validate_flags and only fire
+    through argv parsing, so they are exercised via the CLI.
+    """
+
+    def test_unknown_flag_dry_run_uses_planned(self) -> None:
+        proc = _run(
+            ["skill", "demo", "--bogus", "--dry-run", "--json"], cwd=REPO_ROOT,
+        )
+        self.assertEqual(proc.returncode, 1, msg=proc.stdout + proc.stderr)
+        data = json.loads(proc.stdout)
+        self.assertFalse(data["success"])
+        self.assertTrue(data["dry_run"])
+        self.assertIn("planned", data)
+        self.assertNotIn("created", data)
+
+    def test_unknown_flag_real_uses_created(self) -> None:
+        proc = _run(["skill", "demo", "--bogus", "--json"], cwd=REPO_ROOT)
+        self.assertEqual(proc.returncode, 1, msg=proc.stdout + proc.stderr)
+        data = json.loads(proc.stdout)
+        self.assertFalse(data["dry_run"])
+        self.assertIn("created", data)
+        self.assertNotIn("planned", data)
+
+    def test_unknown_component_carries_path_list(self) -> None:
+        proc = _run(["bogus", "x", "--json"], cwd=REPO_ROOT)
+        self.assertEqual(proc.returncode, 1, msg=proc.stdout + proc.stderr)
+        data = json.loads(proc.stdout)
+        self.assertIn("dry_run", data)
+        self.assertIn("created", data)
+
+    def test_missing_root_arg_dry_run_uses_planned(self) -> None:
+        proc = _run(
+            ["skill", "demo", "--root", "--dry-run", "--json"], cwd=REPO_ROOT,
+        )
+        self.assertEqual(proc.returncode, 1, msg=proc.stdout + proc.stderr)
+        data = json.loads(proc.stdout)
+        self.assertTrue(data["dry_run"])
+        self.assertIn("planned", data)
+
+
 class DryRunJsonShapeTests(unittest.TestCase):
     """JSON payload shape for --dry-run runs."""
 

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -2597,5 +2597,338 @@ class CollectFrontmatterFindingsTests(unittest.TestCase):
         self.assertTrue(any("': '" in f for f in findings))
 
 
+# ===================================================================
+# --dry-run flag
+# ===================================================================
+
+
+def _strip_root(paths: list[str], root: str) -> set[str]:
+    """Return *paths* made relative to the absolute *root* as a set.
+
+    Lets a dry-run plan be compared to a real run produced under a
+    different temporary root by removing the root-specific prefix.
+    """
+    abs_root = os.path.abspath(root)
+    return {
+        to_posix(os.path.relpath(os.path.abspath(p), abs_root)) for p in paths
+    }
+
+
+class DryRunWritePrimitiveTests(unittest.TestCase):
+    """write_file / create_dir_with_gitkeep honor dry_run=True."""
+
+    def test_write_file_dry_run_writes_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "sub", "file.txt")
+            write_file(path, "hello", quiet=True, dry_run=True)
+            self.assertFalse(os.path.exists(path))
+            self.assertFalse(os.path.exists(os.path.dirname(path)))
+
+    def test_write_file_dry_run_prints_would_create(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "file.txt")
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                write_file(path, "hello", dry_run=True)
+            output = buf.getvalue()
+            self.assertIn("Would create:", output)
+            self.assertIn(to_posix(path), output)
+            self.assertNotIn("Created:", output.replace("Would create:", ""))
+
+    def test_write_file_dry_run_quiet_suppresses_output(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "file.txt")
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                write_file(path, "hello", quiet=True, dry_run=True)
+            self.assertEqual(buf.getvalue(), "")
+
+    def test_create_dir_dry_run_writes_nothing_but_returns_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "newdir")
+            gitkeep = create_dir_with_gitkeep(target, dry_run=True)
+            self.assertFalse(os.path.isdir(target))
+            self.assertFalse(os.path.exists(gitkeep))
+            # Path returned is identical to what a real run would return.
+            self.assertEqual(gitkeep, os.path.join(target, FILE_GITKEEP))
+
+
+class DryRunWritesNothingTests(unittest.TestCase):
+    """A --dry-run scaffold creates no files or directories on disk."""
+
+    def test_skill_dry_run_creates_no_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "out")
+            proc = _run(
+                ["skill", "my-skill", "--root", target, "--dry-run"],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            self.assertFalse(os.path.exists(target))
+            self.assertIn("Would create:", proc.stdout)
+
+    def test_router_skill_dry_run_creates_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "out")
+            proc = _run(
+                [
+                    "skill", "my-router", "--router",
+                    "--with-references", "--root", target, "--dry-run",
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            self.assertFalse(os.path.exists(target))
+
+    def test_skill_dry_run_with_update_manifest_writes_no_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            proc = _run(
+                [
+                    "skill", "my-skill", "--update-manifest",
+                    "--root", tmpdir, "--dry-run",
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            self.assertFalse(
+                os.path.exists(os.path.join(tmpdir, "manifest.yaml"))
+            )
+            self.assertFalse(os.path.exists(os.path.join(tmpdir, "skills")))
+
+    def test_skill_dry_run_does_not_mutate_existing_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = os.path.join(tmpdir, "manifest.yaml")
+            original = "# Manifest\n\nskills:\n\nroles:\n"
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                f.write(original)
+            proc = _run(
+                [
+                    "skill", "my-skill", "--update-manifest",
+                    "--root", tmpdir, "--dry-run",
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            with open(manifest_path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), original)
+
+    def test_role_dry_run_creates_nothing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "out")
+            proc = _run(
+                ["role", "my-group", "my-role", "--root", target, "--dry-run"],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            self.assertFalse(os.path.exists(target))
+
+    def test_capability_dry_run_creates_nothing_under_real_parent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Real parent so the existence gate passes.
+            pre = _run(
+                ["skill", "my-domain", "--router", "--root", tmpdir],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(pre.returncode, 0, msg=pre.stdout + pre.stderr)
+            proc = _run(
+                [
+                    "capability", "my-domain", "my-cap",
+                    "--root", tmpdir, "--dry-run",
+                ],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            cap_dir = os.path.join(
+                tmpdir, "skills", "my-domain", "capabilities", "my-cap"
+            )
+            self.assertFalse(os.path.exists(cap_dir))
+
+
+class DryRunPlanMatchesRealRunTests(unittest.TestCase):
+    """The dry-run plan reports the same path set a real run creates."""
+
+    def test_skill_plan_equals_created(self) -> None:
+        with tempfile.TemporaryDirectory() as dry_root, \
+             tempfile.TemporaryDirectory() as real_root:
+            dry = scaffold_skill(
+                "demo", router=True,
+                optional_dirs=[DIR_REFERENCES],
+                root=dry_root, json_output=True, dry_run=True,
+            )
+            real = scaffold_skill(
+                "demo", router=True,
+                optional_dirs=[DIR_REFERENCES],
+                root=real_root, json_output=True, dry_run=False,
+            )
+        self.assertEqual(
+            _strip_root(dry["planned"], dry_root),
+            _strip_root(real["created"], real_root),
+        )
+
+    def test_skill_plan_with_manifest_equals_created(self) -> None:
+        with tempfile.TemporaryDirectory() as dry_root, \
+             tempfile.TemporaryDirectory() as real_root:
+            dry = scaffold_skill(
+                "demo", root=dry_root, json_output=True,
+                update_manifest=True, dry_run=True,
+            )
+            real = scaffold_skill(
+                "demo", root=real_root, json_output=True,
+                update_manifest=True, dry_run=False,
+            )
+        dry_set = _strip_root(dry["planned"], dry_root)
+        real_set = _strip_root(real["created"], real_root)
+        self.assertEqual(dry_set, real_set)
+        # manifest.yaml is part of both sets.
+        self.assertIn("manifest.yaml", dry_set)
+
+    def test_role_plan_equals_created(self) -> None:
+        with tempfile.TemporaryDirectory() as dry_root, \
+             tempfile.TemporaryDirectory() as real_root:
+            dry = scaffold_role(
+                "grp", "rl", root=dry_root, json_output=True, dry_run=True,
+            )
+            real = scaffold_role(
+                "grp", "rl", root=real_root, json_output=True, dry_run=False,
+            )
+        self.assertEqual(
+            _strip_root(dry["planned"], dry_root),
+            _strip_root(real["created"], real_root),
+        )
+
+    def test_capability_plan_equals_created(self) -> None:
+        with tempfile.TemporaryDirectory() as dry_root, \
+             tempfile.TemporaryDirectory() as real_root:
+            # Both need a real parent skill.
+            scaffold_skill("dom", router=True, root=dry_root, json_output=True)
+            scaffold_skill("dom", router=True, root=real_root, json_output=True)
+            dry = scaffold_capability(
+                "dom", "cap", optional_dirs=[DIR_REFERENCES],
+                root=dry_root, json_output=True, dry_run=True,
+            )
+            real = scaffold_capability(
+                "dom", "cap", optional_dirs=[DIR_REFERENCES],
+                root=real_root, json_output=True, dry_run=False,
+            )
+        self.assertEqual(
+            _strip_root(dry["planned"], dry_root),
+            _strip_root(real["created"], real_root),
+        )
+
+
+class DryRunJsonShapeTests(unittest.TestCase):
+    """JSON payload shape for --dry-run runs."""
+
+    def test_skill_json_has_dry_run_true_and_planned_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True, dry_run=True,
+            )
+        self.assertTrue(result["dry_run"])
+        self.assertIn("planned", result)
+        self.assertNotIn("created", result)
+        self.assertTrue(result["success"])
+
+    def test_real_run_json_has_dry_run_false_and_created_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True, dry_run=False,
+            )
+        self.assertFalse(result["dry_run"])
+        self.assertIn("created", result)
+        self.assertNotIn("planned", result)
+
+    def test_capability_json_dry_run_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scaffold_skill("dom", router=True, root=tmpdir, json_output=True)
+            result = scaffold_capability(
+                "dom", "cap", root=tmpdir, json_output=True, dry_run=True,
+            )
+        self.assertTrue(result["dry_run"])
+        self.assertIn("planned", result)
+        self.assertNotIn("created", result)
+
+    def test_role_json_dry_run_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_role(
+                "grp", "rl", root=tmpdir, json_output=True, dry_run=True,
+            )
+        self.assertTrue(result["dry_run"])
+        self.assertIn("planned", result)
+        self.assertNotIn("created", result)
+
+    def test_cli_json_dry_run_emits_valid_json_and_exit_zero(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "out")
+            proc = _run(
+                ["skill", "demo", "--root", target, "--dry-run", "--json"],
+                cwd=REPO_ROOT,
+            )
+            self.assertEqual(proc.returncode, 0, msg=proc.stdout + proc.stderr)
+            data = json.loads(proc.stdout)
+            self.assertTrue(data["dry_run"])
+            self.assertIn("planned", data)
+            self.assertFalse(os.path.exists(target))
+
+
+class DryRunHumanOutputTests(unittest.TestCase):
+    """Human-mode summary lines for --dry-run runs."""
+
+    def test_skill_summary_says_would_be_scaffolded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_skill("demo", root=tmpdir, dry_run=True)
+            output = buf.getvalue()
+            self.assertIn("would be scaffolded", output)
+            self.assertIn("Dry run: no files were written.", output)
+            self.assertNotIn("Next:", output)
+
+    def test_capability_summary_says_would_be_scaffolded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scaffold_skill("dom", router=True, root=tmpdir, json_output=True)
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_capability("dom", "cap", root=tmpdir, dry_run=True)
+            output = buf.getvalue()
+            self.assertIn("would be scaffolded", output)
+            self.assertIn("Dry run: no files were written.", output)
+            self.assertNotIn("routing table", output)
+
+    def test_role_summary_says_would_be_scaffolded(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_role("grp", "rl", root=tmpdir, dry_run=True)
+            output = buf.getvalue()
+            self.assertIn("would be scaffolded", output)
+            self.assertIn("Dry run: no files were written.", output)
+            self.assertNotIn("Next:", output)
+
+    def test_router_dry_run_prints_would_create_for_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_skill(
+                    "demo", router=True,
+                    optional_dirs=[DIR_REFERENCES],
+                    root=tmpdir, dry_run=True,
+                )
+            output = buf.getvalue()
+            # capabilities/ and references/ directories both planned.
+            self.assertIn(DIR_CAPABILITIES, output)
+            self.assertIn(DIR_REFERENCES, output)
+            self.assertIn("Would create:", output)
+            self.assertNotIn("  Created:", output)
+
+
+class DryRunDocstringTests(unittest.TestCase):
+    """The usage docstring advertises --dry-run."""
+
+    def test_docstring_mentions_dry_run(self) -> None:
+        proc = _run([], cwd=REPO_ROOT)
+        self.assertIn("--dry-run", proc.stdout)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3002,6 +3002,67 @@ class DryRunExistingManifestTests(unittest.TestCase):
         )
 
 
+class DryRunImplicitDirsTests(unittest.TestCase):
+    """Dry-run lists the directories a real run creates implicitly.
+
+    ``write_file`` / ``create_dir_with_gitkeep`` create parent
+    directories via ``os.makedirs``; the plan must enumerate them so the
+    preview is complete and ``planned`` stays equal to a real run's
+    ``created``.
+    """
+
+    def test_skill_plan_includes_skill_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True, dry_run=True,
+            )
+        rels = _strip_root(result["planned"], tmpdir)
+        self.assertIn("skills", rels)
+        self.assertIn("skills/demo", rels)
+
+    def test_router_skill_plan_includes_skill_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_skill(
+                "demo", router=True, root=tmpdir,
+                json_output=True, dry_run=True,
+            )
+        rels = _strip_root(result["planned"], tmpdir)
+        self.assertIn("skills/demo", rels)
+        self.assertIn("skills/demo/capabilities", rels)
+
+    def test_capability_plan_includes_cap_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            scaffold_skill("dom", router=True, root=tmpdir, json_output=True)
+            result = scaffold_capability(
+                "dom", "cap", root=tmpdir, json_output=True, dry_run=True,
+            )
+        rels = _strip_root(result["planned"], tmpdir)
+        self.assertIn("skills/dom/capabilities/cap", rels)
+
+    def test_role_plan_includes_group_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_role(
+                "grp", "rl", root=tmpdir, json_output=True, dry_run=True,
+            )
+        rels = _strip_root(result["planned"], tmpdir)
+        self.assertIn("roles/grp", rels)
+
+    def test_real_run_created_includes_skill_dir(self) -> None:
+        """Parity: a real run records the same implicit container dir."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_skill("demo", root=tmpdir, json_output=True)
+        rels = _strip_root(result["created"], tmpdir)
+        self.assertIn("skills/demo", rels)
+
+    def test_skill_dry_run_human_lists_skill_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_skill("demo", root=tmpdir, dry_run=True)
+            output = buf.getvalue()
+        self.assertIn("skills/demo", output)
+
+
 class DryRunJsonShapeTests(unittest.TestCase):
     """JSON payload shape for --dry-run runs."""
 

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3231,6 +3231,56 @@ class RealRunDirNarrationTests(unittest.TestCase):
         self.assertFalse(os.path.exists(os.path.join(tmpdir, DIR_SKILLS)))
 
 
+class ErrorSchemaTests(unittest.TestCase):
+    """Error JSON carries dry_run and the run-mode path-list key."""
+
+    @staticmethod
+    def _existing_skill_dir(tmpdir: str) -> None:
+        os.makedirs(os.path.join(tmpdir, DIR_SKILLS, "demo"))
+
+    def test_error_dry_run_true_uses_planned_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._existing_skill_dir(tmpdir)
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True, dry_run=True,
+            )
+        self.assertFalse(result["success"])
+        self.assertTrue(result["dry_run"])
+        self.assertIn("planned", result)
+        self.assertNotIn("created", result)
+
+    def test_error_dry_run_false_uses_created_key(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._existing_skill_dir(tmpdir)
+            result = scaffold_skill("demo", root=tmpdir, json_output=True)
+        self.assertFalse(result["success"])
+        self.assertFalse(result["dry_run"])
+        self.assertIn("created", result)
+        self.assertNotIn("planned", result)
+
+    def test_invalid_name_error_carries_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_skill(
+                "INVALID", root=tmpdir, json_output=True, dry_run=True,
+            )
+        self.assertFalse(result["success"])
+        self.assertTrue(result["dry_run"])
+        self.assertIn("planned", result)
+
+    def test_capability_and_role_errors_carry_dry_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cap = scaffold_capability(
+                "INVALID", "x", root=tmpdir, json_output=True, dry_run=True,
+            )
+            role = scaffold_role(
+                "INVALID", "x", root=tmpdir, json_output=True, dry_run=True,
+            )
+        self.assertIn("dry_run", cap)
+        self.assertIn("dry_run", role)
+        self.assertTrue(cap["dry_run"])
+        self.assertTrue(role["dry_run"])
+
+
 class DryRunJsonShapeTests(unittest.TestCase):
     """JSON payload shape for --dry-run runs."""
 

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -2816,6 +2816,112 @@ class DryRunPlanMatchesRealRunTests(unittest.TestCase):
         )
 
 
+class DryRunExistingManifestTests(unittest.TestCase):
+    """--dry-run reports an existing manifest as an update, not a create.
+
+    A real ``--update-manifest`` run appends to an existing manifest and
+    reports it as ``Updated:`` — it never lists it in the JSON
+    ``created`` set. The dry-run preview must mirror that: an existing
+    manifest is a planned *update*, kept out of ``planned`` and narrated
+    with the update verb, while an absent manifest is a planned create.
+    """
+
+    _NONEMPTY_MANIFEST = "# Manifest\n\nskills:\n\nroles:\n"
+
+    def _write_manifest(self, tmpdir: str) -> str:
+        manifest_path = os.path.join(tmpdir, "manifest.yaml")
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            f.write(self._NONEMPTY_MANIFEST)
+        return manifest_path
+
+    def test_skill_existing_manifest_absent_from_planned(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_manifest(tmpdir)
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True,
+                update_manifest=True, dry_run=True,
+            )
+        self.assertFalse(
+            any(p.endswith("manifest.yaml") for p in result["planned"]),
+            msg=f"existing manifest listed as planned create: {result['planned']}",
+        )
+        # A real run would still append the entry, so manifest_updated holds.
+        self.assertTrue(result["manifest_updated"])
+
+    def test_skill_absent_manifest_in_planned(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True,
+                update_manifest=True, dry_run=True,
+            )
+        self.assertTrue(
+            any(p.endswith("manifest.yaml") for p in result["planned"]),
+            msg=f"absent manifest missing from planned create: {result['planned']}",
+        )
+        self.assertTrue(result["manifest_updated"])
+
+    def test_skill_existing_manifest_human_says_would_update(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = self._write_manifest(tmpdir)
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_skill(
+                    "demo", root=tmpdir, update_manifest=True, dry_run=True,
+                )
+            output = buf.getvalue()
+        self.assertIn(f"Would update: {to_posix(manifest_path)}", output)
+        self.assertNotIn(f"Would create: {to_posix(manifest_path)}", output)
+
+    def test_skill_absent_manifest_human_says_would_create(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = os.path.join(tmpdir, "manifest.yaml")
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_skill(
+                    "demo", root=tmpdir, update_manifest=True, dry_run=True,
+                )
+            output = buf.getvalue()
+        self.assertIn(f"Would create: {to_posix(manifest_path)}", output)
+        self.assertNotIn("Would update:", output)
+
+    def test_role_existing_manifest_absent_from_planned(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self._write_manifest(tmpdir)
+            result = scaffold_role(
+                "grp", "rl", root=tmpdir, json_output=True,
+                update_manifest=True, dry_run=True,
+            )
+        self.assertFalse(
+            any(p.endswith("manifest.yaml") for p in result["planned"]),
+            msg=f"existing manifest listed as planned create: {result['planned']}",
+        )
+        self.assertTrue(result["manifest_updated"])
+
+    def test_role_existing_manifest_human_says_would_update(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = self._write_manifest(tmpdir)
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_role(
+                    "grp", "rl", root=tmpdir,
+                    update_manifest=True, dry_run=True,
+                )
+            output = buf.getvalue()
+        self.assertIn(f"Would update: {to_posix(manifest_path)}", output)
+        self.assertNotIn(f"Would create: {to_posix(manifest_path)}", output)
+
+    def test_existing_manifest_left_unmutated(self) -> None:
+        """The read-only existence check never rewrites the manifest."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = self._write_manifest(tmpdir)
+            scaffold_skill(
+                "demo", root=tmpdir, json_output=True,
+                update_manifest=True, dry_run=True,
+            )
+            with open(manifest_path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), self._NONEMPTY_MANIFEST)
+
+
 class DryRunJsonShapeTests(unittest.TestCase):
     """JSON payload shape for --dry-run runs."""
 

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3230,6 +3230,26 @@ class RealRunDirNarrationTests(unittest.TestCase):
         self.assertNotIn("Created:", output)
         self.assertFalse(os.path.exists(os.path.join(tmpdir, DIR_SKILLS)))
 
+    def test_dry_run_template_failure_advertises_no_dirs(self) -> None:
+        """A pre-write failure yields no planned dirs in either dry-run mode."""
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch(
+                    "scaffold.read_template",
+                    side_effect=FileNotFoundError("missing template"),
+                ):
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True, dry_run=True,
+            )
+            self.assertFalse(result["success"])
+            # JSON: no planned paths advertised for a command that can't run.
+            self.assertEqual(result.get("planned", []), [])
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                with self.assertRaises(SystemExit):
+                    scaffold_skill("demo", root=tmpdir, dry_run=True)
+            # Human matches JSON: no "Would create" lines before the failure.
+            self.assertNotIn("Would create", buf.getvalue())
+
 
 class ErrorSchemaTests(unittest.TestCase):
     """Error JSON carries dry_run and the run-mode path-list key."""

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -2911,7 +2911,7 @@ class DryRunExistingManifestTests(unittest.TestCase):
         self.assertNotIn(f"Would create: {to_posix(manifest_path)}", output)
 
     def test_existing_manifest_left_unmutated(self) -> None:
-        """The read-only existence check never rewrites the manifest."""
+        """The read-only preview never rewrites the manifest."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manifest_path = self._write_manifest(tmpdir)
             scaffold_skill(
@@ -2920,6 +2920,86 @@ class DryRunExistingManifestTests(unittest.TestCase):
             )
             with open(manifest_path, "r", encoding="utf-8") as f:
                 self.assertEqual(f.read(), self._NONEMPTY_MANIFEST)
+
+    # The read-only preview also catches the cases a real run would skip:
+    # a name already in the manifest, and a manifest that does not parse.
+
+    _CONFLICT_MANIFEST = (
+        "# Manifest\n\nskills:\n  demo:\n"
+        "    canonical: skills/demo/SKILL.md\n    type: standalone\n\nroles:\n"
+    )
+    _ROLE_CONFLICT_MANIFEST = (
+        "# Manifest\n\nskills:\n\nroles:\n  grp:\n"
+        "    - name: rl\n      path: roles/grp/rl.md\n"
+    )
+    _MALFORMED_MANIFEST = "skills:\n  - item1\n  - item2\n"
+
+    def test_skill_conflict_reports_skip_not_update(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = os.path.join(tmpdir, "manifest.yaml")
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                f.write(self._CONFLICT_MANIFEST)
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True,
+                update_manifest=True, dry_run=True,
+            )
+            # The preview must not have rewritten the manifest.
+            with open(manifest_path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), self._CONFLICT_MANIFEST)
+        self.assertFalse(result["manifest_updated"])
+        self.assertIn("already exists", result["manifest_warning"])
+        self.assertFalse(
+            any(p.endswith("manifest.yaml") for p in result["planned"])
+        )
+        # A skipped manifest update is a warning, not a failure.
+        self.assertTrue(result["success"])
+
+    def test_skill_conflict_human_output_warns(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = os.path.join(tmpdir, "manifest.yaml")
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                f.write(self._CONFLICT_MANIFEST)
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                scaffold_skill(
+                    "demo", root=tmpdir, update_manifest=True, dry_run=True,
+                )
+            output = buf.getvalue()
+        self.assertIn("already exists", output)
+        self.assertNotIn(f"Would update: {to_posix(manifest_path)}", output)
+        self.assertNotIn(f"Would create: {to_posix(manifest_path)}", output)
+
+    def test_skill_malformed_manifest_reports_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = os.path.join(tmpdir, "manifest.yaml")
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                f.write(self._MALFORMED_MANIFEST)
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True,
+                update_manifest=True, dry_run=True,
+            )
+        self.assertFalse(result["manifest_updated"])
+        self.assertIn("skipping manifest update", result["manifest_warning"])
+        self.assertTrue(result["success"])
+        self.assertFalse(
+            any(p.endswith("manifest.yaml") for p in result["planned"])
+        )
+
+    def test_role_conflict_reports_skip_not_update(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manifest_path = os.path.join(tmpdir, "manifest.yaml")
+            with open(manifest_path, "w", encoding="utf-8") as f:
+                f.write(self._ROLE_CONFLICT_MANIFEST)
+            result = scaffold_role(
+                "grp", "rl", root=tmpdir, json_output=True,
+                update_manifest=True, dry_run=True,
+            )
+        self.assertFalse(result["manifest_updated"])
+        self.assertIn("already exists", result["manifest_warning"])
+        self.assertTrue(result["success"])
+        self.assertFalse(
+            any(p.endswith("manifest.yaml") for p in result["planned"])
+        )
 
 
 class DryRunJsonShapeTests(unittest.TestCase):

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3063,6 +3063,48 @@ class DryRunImplicitDirsTests(unittest.TestCase):
         self.assertIn("skills/demo", output)
 
 
+class NonFileManifestScaffoldTests(unittest.TestCase):
+    """--update-manifest skips gracefully when manifest.yaml is not a file."""
+
+    def test_skill_dry_run_reports_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.mkdir(os.path.join(tmpdir, "manifest.yaml"))
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True,
+                update_manifest=True, dry_run=True,
+            )
+        self.assertFalse(result["manifest_updated"])
+        self.assertIn("not a regular file", result["manifest_warning"])
+        self.assertTrue(result["success"])
+        self.assertFalse(
+            any(p.endswith("manifest.yaml") for p in result["planned"])
+        )
+
+    def test_skill_real_run_does_not_crash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.mkdir(os.path.join(tmpdir, "manifest.yaml"))
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True, update_manifest=True,
+            )
+        self.assertFalse(result["manifest_updated"])
+        self.assertIn("not a regular file", result["manifest_warning"])
+        # The skill itself is still scaffolded; only the manifest is skipped.
+        self.assertTrue(
+            any(p.endswith("SKILL.md") for p in result["created"])
+        )
+
+    def test_role_dry_run_reports_skip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.mkdir(os.path.join(tmpdir, "manifest.yaml"))
+            result = scaffold_role(
+                "grp", "rl", root=tmpdir, json_output=True,
+                update_manifest=True, dry_run=True,
+            )
+        self.assertFalse(result["manifest_updated"])
+        self.assertIn("not a regular file", result["manifest_warning"])
+        self.assertTrue(result["success"])
+
+
 class DryRunJsonShapeTests(unittest.TestCase):
     """JSON payload shape for --dry-run runs."""
 

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3174,6 +3174,43 @@ class BlockingDirAncestorTests(unittest.TestCase):
             self.assertIn("is not a directory", proc.stdout)
 
 
+class DryRunFrontmatterValidationTests(unittest.TestCase):
+    """Dry-run validates rendered frontmatter in memory, like the real run."""
+
+    # Opening delimiter with no closing '---' — a parse failure the real
+    # run would surface after writing.
+    _BAD_TEMPLATE = "---\nname: demo\n"
+
+    def test_dry_run_reports_malformed_frontmatter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("scaffold.read_template", return_value=self._BAD_TEMPLATE):
+            result = scaffold_skill(
+                "demo", root=tmpdir, json_output=True, dry_run=True,
+            )
+        self.assertFalse(result["success"])
+        self.assertTrue(
+            any("Invalid frontmatter" in w for w in result.get("warnings", [])),
+            msg=f"expected a frontmatter parse finding: {result.get('warnings')}",
+        )
+
+    def test_dry_run_matches_real_run_verdict(self) -> None:
+        with tempfile.TemporaryDirectory() as dry_root, \
+                tempfile.TemporaryDirectory() as real_root, \
+                patch("scaffold.read_template", return_value=self._BAD_TEMPLATE):
+            dry = scaffold_skill(
+                "demo", root=dry_root, json_output=True, dry_run=True,
+            )
+            real = scaffold_skill("demo", root=real_root, json_output=True)
+        self.assertFalse(dry["success"])
+        self.assertEqual(dry["success"], real["success"])
+
+    def test_dry_run_writes_nothing_even_when_invalid(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch("scaffold.read_template", return_value=self._BAD_TEMPLATE):
+            scaffold_skill("demo", root=tmpdir, json_output=True, dry_run=True)
+            self.assertFalse(os.path.exists(os.path.join(tmpdir, DIR_SKILLS)))
+
+
 class RealRunDirNarrationTests(unittest.TestCase):
     """A real run does not narrate directories before they exist."""
 

--- a/tests/test_scaffold_cli.py
+++ b/tests/test_scaffold_cli.py
@@ -3174,6 +3174,26 @@ class BlockingDirAncestorTests(unittest.TestCase):
             self.assertIn("is not a directory", proc.stdout)
 
 
+class RealRunDirNarrationTests(unittest.TestCase):
+    """A real run does not narrate directories before they exist."""
+
+    def test_no_premature_created_line_on_template_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir, \
+                patch(
+                    "scaffold.read_template",
+                    side_effect=FileNotFoundError("missing template"),
+                ):
+            buf = io.StringIO()
+            with mock.patch("sys.stdout", buf):
+                with self.assertRaises(SystemExit):
+                    scaffold_skill("demo", root=tmpdir)
+            output = buf.getvalue()
+        # The run failed before the first write, so nothing was created and
+        # nothing should have been narrated as created.
+        self.assertNotIn("Created:", output)
+        self.assertFalse(os.path.exists(os.path.join(tmpdir, DIR_SKILLS)))
+
+
 class DryRunJsonShapeTests(unittest.TestCase):
     """JSON payload shape for --dry-run runs."""
 


### PR DESCRIPTION
Adds a `--dry-run` flag to `scaffold.py` that previews every file and directory a scaffold command would create without writing anything to disk (FINDINGS F-04). The flag threads through the `write_file()` and `create_dir_with_gitkeep()` writers and the skill, capability, and role scaffolders: human output lists `Would create:` lines, and `--json` reports the same paths under a `planned` key (versus `created` for a real run) alongside a top-level `dry_run` boolean.

The preview is faithful to the real run rather than a partial sketch. It enumerates the implicit parent directories `os.makedirs` would create, so `planned` equals a real run's `created`; it validates the rendered frontmatter in memory, so a malformed template fails the dry run with the same findings and exit status a real run would produce; and it loads the template before advertising any directory, so a pre-write failure such as a missing template never previews paths the command cannot create.

Manifest handling under `--update-manifest` mirrors real-run semantics through a read-only preview: the manifest is read and validated but never written, so the plan reports whether a real run would create the file, update it in place, or skip it — on a name conflict, a parse failure, or a path already occupied by a non-regular file. A non-directory path component anywhere in the target tree is reported as an error in both dry-run and real mode rather than a bogus planned create or a mid-write crash.

Every scaffold JSON response, success or failure, now carries `dry_run` and the run-mode path-list key for a stable schema, built through a shared error helper. The dry-run formatting helpers live in a new `lib/dry_run.py`, and frontmatter parsing gains an in-memory `parse_frontmatter` in `lib/frontmatter.py` so dry-run validation needs no file on disk.

Tests cover write-nothing behavior, `planned == created` parity across skill / router / capability / role, the JSON shape, the manifest create/update/skip previews (conflicts, parse failures, and non-regular-file paths), blocking non-directory ancestors, in-memory frontmatter validation, and the error-response schema. Full suite green; `lib/dry_run.py` and `lib/frontmatter.py` at 100%, `scaffold.py` at 96%.
