### PR TITLE
Add Python 3.13 and 3.14 to CI test matrix

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -38,7 +38,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.12"]
+        # 3.12 is the required floor — only the (ubuntu, 3.12) and
+        # (windows, 3.12) contexts are listed as required status checks
+        # in the main ruleset. 3.13 and 3.14 are advisory (non-required)
+        # forward-compat signals exercising the project's "3.12+" claim.
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -73,13 +73,16 @@ jobs:
           PYTHONUTF8: "1"
 
       - name: Generate coverage JSON
+        # Only the 3.12 floor feeds the per-file coverage check below.
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         run: python -m coverage json
 
       - name: Check per-file coverage
-        # Coverage thresholds are enforced against the Ubuntu run only;
+        # Coverage thresholds are enforced against the Ubuntu 3.12 floor only;
         # Windows numbers are advisory because branch coverage can vary
-        # with platform-conditional code paths.
-        if: matrix.os == 'ubuntu-latest'
+        # with platform-conditional code paths, and 3.13/3.14 are advisory
+        # forward-compat signals.
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         run: |
           python .github/scripts/check-per-file-coverage.py \
             --file-threshold skill-system-foundry/scripts/lib/prose_yaml.py=90 \
@@ -92,31 +95,39 @@ jobs:
             --file-threshold skill-system-foundry/scripts/evaluate_descriptions.py=90
 
       - name: Generate coverage HTML report
-        if: always() && steps.run-tests.outcome != 'skipped'
+        # Gated to the 3.12 floor so the per-OS artifact name below
+        # stays unique across the matrix — upload-artifact@v4 rejects
+        # duplicate names within a run.
+        if: always() && steps.run-tests.outcome != 'skipped' && matrix.python-version == '3.12'
         run: python -m coverage html
 
       - name: Upload coverage report
-        if: always() && steps.run-tests.outcome != 'skipped'
+        if: always() && steps.run-tests.outcome != 'skipped' && matrix.python-version == '3.12'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # @v4 as 7.0.1
         with:
           name: coverage-report-${{ matrix.os }}
           path: htmlcov/
 
       - name: Write coverage total
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         run: |
           TOTAL_RAW=$(python -m coverage report --format=total --fail-under=0)
           TOTAL_STRIPPED=${TOTAL_RAW%\%}
           printf '%.0f\n' "$TOTAL_STRIPPED" > coverage-total.txt
 
       - name: Upload coverage total
-        if: matrix.os == 'ubuntu-latest'
+        # Gated to the 3.12 floor so the fixed artifact name stays
+        # unique across the matrix; coverage-badge.yaml downloads this
+        # exact name from the triggering run.
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # @v4 as 7.0.1
         with:
           name: coverage-total
           path: coverage-total.txt
 
       - name: Check coverage threshold
+        # Applies .coveragerc fail_under on every matrix cell as a
+        # cross-version regression gate; no artifact, so no collision.
         run: python -m coverage report
 
   validate-examples:

--- a/skill-system-foundry/scripts/lib/codex_config.py
+++ b/skill-system-foundry/scripts/lib/codex_config.py
@@ -13,6 +13,7 @@ part of the Agent Skills specification.
 
 import os
 
+from .references import is_posix_absolute
 from .yaml_parser import parse_yaml_subset
 from .constants import (
     FILE_CODEX_CONFIG,
@@ -470,9 +471,15 @@ def _is_valid_relative_path(path: str) -> bool:
         return False
     # Normalize backslashes first so that Windows-style absolute and
     # UNC paths (e.g., \\server\share\icon.svg → //server/share/icon.svg)
-    # are detected consistently on all platforms.
+    # are detected consistently on all platforms.  ``is_posix_absolute``
+    # catches the single-leading-slash form that ``os.path.isabs`` no
+    # longer reports as absolute on Windows under Python 3.13+.
     normalized = path.replace("\\", "/")
-    if os.path.isabs(normalized) or normalized.startswith("//"):
+    if (
+        os.path.isabs(normalized)
+        or normalized.startswith("//")
+        or is_posix_absolute(normalized)
+    ):
         return False
     # Reject Windows drive-letter absolute paths (e.g., C:/icons/icon.svg)
     # which os.path.isabs() does not catch on POSIX.

--- a/skill-system-foundry/scripts/lib/conformance.py
+++ b/skill-system-foundry/scripts/lib/conformance.py
@@ -23,7 +23,12 @@ from .constants import (
 )
 from .frontmatter import strip_frontmatter_for_scan
 from .reachability import extract_body_references
-from .references import is_drive_qualified, is_within_directory, strip_fragment
+from .references import (
+    is_drive_qualified,
+    is_posix_absolute,
+    is_within_directory,
+    strip_fragment,
+)
 from .router_table import extract_capability_paths
 
 
@@ -212,7 +217,11 @@ def _build_graph(
             # would also treat the path as drive-rooted on Windows,
             # so this branch must run before resolution to avoid
             # distorting the resolved/broken tally.
-            if os.path.isabs(normalized) or is_drive_qualified(normalized):
+            if (
+                os.path.isabs(normalized)
+                or is_drive_qualified(normalized)
+                or is_posix_absolute(normalized)
+            ):
                 total_links += 1
                 broken += 1
                 broken_rows.append((rel, ref))

--- a/skill-system-foundry/scripts/lib/path_rewriter.py
+++ b/skill-system-foundry/scripts/lib/path_rewriter.py
@@ -35,6 +35,7 @@ from .frontmatter import split_frontmatter, strip_frontmatter_for_scan
 from .references import (
     is_drive_qualified,
     is_glob_path,
+    is_posix_absolute,
     is_within_directory,
     should_skip_reference,
 )
@@ -152,6 +153,7 @@ def compute_recommended_replacement(
         not ref_norm
         or os.path.isabs(ref_norm)
         or is_drive_qualified(ref_norm)
+        or is_posix_absolute(ref_norm)
     ):
         return None
 
@@ -268,6 +270,7 @@ def detect_ambiguous_legacy_target(
         not ref_norm
         or os.path.isabs(ref_norm)
         or is_drive_qualified(ref_norm)
+        or is_posix_absolute(ref_norm)
     ):
         return None
     ref_path_only, _suffix = _split_path_and_suffix(ref_norm)

--- a/skill-system-foundry/scripts/lib/reachability.py
+++ b/skill-system-foundry/scripts/lib/reachability.py
@@ -37,6 +37,7 @@ from .references import (
     RE_FENCED_BLOCK,
     is_drive_qualified,
     is_glob_path,
+    is_posix_absolute,
     is_within_directory,
     should_skip_reference,
     strip_fragment,
@@ -332,7 +333,11 @@ def walk_reachable(
             # check ``os.path.join`` would treat the path as drive-
             # rooted on Windows and let the reference escape the
             # skill walk.
-            if os.path.isabs(ref) or is_drive_qualified(ref):
+            if (
+                os.path.isabs(ref)
+                or is_drive_qualified(ref)
+                or is_posix_absolute(ref)
+            ):
                 warnings.append(
                     f"{LEVEL_WARN}: [{PATH_RESOLUTION_RULE_NAME}] "
                     f"reference '{ref}' in '{rel}' is absolute or "

--- a/skill-system-foundry/scripts/lib/references.py
+++ b/skill-system-foundry/scripts/lib/references.py
@@ -284,6 +284,25 @@ def is_drive_qualified(path: str) -> bool:
     return is_ascii_letter and path[1] == ":"
 
 
+def is_posix_absolute(path: str) -> bool:
+    """Return True when *path* begins with a leading slash or backslash.
+
+    A reference that starts with ``/`` or ``\\`` (``/tmp/foo.md``,
+    ``\\foo.md``) is treated as absolute on every platform.
+    ``os.path.isabs`` cannot be relied on for this: under Python 3.13+
+    on Windows ``ntpath.isabs('/foo')`` returns ``False`` because a
+    single leading slash without a drive letter is no longer
+    Windows-absolute (PEP/CPython behavior change).  The foundry's
+    validation surface must reject these refs identically on every
+    runner — Ubuntu, Windows, and every supported Python version — so
+    the absolute-path check explicitly OR's this helper with
+    ``os.path.isabs`` and ``is_drive_qualified``.
+    """
+    if not path:
+        return False
+    return path[0] in ("/", "\\")
+
+
 def is_dangling_symlink(path: str) -> bool:
     """Return True when *path* is a symlink whose target does not exist.
 
@@ -882,7 +901,11 @@ def resolve_reference_with_reason(
     # platform-independent detection of the ``C:...`` form;
     # ``os.path.splitdrive`` would only catch it on Windows because
     # ``os.path`` is host-dependent.
-    if os.path.isabs(ref_path) or is_drive_qualified(ref_path):
+    if (
+        os.path.isabs(ref_path)
+        or is_drive_qualified(ref_path)
+        or is_posix_absolute(ref_path)
+    ):
         return None, "absolute_path"
 
     source_dir = os.path.dirname(os.path.abspath(source_file))

--- a/skill-system-foundry/scripts/lib/stats.py
+++ b/skill-system-foundry/scripts/lib/stats.py
@@ -45,7 +45,7 @@ from .constants import (
 )
 from .frontmatter import load_frontmatter, strip_frontmatter_for_scan
 from .reachability import extract_body_references
-from .references import is_drive_qualified, is_within_directory
+from .references import is_drive_qualified, is_posix_absolute, is_within_directory
 from .reporting import format_exception, to_posix
 
 
@@ -641,7 +641,11 @@ def compute_stats(skill_path: str) -> dict:
             # check ``os.path.join`` would treat the path as drive-
             # rooted on Windows and the byte-budget metric would
             # include a file outside the skill tree.
-            if os.path.isabs(ref) or is_drive_qualified(ref):
+            if (
+                os.path.isabs(ref)
+                or is_drive_qualified(ref)
+                or is_posix_absolute(ref)
+            ):
                 result["errors"].append(
                     f"{LEVEL_WARN}: [{PATH_RESOLUTION_RULE_NAME}] "
                     f"absolute or drive-qualified reference '{ref}' in "

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -26,6 +26,7 @@ from lib.references import (
     infer_system_root,
     is_dangling_symlink,
     is_drive_qualified,
+    is_posix_absolute,
     is_within_directory,
     resolve_case_exact,
     strip_fragment,
@@ -286,7 +287,11 @@ def _check_references(
         # ``os.path.isabs`` misses on every platform — using
         # ``os.path.splitdrive`` would only catch it on Windows
         # because ``os.path`` is host-dependent.
-        if os.path.isabs(normalized_ref) or is_drive_qualified(normalized_ref):
+        if (
+            os.path.isabs(normalized_ref)
+            or is_drive_qualified(normalized_ref)
+            or is_posix_absolute(normalized_ref)
+        ):
             errors.append(
                 f"{LEVEL_WARN}: [{PATH_RESOLUTION_RULE_NAME}] '{ref}' "
                 f"referenced in {source_label} (scope: {scope_tag}) "

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -24,6 +24,7 @@ from lib.references import (
     infer_system_root,
     is_dangling_symlink,
     is_drive_qualified,
+    is_posix_absolute,
     is_glob_path,
     is_within_directory,
     looks_like_ambiguous_one_line_shim,
@@ -184,6 +185,40 @@ class IsDriveQualifiedTests(unittest.TestCase):
         ):
             with self.subTest(ref=ref):
                 self.assertFalse(is_drive_qualified(ref), msg=ref)
+
+
+class IsPosixAbsoluteTests(unittest.TestCase):
+    """``is_posix_absolute`` recognizes leading-slash references on every
+    platform.  Python 3.13 changed ``ntpath.isabs`` so that
+    ``ntpath.isabs('/foo')`` returns ``False`` on Windows — the
+    foundry's absolute-path checks need a platform-independent
+    fallback so ``/tmp/foo.md`` and ``\\foo.md`` keep flagging on
+    every runner / interpreter.
+    """
+
+    def test_positive_cases(self) -> None:
+        for ref in (
+            "/tmp/foo.md",
+            "/foo.md",
+            "\\foo.md",
+            "\\\\server\\share\\foo.md",
+        ):
+            with self.subTest(ref=ref):
+                self.assertTrue(is_posix_absolute(ref), msg=ref)
+
+    def test_negative_cases(self) -> None:
+        for ref in (
+            "",
+            "foo.md",
+            "references/foo.md",
+            "./foo.md",
+            "../foo.md",
+            "C:foo.md",
+            "C:/foo.md",
+            "#fragment",
+        ):
+            with self.subTest(ref=ref):
+                self.assertFalse(is_posix_absolute(ref), msg=ref)
 
 
 class ShouldSkipReferenceTests(unittest.TestCase):


### PR DESCRIPTION
Adds Python 3.13 and 3.14 to the `test` job matrix in `python-tests.yaml` so CI exercises the project's stated 3.12+ compatibility (FINDINGS F-18). 3.12 stays the first matrix entry and the required floor — only `test (ubuntu-latest, 3.12)` and `test (windows-latest, 3.12)` are listed as required status checks in the main ruleset, so 3.13 and 3.14 add advisory (non-required) contexts and the existing required context names are unchanged. The OS matrix and the branch ruleset are untouched; an inline comment records the required-floor / advisory split. `actionlint` passes clean. Note: GitHub-hosted 3.14 provisioning via `actions/setup-python` may lag the runner image, and the 3.14 jobs are non-required so a transient failure there does not block merges.
