### PR TITLE
Validate configuration.yaml structure at load time

### DIFF
--- a/skill-system-foundry/scripts/lib/config_validation.py
+++ b/skill-system-foundry/scripts/lib/config_validation.py
@@ -70,17 +70,18 @@ def _require_key(parent: dict, path: tuple[str, ...]) -> object:
 def _require_mapping(parent: dict, path: tuple[str, ...]) -> dict:
     """Return ``parent[path[-1]]`` ensuring it is a mapping.
 
-    The YAML subset parser returns a key authored with no children
-    (``stats:`` followed by no indented lines) as the empty string,
-    not an empty dict.  Treat that blank form as an empty mapping so the
-    subsequent required-child lookups raise naming the *missing child*
-    (``stats.line_endings``) rather than reporting the parent as a
-    scalar — which is the more actionable diagnostic and matches the
-    fail-fast behaviour the inline ``constants.py`` checks already had.
+    A key authored with no children (``stats:`` followed by no indented
+    lines) parses as the empty string ``""`` rather than an empty dict
+    in the stdlib YAML subset, so a blank value here is rejected with
+    the same diagnostic as a scalar.  Leaf mappings such as
+    ``skill.allowed_tools.fence_languages`` and ``stats.line_endings``
+    have no required children that would catch the blank form
+    downstream — ``constants.py`` would then crash on ``.items()`` /
+    ``.get()`` against ``""``.  Failing here keeps the diagnostic
+    actionable and the validator a faithful guard for the dereferences
+    that follow.
     """
     value = _require_key(parent, path)
-    if value == "":
-        return {}
     if not isinstance(value, dict):
         raise ConfigurationError(
             f"key '{_format_path(path)}' in {CONFIG_FILE_NAME}: expected a "

--- a/skill-system-foundry/scripts/lib/config_validation.py
+++ b/skill-system-foundry/scripts/lib/config_validation.py
@@ -1,0 +1,445 @@
+"""Load-time structure validation for ``configuration.yaml``.
+
+``constants.py`` dereferences a fixed set of key paths out of the parsed
+configuration mapping (and converts numeric scalars with ``int()`` /
+``float()``).  A missing or wrong-typed key in ``configuration.yaml``
+would otherwise surface as a bare ``KeyError`` / ``TypeError`` /
+``ValueError`` at *import* time, with a traceback that names a private
+local (``_skill``, ``_eval``) rather than the offending YAML key — an
+opaque failure for anyone editing the config or running a stale
+checkout.
+
+This module guards exactly the key paths ``constants.py`` consumes.  It
+checks presence and basic shape (mapping vs list vs scalar) and that
+scalars destined for ``int()`` / ``float()`` actually convert.  On the
+first problem it raises :class:`ConfigurationError` with a message that
+names the offending dotted key path, e.g.::
+
+    ConfigurationError: missing required key
+    'skill.description.evaluation.thresholds' in configuration.yaml
+
+The scope is deliberately narrow: this is not a general JSON-schema
+engine.  It validates the structural shape ``constants.py`` relies on so
+the loader fails fast and clearly.  Deeper per-entry semantics (empty /
+duplicate / path-traversal list entries, range bounds on integers) stay
+in ``constants.py`` where the normalized values are produced — this
+module only guarantees the dereferences in that module will not raise an
+unhelpful builtin error.
+
+The function takes a plain ``dict`` so it can be unit-tested in
+isolation without reading the on-disk file.  The stdlib-only YAML subset
+parser returns every scalar as a ``str``, so the numeric checks below
+attempt the same conversion ``constants.py`` performs.
+"""
+
+CONFIG_FILE_NAME = "configuration.yaml"
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when ``configuration.yaml`` is missing a required key or
+    a key has the wrong shape for what ``constants.py`` expects.
+
+    Subclasses ``RuntimeError`` so the inline fail-fast checks in
+    ``constants.py`` (which raise ``RuntimeError`` for per-entry semantic
+    problems) and this structural loader present one exception family to
+    callers — ``except RuntimeError`` catches both, and existing tests
+    asserting ``RuntimeError`` on a malformed config continue to hold.
+    """
+
+
+def _format_path(path: tuple[str, ...]) -> str:
+    """Render a key-path tuple as a dotted string for diagnostics."""
+    return ".".join(path)
+
+
+def _require_key(parent: dict, path: tuple[str, ...]) -> object:
+    """Return ``parent[path[-1]]`` or raise naming the dotted *path*.
+
+    *parent* is the already-resolved mapping that should contain the
+    final segment of *path*; the full *path* is used only for the
+    diagnostic message.
+    """
+    key = path[-1]
+    if key not in parent:
+        raise ConfigurationError(
+            f"missing required key '{_format_path(path)}' in {CONFIG_FILE_NAME}"
+        )
+    return parent[key]
+
+
+def _require_mapping(parent: dict, path: tuple[str, ...]) -> dict:
+    """Return ``parent[path[-1]]`` ensuring it is a mapping.
+
+    The YAML subset parser returns a key authored with no children
+    (``stats:`` followed by no indented lines) as the empty string,
+    not an empty dict.  Treat that blank form as an empty mapping so the
+    subsequent required-child lookups raise naming the *missing child*
+    (``stats.line_endings``) rather than reporting the parent as a
+    scalar — which is the more actionable diagnostic and matches the
+    fail-fast behaviour the inline ``constants.py`` checks already had.
+    """
+    value = _require_key(parent, path)
+    if value == "":
+        return {}
+    if not isinstance(value, dict):
+        raise ConfigurationError(
+            f"key '{_format_path(path)}' in {CONFIG_FILE_NAME}: expected a "
+            f"mapping, got {type(value).__name__}"
+        )
+    return value
+
+
+def _require_list(parent: dict, path: tuple[str, ...]) -> list:
+    """Return ``parent[path[-1]]`` ensuring it is a list."""
+    value = _require_key(parent, path)
+    if not isinstance(value, list):
+        raise ConfigurationError(
+            f"key '{_format_path(path)}' in {CONFIG_FILE_NAME}: expected a "
+            f"list, got {type(value).__name__}"
+        )
+    return value
+
+
+def _require_scalar(parent: dict, path: tuple[str, ...]) -> str:
+    """Return ``parent[path[-1]]`` ensuring it is a scalar (not a
+    mapping or list).
+
+    The YAML subset parser returns scalars as ``str``; a key with no
+    value is returned as ``""``.  A mapping or list here means the key
+    was authored as a nested structure where ``constants.py`` expects a
+    plain value.
+    """
+    value = _require_key(parent, path)
+    if isinstance(value, (dict, list)):
+        raise ConfigurationError(
+            f"key '{_format_path(path)}' in {CONFIG_FILE_NAME}: expected a "
+            f"scalar string value, got {type(value).__name__}"
+        )
+    return str(value)
+
+
+def _require_int(parent: dict, path: tuple[str, ...]) -> None:
+    """Ensure ``parent[path[-1]]`` is a scalar that ``int()`` accepts.
+
+    Mirrors the ``int(...)`` conversion ``constants.py`` performs so a
+    malformed numeric (``max_length: abc``) produces a message naming
+    the key instead of a bare ``ValueError`` at import.
+    """
+    value = _require_scalar(parent, path)
+    try:
+        int(value)
+    except (TypeError, ValueError):
+        raise ConfigurationError(
+            f"key '{_format_path(path)}' in {CONFIG_FILE_NAME}: expected an "
+            f"integer, got {value!r}"
+        ) from None
+
+
+def _require_float(parent: dict, path: tuple[str, ...]) -> None:
+    """Ensure ``parent[path[-1]]`` is a scalar that ``float()`` accepts."""
+    value = _require_scalar(parent, path)
+    try:
+        float(value)
+    except (TypeError, ValueError):
+        raise ConfigurationError(
+            f"key '{_format_path(path)}' in {CONFIG_FILE_NAME}: expected a "
+            f"number, got {value!r}"
+        ) from None
+
+
+def validate_config_structure(config: dict) -> None:
+    """Validate the structure ``constants.py`` depends on.
+
+    Walks every key path ``constants.py`` dereferences from the parsed
+    configuration, checking presence and basic shape (mapping / list /
+    scalar) and that scalars converted with ``int()`` / ``float()``
+    convert cleanly.  Raises :class:`ConfigurationError` naming the
+    offending dotted key path on the first problem; returns ``None`` when
+    every consumed path is present and well-shaped.
+
+    Does not mutate *config*.  Per-entry semantic checks (empty /
+    duplicate / traversal entries, integer range bounds) remain in
+    ``constants.py``; this guards the dereferences themselves.
+    """
+    if not isinstance(config, dict):
+        raise ConfigurationError(
+            f"{CONFIG_FILE_NAME} did not parse to a mapping, got "
+            f"{type(config).__name__}"
+        )
+
+    _validate_skill(config)
+    _validate_plain_scalar(config)
+    _validate_path_resolution(config)
+    _validate_prose_yaml(config)
+    _validate_yaml_conformance(config)
+    _validate_codex_config(config)
+    _validate_dependency_direction(config)
+    _validate_role_composition(config)
+    _validate_orphan_references(config)
+    _validate_bundle(config)
+    _validate_stats(config)
+
+
+def _validate_skill(config: dict) -> None:
+    """Guard the ``skill`` section and everything ``constants.py`` reads
+    beneath it."""
+    skill = _require_mapping(config, ("skill",))
+
+    # skill.name
+    name = _require_mapping(skill, ("skill", "name"))
+    _require_int(name, ("skill", "name", "max_length"))
+    _require_int(name, ("skill", "name", "min_length"))
+    _require_scalar(name, ("skill", "name", "format_pattern"))
+    _require_list(name, ("skill", "name", "reserved_words"))
+    _require_list(name, ("skill", "name", "windows_reserved_names"))
+
+    # skill.description
+    desc = _require_mapping(skill, ("skill", "description"))
+    _require_int(desc, ("skill", "description", "max_length"))
+    _require_scalar(desc, ("skill", "description", "xml_tag_pattern"))
+    _require_list(desc, ("skill", "description", "trigger_phrases"))
+
+    voice = _require_mapping(desc, ("skill", "description", "voice_patterns"))
+    voice_base = ("skill", "description", "voice_patterns")
+    _require_scalar(voice, voice_base + ("first_person",))
+    _require_scalar(voice, voice_base + ("first_person_plural",))
+    _require_scalar(voice, voice_base + ("second_person",))
+    _require_scalar(voice, voice_base + ("imperative_start",))
+
+    _validate_evaluation(desc)
+    _validate_structural_rules(desc)
+
+    # skill.body
+    body = _require_mapping(skill, ("skill", "body"))
+    _require_int(body, ("skill", "body", "max_lines"))
+    refs = _require_mapping(body, ("skill", "body", "reference_patterns"))
+    _require_scalar(refs, ("skill", "body", "reference_patterns", "markdown_link"))
+    _require_scalar(refs, ("skill", "body", "reference_patterns", "backtick"))
+
+    # skill.compatibility
+    compat = _require_mapping(skill, ("skill", "compatibility"))
+    _require_int(compat, ("skill", "compatibility", "max_length"))
+
+    # skill.known_frontmatter_keys
+    _require_list(skill, ("skill", "known_frontmatter_keys"))
+
+    # skill.frontmatter_suggestions
+    fm = _require_mapping(skill, ("skill", "frontmatter_suggestions"))
+    _require_int(fm, ("skill", "frontmatter_suggestions", "max_matches"))
+    _require_float(fm, ("skill", "frontmatter_suggestions", "cutoff"))
+
+    _validate_allowed_tools(skill)
+
+    # skill.metadata
+    metadata = _require_mapping(skill, ("skill", "metadata"))
+    version = _require_mapping(metadata, ("skill", "metadata", "version"))
+    _require_scalar(version, ("skill", "metadata", "version", "pattern"))
+    author = _require_mapping(metadata, ("skill", "metadata", "author"))
+    _require_int(author, ("skill", "metadata", "author", "max_length"))
+
+    # skill.license
+    license_section = _require_mapping(skill, ("skill", "license"))
+    _require_list(license_section, ("skill", "license", "known_spdx"))
+
+    # skill.recognized_subdirectories
+    _require_list(skill, ("skill", "recognized_subdirectories"))
+
+    # skill.capability_frontmatter
+    cap_fm = _require_mapping(skill, ("skill", "capability_frontmatter"))
+    _require_list(
+        cap_fm, ("skill", "capability_frontmatter", "skill_only_fields")
+    )
+
+
+def _validate_evaluation(desc: dict) -> None:
+    """Guard ``skill.description.evaluation`` and its coverage subtree."""
+    base = ("skill", "description", "evaluation")
+    evaluation = _require_mapping(desc, base)
+    _require_float(evaluation, base + ("default_min_precision",))
+    _require_float(evaluation, base + ("default_min_recall",))
+    _require_float(evaluation, base + ("heuristic_min_overlap",))
+    _require_int(evaluation, base + ("max_prompt_chars",))
+    _require_float(evaluation, base + ("diversity_distinct_bigram_min_ratio",))
+    _require_int(evaluation, base + ("min_prompts_per_side",))
+    _require_int(evaluation, base + ("recommended_prompts_per_side",))
+    _require_list(evaluation, base + ("stopwords",))
+
+    cov_base = base + ("coverage",)
+    coverage = _require_mapping(evaluation, cov_base)
+    _require_scalar(coverage, cov_base + ("corpus_root_relative",))
+    # allowed_missing_corpus and freshness_check_enabled are optional in
+    # constants.py (.get with a default); their shape is validated there
+    # when present, so they are not required here.
+
+
+def _validate_structural_rules(desc: dict) -> None:
+    """Guard ``skill.description.structural_rules``."""
+    base = ("skill", "description", "structural_rules")
+    structural = _require_mapping(desc, base)
+    _require_int(structural, base + ("trigger_minimum_count",))
+    _require_list(structural, base + ("negative_trigger_phrases",))
+    _require_list(structural, base + ("filler_phrases",))
+    _require_int(structural, base + ("filler_lookahead_tokens",))
+    _require_list(structural, base + ("boundary_clause_phrases",))
+    _require_int(structural, base + ("length_tier_warn_below",))
+    _require_int(structural, base + ("length_tier_warn_above",))
+    _require_int(structural, base + ("vocabulary_minimum",))
+    _require_list(structural, base + ("vocabulary_list",))
+    _require_int(structural, base + ("redundancy_min_count",))
+    _require_float(structural, base + ("redundancy_max_ratio",))
+    _require_list(structural, base + ("stopwords",))
+
+
+def _validate_allowed_tools(skill: dict) -> None:
+    """Guard ``skill.allowed_tools`` and the claude_code catalog."""
+    base = ("skill", "allowed_tools")
+    allowed = _require_mapping(skill, base)
+    _require_int(allowed, base + ("max_tools",))
+    _require_scalar(allowed, base + ("mcp_tool_pattern",))
+    _require_scalar(allowed, base + ("harness_tool_shape_pattern",))
+
+    cat_base = base + ("catalogs",)
+    catalogs = _require_mapping(allowed, cat_base)
+    cc_base = cat_base + ("claude_code",)
+    claude_code = _require_mapping(catalogs, cc_base)
+    _require_list(claude_code, cc_base + ("harness_tools",))
+    _require_list(claude_code, cc_base + ("cli_tools",))
+
+    # fence_languages: a mapping of tool-name -> { languages: [...] }.
+    fence_base = base + ("fence_languages",)
+    fence = _require_mapping(allowed, fence_base)
+    for tool_name, entry in fence.items():
+        entry_path = fence_base + (str(tool_name),)
+        if not isinstance(entry, dict):
+            raise ConfigurationError(
+                f"key '{_format_path(entry_path)}' in {CONFIG_FILE_NAME}: "
+                f"expected a mapping, got {type(entry).__name__}"
+            )
+        _require_list(entry, entry_path + ("languages",))
+
+
+def _validate_plain_scalar(config: dict) -> None:
+    """Guard ``plain_scalar`` indicators and context whitespace."""
+    plain = _require_mapping(config, ("plain_scalar",))
+    indicators = _require_mapping(plain, ("plain_scalar", "indicators"))
+    ind_base = ("plain_scalar", "indicators")
+    for key in (
+        "flow", "alias", "reserved", "directive", "block_entry",
+        "mapping_key", "anchor", "block_scalar", "quote_single",
+        "quote_double", "tag",
+    ):
+        _require_scalar(indicators, ind_base + (key,))
+    _require_list(plain, ("plain_scalar", "context_whitespace"))
+
+
+def _validate_path_resolution(config: dict) -> None:
+    """Guard ``path_resolution`` and its degraded_symlink subtree."""
+    base = ("path_resolution",)
+    pr = _require_mapping(config, base)
+    _require_scalar(pr, base + ("rule_name",))
+    _require_scalar(pr, base + ("documentation_path",))
+    _require_list(pr, base + ("reference_extensions",))
+
+    ds_base = base + ("degraded_symlink",)
+    ds = _require_mapping(pr, ds_base)
+    _require_int(ds, ds_base + ("max_bytes",))
+    _require_list(ds, ds_base + ("foundry_extensions",))
+
+
+def _validate_prose_yaml(config: dict) -> None:
+    """Guard ``prose_yaml``."""
+    base = ("prose_yaml",)
+    prose = _require_mapping(config, base)
+    _require_scalar(prose, base + ("opt_out_marker",))
+    _require_list(prose, base + ("in_scope_globs",))
+
+
+def _validate_yaml_conformance(config: dict) -> None:
+    """Guard ``yaml_conformance``."""
+    base = ("yaml_conformance",)
+    yc = _require_mapping(config, base)
+    _require_list(yc, base + ("construct_ids",))
+
+
+def _validate_codex_config(config: dict) -> None:
+    """Guard ``codex_config`` interface / dependencies / schema key sets."""
+    base = ("codex_config",)
+    codex = _require_mapping(config, base)
+
+    iface_base = base + ("interface",)
+    iface = _require_mapping(codex, iface_base)
+    _require_int(iface, iface_base + ("max_display_name_length",))
+    _require_int(iface, iface_base + ("max_short_description_length",))
+    _require_scalar(iface, iface_base + ("hex_color_pattern",))
+
+    deps_base = base + ("dependencies",)
+    deps = _require_mapping(codex, deps_base)
+    _require_list(deps, deps_base + ("known_tool_types",))
+    _require_list(deps, deps_base + ("known_transports",))
+
+    _require_list(codex, base + ("known_top_level_keys",))
+    _require_list(codex, base + ("known_interface_keys",))
+    _require_list(codex, base + ("known_policy_keys",))
+    _require_list(codex, base + ("known_dependencies_keys",))
+    _require_list(codex, base + ("known_tool_keys",))
+
+
+def _validate_dependency_direction(config: dict) -> None:
+    """Guard ``dependency_direction`` patterns."""
+    base = ("dependency_direction",)
+    dep = _require_mapping(config, base)
+    _require_scalar(dep, base + ("roles_ref_pattern",))
+    _require_scalar(dep, base + ("sibling_capability_ref_pattern",))
+
+
+def _validate_role_composition(config: dict) -> None:
+    """Guard ``role_composition``."""
+    base = ("role_composition",)
+    role = _require_mapping(config, base)
+    _require_int(role, base + ("min_skills",))
+    _require_scalar(role, base + ("skill_ref_pattern",))
+    _require_scalar(role, base + ("capability_ref_pattern",))
+
+
+def _validate_orphan_references(config: dict) -> None:
+    """Guard ``orphan_references.allowed_orphans``.
+
+    The key must be present, but its value may be blank (``""`` / a list)
+    — ``constants.py`` coerces the empty form to an empty list.  Only a
+    mapping is rejected here as a structural error.
+    """
+    base = ("orphan_references",)
+    orphan = _require_mapping(config, base)
+    value = _require_key(orphan, base + ("allowed_orphans",))
+    if isinstance(value, dict):
+        raise ConfigurationError(
+            f"key '{_format_path(base + ('allowed_orphans',))}' in "
+            f"{CONFIG_FILE_NAME}: expected a list (or blank), got "
+            f"{type(value).__name__}"
+        )
+
+
+def _validate_bundle(config: dict) -> None:
+    """Guard ``bundle`` and its long_path subtree."""
+    base = ("bundle",)
+    bundle = _require_mapping(config, base)
+    _require_int(bundle, base + ("max_reference_depth",))
+    _require_int(bundle, base + ("description_max_length",))
+    _require_int(bundle, base + ("infer_max_walk_depth",))
+    _require_list(bundle, base + ("exclude_patterns",))
+    _require_list(bundle, base + ("valid_targets",))
+    _require_scalar(bundle, base + ("default_target",))
+
+    lp_base = base + ("long_path",)
+    long_path = _require_mapping(bundle, lp_base)
+    _require_int(long_path, lp_base + ("threshold",))
+    _require_int(long_path, lp_base + ("user_prefix_budget",))
+
+
+def _validate_stats(config: dict) -> None:
+    """Guard ``stats.line_endings``."""
+    base = ("stats",)
+    stats = _require_mapping(config, base)
+    _require_mapping(stats, base + ("line_endings",))
+    # ``enabled`` is optional (constants.py uses .get with a default and
+    # validates the value when present), so it is not required here.

--- a/skill-system-foundry/scripts/lib/config_validation.py
+++ b/skill-system-foundry/scripts/lib/config_validation.py
@@ -16,7 +16,7 @@ first problem it raises :class:`ConfigurationError` with a message that
 names the offending dotted key path, e.g.::
 
     ConfigurationError: missing required key
-    'skill.description.evaluation.thresholds' in configuration.yaml
+    'skill.description.evaluation.default_min_precision' in configuration.yaml
 
 The scope is deliberately narrow: this is not a general JSON-schema
 engine.  It validates the structural shape ``constants.py`` relies on so

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -17,6 +17,7 @@ LEVEL_WARN = "WARN"
 LEVEL_INFO = "INFO"
 
 from .yaml_parser import parse_yaml_subset
+from .config_validation import validate_config_structure
 
 # ===================================================================
 # Script Internals (structural — rarely changes)
@@ -102,6 +103,15 @@ CONFIG_PATH = os.path.abspath(
 # _check_plain_scalar imports PLAIN_SCALAR_INDICATORS from this module.
 with open(CONFIG_PATH, "r", encoding="utf-8") as _f:
     _config = parse_yaml_subset(_f.read())
+
+# Structure validation runs before any dereference below so a missing or
+# wrong-typed key produces a clear ConfigurationError naming the offending
+# dotted key path (e.g. 'skill.description.evaluation') instead of a bare
+# KeyError / TypeError / ValueError from the constant assignments that
+# follow.  The deeper per-entry semantic checks (empty / duplicate /
+# traversal list entries, integer range bounds) stay inline below where
+# the normalized values are produced.
+validate_config_structure(_config)
 
 _CONFIG_FINDINGS: list[str] | None = None
 
@@ -221,30 +231,11 @@ RE_IMPERATIVE_START = re.compile(_voice["imperative_start"])
 # lib/description_eval.py and the evaluate_descriptions.py entry point.
 # The custom YAML parser returns every scalar as a string, so counts go
 # through int(), thresholds/ratios through float(); the stopword list passes
-# through as a frozenset.
-if "evaluation" not in _skill_desc:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'skill.description.evaluation'; update your checkout or restore the "
-        "full configuration file."
-    )
+# through as a frozenset.  Presence and shape of the section and its
+# required keys are guaranteed by validate_config_structure (called above);
+# the per-entry semantic checks below (empty / non-string entries) are
+# unique to this loader.
 _eval = _skill_desc["evaluation"]
-if not isinstance(_eval, dict):
-    raise RuntimeError(
-        "configuration.yaml has invalid value for "
-        f"'skill.description.evaluation': expected a mapping, got {_eval!r}."
-    )
-_required_eval_keys = (
-    "default_min_precision", "default_min_recall", "heuristic_min_overlap",
-    "max_prompt_chars", "diversity_distinct_bigram_min_ratio",
-    "min_prompts_per_side", "recommended_prompts_per_side", "stopwords",
-)
-_missing_eval = [_k for _k in _required_eval_keys if _k not in _eval]
-if _missing_eval:
-    raise RuntimeError(
-        "configuration.yaml 'skill.description.evaluation' is missing required "
-        f"keys: {', '.join(_missing_eval)}."
-    )
 EVAL_DEFAULT_MIN_PRECISION = float(_eval["default_min_precision"])
 EVAL_DEFAULT_MIN_RECALL = float(_eval["default_min_recall"])
 EVAL_HEURISTIC_MIN_OVERLAP = float(_eval["heuristic_min_overlap"])
@@ -272,33 +263,16 @@ EVAL_STOPWORDS = frozenset(_normalized_stopwords)
 # the skill-root self-check (no corpus under the skill) stays quiet.
 # The size-escalation rule reuses EVAL_MIN_PROMPTS / EVAL_RECOMMENDED_
 # PROMPTS above rather than a parallel floor that could drift.
-if "coverage" not in _eval:
-    raise RuntimeError(
-        "configuration.yaml is missing required key "
-        "'skill.description.evaluation.coverage'; update your checkout."
-    )
+# Presence and mapping-shape of the coverage block and presence of
+# corpus_root_relative are guaranteed by validate_config_structure
+# (called above); the non-string / path-traversal semantic checks below
+# are unique to this loader.
 _coverage = _eval["coverage"]
-if not isinstance(_coverage, dict):
-    raise RuntimeError(
-        "configuration.yaml has invalid value for "
-        "'skill.description.evaluation.coverage': expected a mapping, got "
-        f"{type(_coverage).__name__}."
-    )
-if "corpus_root_relative" not in _coverage:
-    raise RuntimeError(
-        "configuration.yaml is missing required key "
-        "'skill.description.evaluation.coverage.corpus_root_relative'."
-    )
-# Reject non-string YAML values (a list / mapping survives ``str(...)`` as a
-# bogus path like ``['tests/skill-corpus']`` and would self-skip coverage
-# instead of failing fast) — the loader exposes typed, fail-fast constants.
+# A scalar string value for corpus_root_relative is guaranteed by
+# validate_config_structure (a list / mapping is rejected there as a
+# non-scalar, naming the key); the path-traversal semantic checks below
+# are unique to this loader.
 _corpus_root_raw = _coverage["corpus_root_relative"]
-if not isinstance(_corpus_root_raw, str):
-    raise RuntimeError(
-        "configuration.yaml has invalid value for "
-        "'skill.description.evaluation.coverage.corpus_root_relative': "
-        f"expected a string, got {type(_corpus_root_raw).__name__}."
-    )
 EVAL_COVERAGE_CORPUS_ROOT = _corpus_root_raw.replace("\\", "/").strip()
 if EVAL_COVERAGE_CORPUS_ROOT.startswith("./"):
     EVAL_COVERAGE_CORPUS_ROOT = EVAL_COVERAGE_CORPUS_ROOT[2:]
@@ -389,14 +363,11 @@ EVAL_COVERAGE_ALLOWED_MISSING = tuple(_normalized_missing)
 # way RESERVED_NAMES does.  Empty / whitespace-only entries are
 # rejected at load time: a substring match against an empty string
 # always succeeds, which would silently neuter the rule.
-if "trigger_phrases" not in _skill_desc:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'skill.description.trigger_phrases'; update your checkout "
-        "or restore the full configuration file."
-    )
+# Presence and list-shape are guaranteed by validate_config_structure
+# (called above); the non-empty / empty-entry / duplicate semantic
+# checks below are unique to this loader.
 _raw_trigger_phrases = _skill_desc["trigger_phrases"]
-if not isinstance(_raw_trigger_phrases, list) or not _raw_trigger_phrases:
+if not _raw_trigger_phrases:
     raise RuntimeError(
         "configuration.yaml has invalid value for "
         "'skill.description.trigger_phrases': expected a non-empty "
@@ -453,19 +424,10 @@ DESCRIPTION_TRIGGER_EXAMPLE_PHRASES = tuple(_example_phrases_buffer)
 # tuples and the stopword list as a frozenset.  Fail-fast on a missing
 # or malformed section mirrors the trigger_phrases / evaluation loaders
 # above so a stale checkout errors loudly at import.
-if "structural_rules" not in _skill_desc:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'skill.description.structural_rules'; update your checkout "
-        "or restore the full configuration file."
-    )
+# Presence and mapping-shape are guaranteed by validate_config_structure
+# (called above); the per-key presence, list-shape, and per-entry
+# semantic checks below (via the helpers) are unique to this loader.
 _structural = _skill_desc["structural_rules"]
-if not isinstance(_structural, dict):
-    raise RuntimeError(
-        "configuration.yaml has invalid value for "
-        "'skill.description.structural_rules': expected a mapping, got "
-        f"{_structural!r}."
-    )
 
 
 def _require_structural_key(structural: dict, key: str) -> object:
@@ -628,22 +590,10 @@ del _structural, _require_structural_key, _normalize_structural_phrases
 # the body regex consumes the *validated* extension tuple — empty,
 # dotted, whitespace-bearing, or duplicate entries fail loudly at
 # import instead of silently neutering reference extraction.
-if "path_resolution" not in _config:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'path_resolution'; this foundry build is incomplete."
-    )
+# Presence and shape of path_resolution and its keys are guaranteed by
+# validate_config_structure (called above); the empty-value, per-entry,
+# and range semantic checks below are unique to this loader.
 _path_resolution = _config["path_resolution"]
-if "rule_name" not in _path_resolution:
-    raise RuntimeError(
-        "configuration.yaml is missing required key "
-        "'path_resolution.rule_name'."
-    )
-if "documentation_path" not in _path_resolution:
-    raise RuntimeError(
-        "configuration.yaml is missing required key "
-        "'path_resolution.documentation_path'."
-    )
 PATH_RESOLUTION_RULE_NAME = str(_path_resolution["rule_name"]).strip()
 PATH_RESOLUTION_DOC_PATH = str(_path_resolution["documentation_path"]).strip()
 if not PATH_RESOLUTION_RULE_NAME:
@@ -656,13 +606,8 @@ if not PATH_RESOLUTION_DOC_PATH:
         "configuration.yaml has an empty value for "
         "'path_resolution.documentation_path'."
     )
-if "reference_extensions" not in _path_resolution:
-    raise RuntimeError(
-        "configuration.yaml is missing required key "
-        "'path_resolution.reference_extensions'."
-    )
 _raw_extensions = _path_resolution["reference_extensions"]
-if not isinstance(_raw_extensions, list) or not _raw_extensions:
+if not _raw_extensions:
     raise RuntimeError(
         "configuration.yaml 'path_resolution.reference_extensions' "
         "must be a non-empty list."
@@ -724,17 +669,11 @@ del _raw_extensions, _normalized_extensions, _seen_extensions
 # foundry's text extensions.  The byte cap and extension allow-list
 # live in YAML so integrators can audit and tune the rule from the
 # single source of truth.
-if "degraded_symlink" not in _path_resolution:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'path_resolution.degraded_symlink'; update your checkout."
-    )
+# Presence and shape of degraded_symlink, max_bytes, and
+# foundry_extensions are guaranteed by validate_config_structure (called
+# above); the positive-value, non-empty, and per-entry semantic checks
+# below are unique to this loader.
 _degraded_symlink_cfg = _path_resolution["degraded_symlink"]
-if "max_bytes" not in _degraded_symlink_cfg:
-    raise RuntimeError(
-        "configuration.yaml is missing "
-        "'path_resolution.degraded_symlink.max_bytes'."
-    )
 DEGRADED_SYMLINK_MAX_BYTES = int(_degraded_symlink_cfg["max_bytes"])
 if DEGRADED_SYMLINK_MAX_BYTES <= 0:
     raise RuntimeError(
@@ -742,13 +681,8 @@ if DEGRADED_SYMLINK_MAX_BYTES <= 0:
         "'path_resolution.degraded_symlink.max_bytes': "
         f"{DEGRADED_SYMLINK_MAX_BYTES} (must be positive)."
     )
-if "foundry_extensions" not in _degraded_symlink_cfg:
-    raise RuntimeError(
-        "configuration.yaml is missing "
-        "'path_resolution.degraded_symlink.foundry_extensions'."
-    )
 _raw_shim_exts = _degraded_symlink_cfg["foundry_extensions"]
-if not isinstance(_raw_shim_exts, list) or not _raw_shim_exts:
+if not _raw_shim_exts:
     raise RuntimeError(
         "configuration.yaml has invalid value for "
         "'path_resolution.degraded_symlink.foundry_extensions': "
@@ -835,14 +769,9 @@ MAX_COMPATIBILITY_CHARS = int(_skill["compatibility"]["max_length"])
 KNOWN_FRONTMATTER_KEYS = frozenset(_skill["known_frontmatter_keys"])
 
 # "Did you mean?" suggestion parameters (difflib.get_close_matches).
-# Fail-fast so a stale checkout missing this section produces a clear
-# error at import rather than a later bare KeyError.
-if "frontmatter_suggestions" not in _skill:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'skill.frontmatter_suggestions'; update your checkout or "
-        "restore the full configuration file."
-    )
+# Presence and shape of the section and its max_matches / cutoff scalars
+# are guaranteed by validate_config_structure (called above); the range
+# semantic checks below are unique to this loader.
 _fm_suggest = _skill["frontmatter_suggestions"]
 FRONTMATTER_SUGGEST_MAX_MATCHES = int(_fm_suggest["max_matches"])
 if FRONTMATTER_SUGGEST_MAX_MATCHES <= 0:
@@ -865,20 +794,9 @@ MAX_ALLOWED_TOOLS = int(_allowed_tools["max_tools"])
 
 # Per-harness tool catalogs.  Today only ``claude_code`` consumes the
 # ``allowed-tools`` field; new harnesses go alongside as additional
-# buckets.  Fail-fast so a stale checkout missing the catalog produces
-# a clear error at import rather than a silent ``KeyError`` later.
-if "catalogs" not in _allowed_tools:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'skill.allowed_tools.catalogs'; update your checkout or "
-        "restore the full configuration file."
-    )
+# buckets.  Presence and shape of catalogs and the claude_code catalog
+# are guaranteed by validate_config_structure (called above).
 _catalogs = _allowed_tools["catalogs"]
-if "claude_code" not in _catalogs:
-    raise RuntimeError(
-        "configuration.yaml is missing required catalog "
-        "'skill.allowed_tools.catalogs.claude_code'."
-    )
 _claude_code_catalog = _catalogs["claude_code"]
 HARNESS_TOOLS_CLAUDE_CODE = frozenset(_claude_code_catalog["harness_tools"])
 CLI_TOOLS_CLAUDE_CODE = frozenset(_claude_code_catalog["cli_tools"])
@@ -898,18 +816,8 @@ KNOWN_TOOLS = HARNESS_TOOLS_CLAUDE_CODE | CLI_TOOLS_CLAUDE_CODE
 #   add *)``) via ``_RE_PAREN_ARGS`` in ``validation`` *before*
 #   applying this regex, so the regex itself does not need to model
 #   parens.
-if "mcp_tool_pattern" not in _allowed_tools:
-    raise RuntimeError(
-        "configuration.yaml is missing required pattern "
-        "'skill.allowed_tools.mcp_tool_pattern'; this foundry build "
-        "is incomplete."
-    )
-if "harness_tool_shape_pattern" not in _allowed_tools:
-    raise RuntimeError(
-        "configuration.yaml is missing required pattern "
-        "'skill.allowed_tools.harness_tool_shape_pattern'; this "
-        "foundry build is incomplete."
-    )
+# Presence of both patterns is guaranteed by validate_config_structure
+# (called above).
 RE_MCP_TOOL_NAME = re.compile(_allowed_tools["mcp_tool_pattern"])
 RE_HARNESS_TOOL_SHAPE = re.compile(_allowed_tools["harness_tool_shape_pattern"])
 
@@ -921,12 +829,9 @@ RE_HARNESS_TOOL_SHAPE = re.compile(_allowed_tools["harness_tool_shape_pattern"])
 # expected to be declared whenever the skill carries a top-level
 # ``scripts/`` directory (WARN, not FAIL — non-shell ``scripts/``
 # trees are legitimate).  Adding a tool is a YAML edit only.
-if "fence_languages" not in _allowed_tools:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'skill.allowed_tools.fence_languages'; this foundry build "
-        "is incomplete."
-    )
+# Presence and shape of fence_languages (a mapping of tool-name to an
+# entry with a ``languages`` list) are guaranteed by
+# validate_config_structure (called above).
 _fence_languages = _allowed_tools["fence_languages"]
 TOOL_FENCE_LANGUAGES: dict[str, frozenset[str]] = {
     tool_name: frozenset(entry["languages"])
@@ -959,36 +864,13 @@ RECOGNIZED_DIRS = frozenset(_skill["recognized_subdirectories"])
 # them get an INFO redirect.  Dotted entries (``metadata.author``)
 # traverse nested mappings.  The list is YAML-driven so adding a new
 # field is a configuration edit only.
-if "capability_frontmatter" not in _skill:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'skill.capability_frontmatter'; this foundry build is "
-        "incomplete."
-    )
+# Presence and mapping-shape of capability_frontmatter, and the
+# list-shape of skill_only_fields, are guaranteed by
+# validate_config_structure (called above); the non-empty / empty-entry
+# / duplicate semantic checks below are unique to this loader.
 _capability_frontmatter = _skill["capability_frontmatter"]
-# Reject scalar / list shapes before indexing — a typo like
-# ``capability_frontmatter: []`` would otherwise pass the ``in``
-# check (lists support ``in`` for elements) and crash with a bare
-# ``TypeError`` on the next subscript, breaking the fail-fast
-# RuntimeError contract used elsewhere in this loader.
-if not isinstance(_capability_frontmatter, dict):
-    raise RuntimeError(
-        "configuration.yaml has invalid value for "
-        "'skill.capability_frontmatter': expected a mapping, got "
-        f"{type(_capability_frontmatter).__name__}."
-    )
-if "skill_only_fields" not in _capability_frontmatter:
-    raise RuntimeError(
-        "configuration.yaml is missing required list "
-        "'skill.capability_frontmatter.skill_only_fields'; this "
-        "foundry build is incomplete."
-    )
-# Fail-fast normalization mirrors the trigger_phrases handling above.
-# A malformed list (empty, non-list, empty entries, duplicates) would
-# otherwise silently neuter the skill-only-fields rule and let
-# capability frontmatter drift land without a finding.
 _raw_skill_only_fields = _capability_frontmatter["skill_only_fields"]
-if not isinstance(_raw_skill_only_fields, list) or not _raw_skill_only_fields:
+if not _raw_skill_only_fields:
     raise RuntimeError(
         "configuration.yaml has invalid value for "
         "'skill.capability_frontmatter.skill_only_fields': expected "
@@ -1046,21 +928,11 @@ RE_SKILL_REF = re.compile(_role["skill_ref_pattern"])
 RE_CAPABILITY_REF = re.compile(_role["capability_ref_pattern"])
 
 # --- Orphan Reference Audit ---
-# Fail-fast when the section is missing so a stale checkout produces a
-# clear error at import rather than a silent KeyError later.
-if "orphan_references" not in _config:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'orphan_references'; this foundry build is incomplete."
-    )
+# Presence of the section and the allowed_orphans key (which may be
+# blank) is guaranteed by validate_config_structure (called above); the
+# blank-coercion, list-shape, and per-entry semantic checks below are
+# unique to this loader.
 _orphan_refs = _config["orphan_references"]
-if "allowed_orphans" not in _orphan_refs:
-    raise RuntimeError(
-        "configuration.yaml is missing required key "
-        "'orphan_references.allowed_orphans'; leave the value blank "
-        "(or list block-style entries beneath it) to keep the rule "
-        "fully active."
-    )
 _raw_allowed_orphans = _orphan_refs["allowed_orphans"]
 # A key with no value (``allowed_orphans:`` followed by no items) is
 # returned as ``""`` by the YAML subset parser; ``None`` is also
@@ -1145,12 +1017,9 @@ BUNDLE_DEFAULT_TARGET = _bundle["default_target"]
 # reserves space for a representative install location
 # (``C:\\Users\\<name>\\<repo>\\`` style) so the rule fires on the
 # arcname length the integrator can actually control.
-if "long_path" not in _bundle:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'bundle.long_path'; update your checkout or restore the "
-        "full configuration file."
-    )
+# Presence and shape of long_path and its threshold / user_prefix_budget
+# integers are guaranteed by validate_config_structure (called above);
+# the range / ordering semantic checks below are unique to this loader.
 _long_path = _bundle["long_path"]
 LONG_PATH_THRESHOLD = int(_long_path["threshold"])
 LONG_PATH_USER_PREFIX_BUDGET = int(_long_path["user_prefix_budget"])
@@ -1174,17 +1043,10 @@ if LONG_PATH_USER_PREFIX_BUDGET >= LONG_PATH_THRESHOLD:
 # integrators can opt out without code changes; the fields it gates
 # (``line_endings`` per file, ``*_lf`` aggregates) are additive — the
 # raw byte counts continue to be reported regardless.
-if "stats" not in _config:
-    raise RuntimeError(
-        "configuration.yaml is missing required section 'stats'; "
-        "update your checkout or restore the full configuration file."
-    )
+# Presence and mapping-shape of stats and stats.line_endings are
+# guaranteed by validate_config_structure (called above); the
+# enabled-value semantic check below is unique to this loader.
 _stats = _config["stats"]
-if "line_endings" not in _stats:
-    raise RuntimeError(
-        "configuration.yaml is missing required section "
-        "'stats.line_endings'; update your checkout."
-    )
 _stats_le = _stats["line_endings"]
 _stats_le_enabled = str(
     _stats_le.get("enabled", "true")
@@ -1200,23 +1062,15 @@ if _stats_le_enabled not in ("true", "false"):
 STATS_LINE_ENDINGS_ENABLED = _stats_le_enabled == "true"
 
 # --- Prose YAML Validation ---
-# Fail-fast: a stale checkout missing this section produces a clear
-# error at import rather than a subtle KeyError later.
-if "prose_yaml" not in _config:
-    raise RuntimeError(
-        "configuration.yaml is missing required section 'prose_yaml'; "
-        "this foundry build is incomplete."
-    )
+# Presence and shape of prose_yaml and its keys are guaranteed by
+# validate_config_structure (called above).
 _prose = _config["prose_yaml"]
 PROSE_YAML_OPT_OUT_MARKER = _prose["opt_out_marker"]
 PROSE_YAML_IN_SCOPE_GLOBS = tuple(_prose["in_scope_globs"])
 
 # --- YAML Conformance (construct-id enumeration) ---
-if "yaml_conformance" not in _config:
-    raise RuntimeError(
-        "configuration.yaml is missing required section 'yaml_conformance'; "
-        "this foundry build is incomplete."
-    )
+# Presence and shape of yaml_conformance.construct_ids are guaranteed by
+# validate_config_structure (called above).
 _yaml_conf = _config["yaml_conformance"]
 YAML_CONFORMANCE_CONSTRUCT_IDS = tuple(_yaml_conf["construct_ids"])
 
@@ -1251,6 +1105,6 @@ del _path_resolution
 del _stats, _stats_le, _stats_le_enabled
 del _codex, _codex_iface, _codex_deps
 del _prose, _yaml_conf
-del _eval, _required_eval_keys, _missing_eval, _stopwords, _normalized_stopwords
+del _eval, _stopwords, _normalized_stopwords
 del _coverage, _cov_freshness, _raw_allowed_missing, _normalized_missing
 del _corpus_root_raw

--- a/skill-system-foundry/scripts/lib/constants.py
+++ b/skill-system-foundry/scripts/lib/constants.py
@@ -424,9 +424,16 @@ DESCRIPTION_TRIGGER_EXAMPLE_PHRASES = tuple(_example_phrases_buffer)
 # tuples and the stopword list as a frozenset.  Fail-fast on a missing
 # or malformed section mirrors the trigger_phrases / evaluation loaders
 # above so a stale checkout errors loudly at import.
-# Presence and mapping-shape are guaranteed by validate_config_structure
-# (called above); the per-key presence, list-shape, and per-entry
-# semantic checks below (via the helpers) are unique to this loader.
+# Presence and shape of every key under structural_rules — mapping,
+# lists, and the int/float scalars — are guaranteed by
+# validate_config_structure (called above).  The helpers below add the
+# semantic layer that is unique to this loader: per-entry checks
+# (non-string / empty / duplicate phrases) and integer range bounds
+# (trigger_minimum_count >= 1, filler_lookahead_tokens >= 1,
+# length_tier_warn_below < length_tier_warn_above, vocabulary_minimum
+# >= 1).  The helpers also re-check presence and list-shape inline so
+# their error messages remain specific if the loader is ever invoked
+# without the structural validator running first.
 _structural = _skill_desc["structural_rules"]
 
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,456 @@
+"""Tests for lib.config_validation — load-time structure validation.
+
+``validate_config_structure`` guards every key path ``constants.py``
+dereferences from the parsed ``configuration.yaml``.  These tests run the
+validator in ISOLATION against plain dicts (never the on-disk file) so a
+missing or wrong-typed key is shown to raise ``ConfigurationError`` with a
+message naming the offending dotted key path.
+
+The canonical valid fixture is built by parsing the shipped
+``configuration.yaml`` once and deep-copying it per test, so the
+happy-path assertion tracks the real file and each mutation starts from a
+structure the validator accepts.
+"""
+
+import copy
+import os
+import sys
+import unittest
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "skill-system-foundry", "scripts")
+)
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
+
+from lib.config_validation import (
+    ConfigurationError,
+    validate_config_structure,
+)
+from lib.yaml_parser import parse_yaml_subset
+
+_CONFIG_PATH = os.path.join(SCRIPTS_DIR, "lib", "configuration.yaml")
+
+with open(_CONFIG_PATH, "r", encoding="utf-8") as _fh:
+    _VALID_CONFIG = parse_yaml_subset(_fh.read())
+
+
+def valid_config() -> dict:
+    """Return a fresh deep copy of the parsed shipped configuration."""
+    return copy.deepcopy(_VALID_CONFIG)
+
+
+def _delete(config: dict, dotted: str) -> None:
+    """Delete the leaf addressed by *dotted* (``a.b.c``) from *config*."""
+    parts = dotted.split(".")
+    node = config
+    for part in parts[:-1]:
+        node = node[part]
+    del node[parts[-1]]
+
+
+def _set(config: dict, dotted: str, value: object) -> None:
+    """Set the leaf addressed by *dotted* (``a.b.c``) in *config*."""
+    parts = dotted.split(".")
+    node = config
+    for part in parts[:-1]:
+        node = node[part]
+    node[parts[-1]] = value
+
+
+# ===================================================================
+# Happy Path
+# ===================================================================
+
+
+class ValidConfigTests(unittest.TestCase):
+    """The shipped configuration passes structure validation."""
+
+    def test_shipped_config_passes(self) -> None:
+        # validate_config_structure returns None on a well-formed config.
+        self.assertIsNone(validate_config_structure(valid_config()))
+
+    def test_repeated_calls_do_not_mutate_config(self) -> None:
+        config = valid_config()
+        before = copy.deepcopy(config)
+        validate_config_structure(config)
+        validate_config_structure(config)
+        self.assertEqual(config, before)
+
+
+# ===================================================================
+# Top-level shape
+# ===================================================================
+
+
+class TopLevelShapeTests(unittest.TestCase):
+    """A non-mapping top level is rejected with a clear message."""
+
+    def test_non_dict_top_level_raises(self) -> None:
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure([])  # type: ignore[arg-type]
+        self.assertIn("did not parse to a mapping", str(ctx.exception))
+
+    def test_empty_dict_names_first_missing_section(self) -> None:
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure({})
+        self.assertIn("skill", str(ctx.exception))
+        self.assertIn("configuration.yaml", str(ctx.exception))
+
+
+# ===================================================================
+# Missing top-level sections
+# ===================================================================
+
+
+class MissingTopSectionTests(unittest.TestCase):
+    """Each consumed top-level section, when absent, raises naming it."""
+
+    def _assert_missing_raises(self, section: str) -> None:
+        config = valid_config()
+        del config[section]
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn(section, msg)
+        self.assertIn("configuration.yaml", msg)
+
+    def test_missing_skill_raises(self) -> None:
+        self._assert_missing_raises("skill")
+
+    def test_missing_plain_scalar_raises(self) -> None:
+        self._assert_missing_raises("plain_scalar")
+
+    def test_missing_path_resolution_raises(self) -> None:
+        self._assert_missing_raises("path_resolution")
+
+    def test_missing_prose_yaml_raises(self) -> None:
+        self._assert_missing_raises("prose_yaml")
+
+    def test_missing_yaml_conformance_raises(self) -> None:
+        self._assert_missing_raises("yaml_conformance")
+
+    def test_missing_codex_config_raises(self) -> None:
+        self._assert_missing_raises("codex_config")
+
+    def test_missing_dependency_direction_raises(self) -> None:
+        self._assert_missing_raises("dependency_direction")
+
+    def test_missing_role_composition_raises(self) -> None:
+        self._assert_missing_raises("role_composition")
+
+    def test_missing_orphan_references_raises(self) -> None:
+        self._assert_missing_raises("orphan_references")
+
+    def test_missing_bundle_raises(self) -> None:
+        self._assert_missing_raises("bundle")
+
+    def test_missing_stats_raises(self) -> None:
+        self._assert_missing_raises("stats")
+
+
+# ===================================================================
+# Missing nested keys — message names the full dotted path
+# ===================================================================
+
+
+class MissingNestedKeyTests(unittest.TestCase):
+    """Removing a consumed nested key raises a message naming the path."""
+
+    def _assert_missing_path_raises(self, dotted: str) -> None:
+        config = valid_config()
+        _delete(config, dotted)
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        self.assertIn(dotted, str(ctx.exception))
+
+    def test_missing_skill_name_max_length(self) -> None:
+        self._assert_missing_path_raises("skill.name.max_length")
+
+    def test_missing_skill_description_max_length(self) -> None:
+        self._assert_missing_path_raises("skill.description.max_length")
+
+    def test_missing_evaluation(self) -> None:
+        self._assert_missing_path_raises("skill.description.evaluation")
+
+    def test_missing_evaluation_thresholds_member(self) -> None:
+        self._assert_missing_path_raises(
+            "skill.description.evaluation.default_min_precision"
+        )
+
+    def test_missing_evaluation_coverage(self) -> None:
+        self._assert_missing_path_raises(
+            "skill.description.evaluation.coverage"
+        )
+
+    def test_missing_evaluation_coverage_corpus_root(self) -> None:
+        self._assert_missing_path_raises(
+            "skill.description.evaluation.coverage.corpus_root_relative"
+        )
+
+    def test_missing_structural_rules(self) -> None:
+        self._assert_missing_path_raises(
+            "skill.description.structural_rules"
+        )
+
+    def test_missing_structural_rules_member(self) -> None:
+        self._assert_missing_path_raises(
+            "skill.description.structural_rules.redundancy_max_ratio"
+        )
+
+    def test_missing_voice_pattern(self) -> None:
+        self._assert_missing_path_raises(
+            "skill.description.voice_patterns.first_person"
+        )
+
+    def test_missing_body_max_lines(self) -> None:
+        self._assert_missing_path_raises("skill.body.max_lines")
+
+    def test_missing_reference_pattern(self) -> None:
+        self._assert_missing_path_raises(
+            "skill.body.reference_patterns.markdown_link"
+        )
+
+    def test_missing_allowed_tools_max_tools(self) -> None:
+        self._assert_missing_path_raises("skill.allowed_tools.max_tools")
+
+    def test_missing_catalogs_claude_code(self) -> None:
+        self._assert_missing_path_raises(
+            "skill.allowed_tools.catalogs.claude_code"
+        )
+
+    def test_missing_claude_code_harness_tools(self) -> None:
+        self._assert_missing_path_raises(
+            "skill.allowed_tools.catalogs.claude_code.harness_tools"
+        )
+
+    def test_missing_metadata_version_pattern(self) -> None:
+        self._assert_missing_path_raises("skill.metadata.version.pattern")
+
+    def test_missing_license_known_spdx(self) -> None:
+        self._assert_missing_path_raises("skill.license.known_spdx")
+
+    def test_missing_capability_frontmatter_skill_only_fields(self) -> None:
+        self._assert_missing_path_raises(
+            "skill.capability_frontmatter.skill_only_fields"
+        )
+
+    def test_missing_path_resolution_reference_extensions(self) -> None:
+        self._assert_missing_path_raises(
+            "path_resolution.reference_extensions"
+        )
+
+    def test_missing_degraded_symlink_max_bytes(self) -> None:
+        self._assert_missing_path_raises(
+            "path_resolution.degraded_symlink.max_bytes"
+        )
+
+    def test_missing_bundle_long_path_threshold(self) -> None:
+        self._assert_missing_path_raises("bundle.long_path.threshold")
+
+    def test_missing_codex_interface_hex_color(self) -> None:
+        self._assert_missing_path_raises(
+            "codex_config.interface.hex_color_pattern"
+        )
+
+    def test_missing_role_min_skills(self) -> None:
+        self._assert_missing_path_raises("role_composition.min_skills")
+
+    def test_missing_stats_line_endings(self) -> None:
+        self._assert_missing_path_raises("stats.line_endings")
+
+    def test_missing_orphan_allowed_orphans(self) -> None:
+        self._assert_missing_path_raises(
+            "orphan_references.allowed_orphans"
+        )
+
+    def test_missing_prose_opt_out_marker(self) -> None:
+        self._assert_missing_path_raises("prose_yaml.opt_out_marker")
+
+
+# ===================================================================
+# Wrong shape — mapping / list / scalar mismatch
+# ===================================================================
+
+
+class WrongShapeTests(unittest.TestCase):
+    """A key authored with the wrong shape raises naming the path."""
+
+    def test_skill_scalar_where_mapping_expected(self) -> None:
+        config = valid_config()
+        config["skill"] = "oops"
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill", msg)
+        self.assertIn("expected a mapping", msg)
+
+    def test_evaluation_list_where_mapping_expected(self) -> None:
+        config = valid_config()
+        _set(config, "skill.description.evaluation", [])
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.description.evaluation", msg)
+        self.assertIn("expected a mapping", msg)
+
+    def test_capability_frontmatter_list_where_mapping_expected(self) -> None:
+        config = valid_config()
+        _set(config, "skill.capability_frontmatter", [])
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.capability_frontmatter", msg)
+        self.assertIn("expected a mapping", msg)
+
+    def test_reserved_words_scalar_where_list_expected(self) -> None:
+        config = valid_config()
+        _set(config, "skill.name.reserved_words", "claude")
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.name.reserved_words", msg)
+        self.assertIn("expected a list", msg)
+
+    def test_known_spdx_mapping_where_list_expected(self) -> None:
+        config = valid_config()
+        _set(config, "skill.license.known_spdx", {"a": "b"})
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.license.known_spdx", msg)
+        self.assertIn("expected a list", msg)
+
+    def test_format_pattern_mapping_where_scalar_expected(self) -> None:
+        config = valid_config()
+        _set(config, "skill.name.format_pattern", {"nested": "x"})
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.name.format_pattern", msg)
+        self.assertIn("expected a scalar", msg)
+
+    def test_default_target_list_where_scalar_expected(self) -> None:
+        config = valid_config()
+        _set(config, "bundle.default_target", ["claude"])
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("bundle.default_target", msg)
+        self.assertIn("expected a scalar", msg)
+
+    def test_fence_language_entry_non_mapping_raises(self) -> None:
+        config = valid_config()
+        _set(config, "skill.allowed_tools.fence_languages", {"Bash": []})
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.allowed_tools.fence_languages.Bash", msg)
+        self.assertIn("expected a mapping", msg)
+
+    def test_fence_language_missing_languages_list_raises(self) -> None:
+        config = valid_config()
+        _set(
+            config,
+            "skill.allowed_tools.fence_languages",
+            {"Bash": {"languages": "bash"}},
+        )
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn(
+            "skill.allowed_tools.fence_languages.Bash.languages", msg
+        )
+        self.assertIn("expected a list", msg)
+
+    def test_orphan_allowed_orphans_mapping_rejected(self) -> None:
+        config = valid_config()
+        _set(config, "orphan_references.allowed_orphans", {"a": "b"})
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("orphan_references.allowed_orphans", msg)
+        self.assertIn("expected a list", msg)
+
+    def test_orphan_allowed_orphans_blank_is_accepted(self) -> None:
+        # A key with no value parses as "" — the blank form is legal
+        # (constants.py coerces it to an empty list) and must not raise.
+        config = valid_config()
+        _set(config, "orphan_references.allowed_orphans", "")
+        self.assertIsNone(validate_config_structure(config))
+
+
+# ===================================================================
+# Malformed numerics — non-integer / non-float scalars
+# ===================================================================
+
+
+class MalformedNumericTests(unittest.TestCase):
+    """A scalar destined for int()/float() that does not convert raises
+    a message naming the key (not a bare ValueError)."""
+
+    def test_non_integer_max_length_raises(self) -> None:
+        config = valid_config()
+        _set(config, "skill.name.max_length", "sixty-four")
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.name.max_length", msg)
+        self.assertIn("expected an integer", msg)
+
+    def test_non_integer_body_max_lines_raises(self) -> None:
+        config = valid_config()
+        _set(config, "skill.body.max_lines", "lots")
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.body.max_lines", msg)
+        self.assertIn("expected an integer", msg)
+
+    def test_non_integer_long_path_threshold_raises(self) -> None:
+        config = valid_config()
+        _set(config, "bundle.long_path.threshold", "wide")
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("bundle.long_path.threshold", msg)
+        self.assertIn("expected an integer", msg)
+
+    def test_non_float_cutoff_raises(self) -> None:
+        config = valid_config()
+        _set(config, "skill.frontmatter_suggestions.cutoff", "high")
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.frontmatter_suggestions.cutoff", msg)
+        self.assertIn("expected a number", msg)
+
+    def test_non_float_redundancy_max_ratio_raises(self) -> None:
+        config = valid_config()
+        _set(
+            config,
+            "skill.description.structural_rules.redundancy_max_ratio",
+            "quarter",
+        )
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn(
+            "skill.description.structural_rules.redundancy_max_ratio", msg
+        )
+        self.assertIn("expected a number", msg)
+
+    def test_integer_destined_value_as_mapping_reports_scalar(self) -> None:
+        # An int key authored as a mapping is reported as a scalar
+        # mismatch (the shape check fires before the int() attempt).
+        config = valid_config()
+        _set(config, "skill.name.max_length", {"x": 1})
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.name.max_length", msg)
+        self.assertIn("expected a scalar", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -379,6 +379,41 @@ class WrongShapeTests(unittest.TestCase):
         _set(config, "orphan_references.allowed_orphans", "")
         self.assertIsNone(validate_config_structure(config))
 
+    def test_blank_section_rejected(self) -> None:
+        # A required mapping authored with no children parses as "" —
+        # constants.py would crash dereferencing it, so the validator
+        # must raise naming the section.
+        config = valid_config()
+        config["stats"] = ""
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("stats", msg)
+        self.assertIn("expected a mapping", msg)
+
+    def test_blank_fence_languages_rejected(self) -> None:
+        # Blank fence_languages would let constants.py crash on .items()
+        # since the leaf has no required children to catch the blank
+        # form downstream.
+        config = valid_config()
+        _set(config, "skill.allowed_tools.fence_languages", "")
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("skill.allowed_tools.fence_languages", msg)
+        self.assertIn("expected a mapping", msg)
+
+    def test_blank_stats_line_endings_rejected(self) -> None:
+        # Blank stats.line_endings would let constants.py crash on .get()
+        # since `enabled` is optional and would not be caught downstream.
+        config = valid_config()
+        _set(config, "stats.line_endings", "")
+        with self.assertRaises(ConfigurationError) as ctx:
+            validate_config_structure(config)
+        msg = str(ctx.exception)
+        self.assertIn("stats.line_endings", msg)
+        self.assertIn("expected a mapping", msg)
+
 
 # ===================================================================
 # Malformed numerics — non-integer / non-float scalars

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1340,11 +1340,17 @@ class MissingSectionFailFastTests(unittest.TestCase):
         self.assertIn("degraded_symlink", str(ctx.exception))
 
     def test_missing_stats_line_endings_raises(self) -> None:
+        # Removing the only child under ``stats:`` leaves the section
+        # blank ("") in the YAML subset; the structural validator
+        # rejects that at the parent level since constants.py would
+        # otherwise crash dereferencing it.
         with self.assertRaises(RuntimeError) as ctx:
             self._reimport_with_config(
                 self._full_config_minus_nested("stats", "line_endings")
             )
-        self.assertIn("line_endings", str(ctx.exception))
+        message = str(ctx.exception)
+        self.assertIn("stats", message)
+        self.assertIn("expected a mapping", message)
 
     def test_invalid_stats_line_endings_enabled_raises(self) -> None:
         with self.assertRaises(RuntimeError) as ctx:


### PR DESCRIPTION
Adds load-time structure validation for `configuration.yaml` so a missing or malformed key raises a clear `ConfigurationError` naming the offending dotted key path, instead of a bare `KeyError`/`TypeError` deep inside `constants.py` at import (FINDINGS F-12). A new `lib/config_validation.py` exposes `validate_config_structure(config)` that takes a plain dict so it is unit-testable in isolation; `constants.py` calls it immediately after the config is parsed. The validator subsumes the inline presence/shape guards previously scattered through `constants.py` (net -214 there) while every per-entry semantic guard — empty/duplicate/range/traversal — is retained. `ConfigurationError` subclasses `RuntimeError` so the existing fail-fast tests keep passing. Tests assert the shipped config validates unchanged, that each required key reported missing names its path, and that wrong-typed and malformed-numeric values fail clearly; full suite green, new module at 100%.
