### PR TITLE
Add name normalization to validate_skill.py --fix

### DIFF
--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -260,10 +260,17 @@ def rewrite_name_line(content: str, new_name: str) -> str | None:
     fm_end = fm_start + len(frontmatter_raw)
     fm_text = content[fm_start:fm_end]
 
-    raw_match = _RE_NAME_LINE.search(fm_text)
-    if raw_match is None:
+    raw_matches = list(_RE_NAME_LINE.finditer(fm_text))
+    if not raw_matches:
         return None
-    raw_value = raw_match.group("value")
+    if len(raw_matches) > 1:
+        # Defense-in-depth: the planner already refuses duplicate-key
+        # frontmatter, but the line rewriter is also called directly
+        # from tests and any future caller.  Touching the first match
+        # while ``parse_yaml_subset`` reads the last would silently
+        # rewrite the wrong line.
+        return None
+    raw_value = raw_matches[0].group("value")
     if _raw_value_blocks_rewrite(raw_value):
         return None
 
@@ -361,8 +368,8 @@ def compute_name_fix_plan(
         )
         return None, applied, manual, errors, owned
 
-    raw_value_match = _RE_NAME_LINE.search(frontmatter_raw)
-    if raw_value_match is None:
+    raw_value_matches = list(_RE_NAME_LINE.finditer(frontmatter_raw))
+    if not raw_value_matches:
         # The parser saw a ``name`` key (flow-style mapping, alias, or
         # similar) but the line-oriented rewriter cannot target a single
         # physical line.  Refuse rather than guess.
@@ -372,6 +379,23 @@ def compute_name_fix_plan(
             "frontmatter by hand"
         )
         return None, applied, manual, errors, owned
+    if len(raw_value_matches) > 1:
+        # Duplicate ``name:`` keys: ``parse_yaml_subset`` resolves to
+        # the *last* mapping entry, but a line-targeted rewrite would
+        # only update the *first* — applying the fix would leave the
+        # effective value untouched while ownership-suppressing the
+        # validator FAILs, so ``--fix --apply`` could report success on
+        # a still-invalid skill.  The duplicate-key shape is itself a
+        # frontmatter authoring error the user needs to resolve by hand.
+        errors.append(
+            f"{LEVEL_FAIL}: [foundry] multiple 'name:' keys in "
+            f"frontmatter ({len(raw_value_matches)} found) — "
+            "parse_yaml_subset would use the last and the line "
+            "rewriter would touch the first; remove the duplicates by "
+            "hand"
+        )
+        return None, applied, manual, errors, owned
+    raw_value_match = raw_value_matches[0]
 
     current_name = parsed_fm["name"]
     if not isinstance(current_name, str):
@@ -397,7 +421,7 @@ def compute_name_fix_plan(
     manual.extend(fix_manual)
     owned.extend(fix_owned)
 
-    description = _extract_description_value(content, parsed_fm)
+    description = _extract_description_value(parsed_fm)
     desc_manual = compute_description_manual_finding(description)
     if desc_manual:
         manual.extend(desc_manual)
@@ -501,39 +525,22 @@ def _raw_value_blocks_rewrite(raw_value: str) -> bool:
     return False
 
 
-def _extract_description_value(content: str, parsed_fm: dict) -> str:
-    """Return the inline ``description:`` value, parsed.
+def _extract_description_value(parsed_fm: dict) -> str:
+    """Return the parsed ``description`` scalar, regardless of style.
 
-    Used to decide whether to emit the over-length manual finding.  The
-    raw frontmatter is inspected only to distinguish inline scalars
-    from folded / literal block scalars — folded blocks are deliberately
-    left to the regular validator so a misjudged block-scalar layout
-    cannot produce a spurious manual finding here.  When the line is
-    inline, the *parsed* scalar from ``parsed_fm`` is returned so
-    quoted forms (``description: "..."``) and inline ``# comments`` are
-    accounted for the same way the validator measures them — keeping
-    the planner's owned over-length-description FAIL string
+    Used to decide whether to emit the over-length manual finding.
+    Returns the parsed value from ``parsed_fm`` — ``parse_yaml_subset``
+    already handles every supported scalar style (plain, quoted, folded
+    ``>``, literal ``|``, with chomping indicators) so a folded
+    over-length description is detected the same way an inline one is,
+    keeping the ``--fix`` help text's "manual fix needed" claim honest
+    across scalar styles.  The validator measures length on the same
+    parsed value, so the planner's owned FAIL string stays
     byte-identical with the validator's.
 
-    Returns ``""`` when there is no frontmatter, no ``description:``
-    key, when the key is on a folded / literal block scalar header
-    line, or when the parsed value is not a string scalar.
+    Returns ``""`` when there is no ``description`` key or when the
+    parsed value is not a string scalar.
     """
-    frontmatter_raw, _body_raw = split_frontmatter(content)
-    if frontmatter_raw is None:
-        return ""
-    desc_re = re.compile(
-        r"^description:[ \t]*(?P<value>.*?)[ \t]*$", re.MULTILINE,
-    )
-    match = desc_re.search(frontmatter_raw)
-    if match is None:
-        return ""
-    raw_value = match.group("value").strip()
-    # A folded/literal block scalar marker (``>`` / ``|`` possibly with
-    # a chomping indicator) is not the description text itself — leave
-    # block scalars to the validator.
-    if raw_value in (">", "|", ">-", "|-", ">+", "|+"):
-        return ""
     value = parsed_fm.get("description", "")
     if not isinstance(value, str):
         return ""

--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -502,7 +502,7 @@ def compute_name_fix_plan(
         manual.extend(desc_manual)
         # Own the exact FAIL string ``validate_skill`` emits so the
         # caller does not double-report it.  Mirrors the wording in
-        # ``validate_skill.validate_frontmatter`` — the two strings
+        # ``validate_skill.validate_description`` — the two strings
         # must stay in sync.  ``description`` is the *parsed* scalar
         # (quotes and inline comments already stripped) so its length
         # matches the value the validator measures.

--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -92,11 +92,25 @@ from .yaml_parser import parse_yaml_subset
 # terminator (group ``trailing``).  Anchored at line start so a ``name:``
 # appearing inside a folded ``description`` block (which would be
 # indented) is never matched.  ``re.MULTILINE`` lets ``^``/``$`` bind to
-# physical line boundaries within the frontmatter text.
+# physical line boundaries within the frontmatter text.  The colon must
+# be flush against ``name`` (no leading whitespace) because the
+# rewriter does an exact line replacement — see ``_RE_NAME_KEY_ANY``
+# below for the relaxed regex used by the duplicate-key guard.
 _RE_NAME_LINE = re.compile(
     r"^(?P<prefix>name:[ \t]*)(?P<value>.*?)(?P<trailing>[ \t]*)$",
     re.MULTILINE,
 )
+
+# Matches *any* top-level ``name`` mapping key the parser would
+# accept, including ``name :`` with whitespace before the colon.  Used
+# only by the duplicate-key guard so a mixed-form pair (``name: First``
+# + ``name : Last``) cannot bypass detection — ``parse_yaml_subset``
+# would silently pick the last entry while the line rewriter would
+# touch the first, producing a false successful fix.  This regex is
+# not used for the rewrite span because the rewrite must preserve the
+# exact ``name:`` line shape, which the strict ``_RE_NAME_LINE`` above
+# captures.
+_RE_NAME_KEY_ANY = re.compile(r"^name[ \t]*:", re.MULTILINE)
 
 
 # Marker substring used to recognise the ``validate_name`` dir-mismatch
@@ -291,15 +305,18 @@ def rewrite_name_line(content: str, new_name: str) -> str | None:
     fm_end = fm_start + len(frontmatter_raw)
     fm_text = content[fm_start:fm_end]
 
+    # Defense-in-depth duplicate-key guard.  The planner already
+    # refuses duplicate-key frontmatter (and uses ``_RE_NAME_KEY_ANY``
+    # to catch mixed-form pairs like ``name: First`` + ``name : Last``
+    # that the strict regex would miss), but ``rewrite_name_line`` is
+    # also called directly from tests and any future caller, so it
+    # repeats the same relaxed check here.  Touching the first strict
+    # match while ``parse_yaml_subset`` reads a later relaxed match
+    # would silently rewrite the wrong line.
+    if len(_RE_NAME_KEY_ANY.findall(fm_text)) > 1:
+        return None
     raw_matches = list(_RE_NAME_LINE.finditer(fm_text))
     if not raw_matches:
-        return None
-    if len(raw_matches) > 1:
-        # Defense-in-depth: the planner already refuses duplicate-key
-        # frontmatter, but the line rewriter is also called directly
-        # from tests and any future caller.  Touching the first match
-        # while ``parse_yaml_subset`` reads the last would silently
-        # rewrite the wrong line.
         return None
     raw_value = raw_matches[0].group("value")
     if _raw_value_blocks_rewrite(raw_value):
@@ -409,20 +426,25 @@ def compute_name_fix_plan(
         )
         return None, applied, manual, errors, owned
 
-    # Duplicate ``name:`` keys are unambiguously broken frontmatter
+    # Duplicate ``name`` keys are unambiguously broken frontmatter
     # regardless of whether the planner would propose a rewrite — the
     # parser silently picks one and the rewriter would touch the
     # other.  The error fires up front, before any other reasoning.
-    raw_value_matches = list(_RE_NAME_LINE.finditer(frontmatter_raw))
-    if len(raw_value_matches) > 1:
+    # The duplicate guard uses the relaxed ``_RE_NAME_KEY_ANY`` regex
+    # so a mixed-form pair (``name: First`` + ``name : Last``) cannot
+    # bypass detection — the strict ``_RE_NAME_LINE`` below is still
+    # used to locate the *rewriteable* line for the apply path.
+    name_key_count = len(_RE_NAME_KEY_ANY.findall(frontmatter_raw))
+    if name_key_count > 1:
         errors.append(
             f"{LEVEL_FAIL}: [foundry] multiple 'name:' keys in "
-            f"frontmatter ({len(raw_value_matches)} found) — "
+            f"frontmatter ({name_key_count} found) — "
             "parse_yaml_subset would use the last and the line "
             "rewriter would touch the first; remove the duplicates by "
             "hand"
         )
         return None, applied, manual, errors, owned
+    raw_value_matches = list(_RE_NAME_LINE.finditer(frontmatter_raw))
     raw_value_match = raw_value_matches[0] if raw_value_matches else None
 
     current_name = parsed_fm["name"]
@@ -460,9 +482,11 @@ def compute_name_fix_plan(
         if _raw_value_blocks_rewrite(raw_value):
             manual.append(
                 f"{LEVEL_FAIL}: [spec] manual fix needed — the 'name:' "
-                "line carries a quoted scalar or an inline '#' "
-                "comment; the minimal line rewriter would silently "
-                "strip that syntax — normalize the value by hand"
+                "line carries a quoted scalar, an inline '#' comment, "
+                "or a block-scalar header (|, >, |-, >-, |+, >+); the "
+                "minimal line rewriter would silently strip that "
+                "syntax or leave the indented scalar body behind — "
+                "normalize the value by hand"
             )
             return None, [], manual, errors, []
 
@@ -552,16 +576,28 @@ def _raw_value_blocks_rewrite(raw_value: str) -> bool:
     The minimal line rewriter cannot preserve a quoted scalar wrapper or
     an inline ``# comment`` — applying it would silently strip both.
     Detect either form on the captured value span so the planner can
-    refuse to rewrite rather than lose the source bytes.  ``#`` is only
-    flagged when preceded by a space, matching the exact rule
-    ``yaml_parser._strip_inline_comment`` applies (``text[i - 1] == " "``);
-    a ``#`` preceded by a tab or embedded in a plain scalar
-    (``name: foo#bar`` → YAML value ``foo#bar``) is left for the parser
-    to decide, since the parser treats it as part of the scalar and the
-    rewriter must not be stricter than the parser's view of "what is a
-    comment".
+    refuse to rewrite rather than lose the source bytes.
+
+    Block-scalar headers (``|``, ``>``, plus the chomping-modifier
+    variants ``|-`` / ``>-`` / ``|+`` / ``>+``) appear on the ``name:``
+    line alone, with the scalar text indented on the following lines.
+    ``parse_yaml_subset`` assembles those into an ordinary string, so
+    the planner would otherwise propose a rewrite — and the line-only
+    rewriter would touch *only* the header line, leaving the indented
+    body content as stray YAML the parser then re-reads as separate
+    keys.  Block-scalar headers are therefore non-rewriteable.
+
+    ``#`` is only flagged when preceded by a space, matching the exact
+    rule ``yaml_parser._strip_inline_comment`` applies
+    (``text[i - 1] == " "``); a ``#`` preceded by a tab or embedded in
+    a plain scalar (``name: foo#bar`` → YAML value ``foo#bar``) is left
+    for the parser to decide, since the parser treats it as part of
+    the scalar and the rewriter must not be stricter than the parser's
+    view of "what is a comment".
     """
     trimmed = raw_value.strip()
+    if trimmed in ("|", ">", "|-", ">-", "|+", ">+"):
+        return True
     if (
         len(trimmed) >= 2
         and trimmed[0] in ('"', "'")

--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -13,16 +13,22 @@ The foundry's stdlib-only YAML subset parser does **not** round-trip
 re-serialisation), so this module never re-serialises the frontmatter.
 It rewrites exactly one line.
 
-Two classes of problem are intentionally **not** auto-fixed because the
-correct resolution requires human judgement:
+Three classes of problem are intentionally **not** auto-fixed because
+the correct resolution requires human judgement or because the safe
+rewrite cannot preserve the source bytes:
 
 * ``name`` does not match the directory name — the author must decide
   whether to rename the directory or change the field.
 * the description exceeds the maximum length — truncating would lose
   meaning.
+* the safe-fixer's computed candidate still violates the spec (e.g.,
+  consecutive hyphens or an invalid leading/trailing hyphen after the
+  transform), or the raw ``name:`` line carries quoted scalars or
+  inline ``#`` comments that a minimal single-line rewrite would
+  silently strip.
 
-Both are reported as "manual fix needed" findings so a clean ``--fix``
-run is never mistaken for "the skill conforms".
+All three are reported as "manual fix needed" findings so a clean
+``--fix`` run is never mistaken for "the skill conforms".
 
 Name normalization is folded into the same ``validate_skill.py
 --fix``/``--fix --apply`` preview/apply flow that drives the
@@ -30,6 +36,13 @@ path-resolution rewriter (``lib/path_rewriter.py``): ``compute_name_fix_plan``
 computes the would-be change without touching disk (the preview the bare
 ``--fix`` reports), and ``write_name_fix`` performs the single-line
 rewrite under ``--fix --apply``.
+
+The plan also reports the exact ``validate_name`` / over-length-description
+FAIL strings the fixer takes ownership of (``owned_fails``).  The
+``validate_skill.py --fix`` driver suppresses *only* those strings from
+the generic ``non_path_fails`` bucket — every other name-related FAIL
+flows through unchanged so a partial-fix run cannot mask unresolved
+spec violations.
 
 All functions return findings as ``(errors, passes)``-style tuples per
 the repo convention; none raise for a validation outcome.
@@ -42,9 +55,10 @@ from .constants import (
     LEVEL_FAIL,
     LEVEL_INFO,
     MAX_DESCRIPTION_CHARS,
-    RE_NAME_FORMAT,
 )
 from .frontmatter import split_frontmatter
+from .validation import validate_name
+from .yaml_parser import parse_yaml_subset
 
 
 # Matches a frontmatter ``name:`` line and captures the three spans the
@@ -59,6 +73,12 @@ _RE_NAME_LINE = re.compile(
     r"^(?P<prefix>name:[ \t]*)(?P<value>.*?)(?P<trailing>[ \t]*)$",
     re.MULTILINE,
 )
+
+
+# Marker substring used to recognise the ``validate_name`` dir-mismatch
+# FAIL.  Defined once so the ownership and refusal logic cannot drift
+# from the exact wording in ``validation.validate_name``.
+_DIR_MISMATCH_MARKER = "does not match directory name"
 
 
 def compute_safe_name(name: str) -> str:
@@ -79,56 +99,94 @@ def compute_safe_name(name: str) -> str:
 
 def compute_name_fix(
     current_name: str, dir_name: str,
-) -> tuple[str | None, list[str], list[str]]:
+) -> tuple[str | None, list[str], list[str], list[str]]:
     """Compute the safe ``name`` fix and the findings for one skill.
 
-    Returns ``(new_name, applied, manual)`` where:
+    Returns ``(new_name, applied, manual, owned_fails)`` where:
 
     * ``new_name`` is the corrected ``name`` value when at least one
-      safe fix changes it, else ``None`` (nothing to write).
+      safe fix changes it AND the computed candidate would pass
+      ``validate_name`` (modulo a dir-mismatch, which is reported as a
+      manual finding rather than a spec FAIL).  Otherwise ``None``.
     * ``applied`` is a list of ``INFO``-level finding strings describing
       each safe transformation that fired.
     * ``manual`` is a list of ``FAIL``-level finding strings for the
       ambiguous problems this fixer deliberately does not touch
-      (directory mismatch).  Description-length is reported by
+      (directory mismatch, or a computed candidate that still violates
+      the spec).  Description-length is reported by
       :func:`compute_description_manual_finding` because it needs the
       description value, not the name.
+    * ``owned_fails`` is the list of exact ``validate_name`` FAIL
+      strings the planner takes ownership of — the FAILs the fix
+      *would* resolve when applied, plus any dir-mismatch FAIL that
+      this plan surfaces as a manual finding instead.  The caller
+      suppresses exactly these from its generic FAIL bucket so a name
+      FAIL that the safe fixer does *not* resolve (empty name, length,
+      Windows reserved name, etc.) is never silently swallowed.
 
     Directory mismatch is evaluated against the *fixed* name so a skill
     whose only divergence was casing/underscores does not report a
     spurious mismatch after the fix lands.  An empty or whitespace-only
-    ``current_name`` yields no fix and no manual finding — that is a
-    spec FAIL the regular validator already reports, and inventing a
-    name here would be exactly the kind of judgement call this fixer
-    avoids.
+    ``current_name`` yields no fix, no manual finding, and no owned
+    FAILs — that is a spec FAIL the regular validator already reports
+    on its own.
     """
     applied: list[str] = []
     manual: list[str] = []
+    owned: list[str] = []
 
     if not current_name or not current_name.strip():
-        return None, applied, manual
+        return None, applied, manual, owned
+
+    current_validation, _ = validate_name(current_name, dir_name)
+    current_fails = [e for e in current_validation if e.startswith(LEVEL_FAIL)]
 
     fixed = compute_safe_name(current_name)
 
+    fixed_validation, _ = validate_name(fixed, dir_name)
+    fixed_fails = [e for e in fixed_validation if e.startswith(LEVEL_FAIL)]
+
+    # Residual FAILs *after* applying the safe fix.  Exclude the
+    # dir-mismatch FAIL because it is surfaced as a manual finding by
+    # this planner, not as a regular spec FAIL — keeping it in the
+    # residual would refuse safe fixes for any skill whose name happens
+    # to differ from its directory.
+    residual = [e for e in fixed_fails if _DIR_MISMATCH_MARKER not in e]
+
+    transforms: list[str] = []
     if fixed != current_name:
         if current_name.lower() != current_name:
-            applied.append(
+            transforms.append(
                 f"{LEVEL_INFO}: [foundry] 'name' lowercased "
                 f"from '{current_name}' to '{current_name.lower()}'"
             )
         if "_" in current_name:
-            applied.append(
+            transforms.append(
                 f"{LEVEL_INFO}: [foundry] 'name' underscores replaced "
                 "with hyphens"
             )
         if " " in current_name or "\t" in current_name:
-            applied.append(
+            transforms.append(
                 f"{LEVEL_INFO}: [foundry] 'name' spaces replaced "
                 "with hyphens"
             )
 
-    effective_name = fixed if applied else current_name
+    if residual:
+        # The safe-fix candidate would still violate the spec (e.g.,
+        # ``my__skill`` → ``my--skill`` produces consecutive hyphens).
+        # Refuse to propose a fix: every original ``validate_name`` FAIL
+        # flows through the caller's generic bucket unchanged.  Emit a
+        # manual finding so the user sees *why* the fixer stood down
+        # without having to reverse-engineer it from the FAIL list.
+        manual.append(
+            f"{LEVEL_FAIL}: [spec] manual fix needed — 'name' "
+            f"('{current_name}') cannot be safely normalized "
+            f"(candidate '{fixed}' still violates the spec); rename "
+            "the field by hand"
+        )
+        return None, [], manual, []
 
+    effective_name = fixed if transforms else current_name
     if effective_name != dir_name:
         manual.append(
             f"{LEVEL_FAIL}: [spec] manual fix needed — 'name' "
@@ -137,8 +195,19 @@ def compute_name_fix(
             "by hand"
         )
 
-    new_name = fixed if applied else None
-    return new_name, applied, manual
+    new_name = fixed if transforms else None
+    applied = transforms
+
+    fixed_fails_set = set(fixed_fails)
+    owned = [e for e in current_fails if e not in fixed_fails_set]
+    # The dir-mismatch FAIL is owned by this plan when it surfaces a
+    # manual finding for it, even if the FAIL also survives the fix
+    # (which happens when the fixed name still differs from dir_name).
+    if any(_DIR_MISMATCH_MARKER in e for e in manual):
+        for fail in current_fails:
+            if _DIR_MISMATCH_MARKER in fail and fail not in owned:
+                owned.append(fail)
+    return new_name, applied, manual, owned
 
 
 def compute_description_manual_finding(description: str) -> list[str]:
@@ -169,7 +238,9 @@ def rewrite_name_line(content: str, new_name: str) -> str | None:
 
     Returns the rewritten text, or ``None`` when the ``name:`` line
     cannot be located inside the frontmatter block (no frontmatter, no
-    closing delimiter, or no ``name:`` key).  ``None`` signals the
+    closing delimiter, no ``name:`` key) **or** when the raw value
+    carries a quoted scalar or an inline ``#`` comment that the
+    minimal line rewriter would silently strip.  ``None`` signals the
     caller to leave the file untouched rather than guess.
     """
     frontmatter_raw, _body_raw = split_frontmatter(content)
@@ -189,6 +260,13 @@ def rewrite_name_line(content: str, new_name: str) -> str | None:
     fm_end = fm_start + len(frontmatter_raw)
     fm_text = content[fm_start:fm_end]
 
+    raw_match = _RE_NAME_LINE.search(fm_text)
+    if raw_match is None:
+        return None
+    raw_value = raw_match.group("value")
+    if _raw_value_blocks_rewrite(raw_value):
+        return None
+
     replaced = False
 
     def _sub(match: re.Match) -> str:
@@ -206,7 +284,7 @@ def rewrite_name_line(content: str, new_name: str) -> str | None:
 
 def compute_name_fix_plan(
     skill_md_path: str,
-) -> tuple[str | None, list[str], list[str], list[str]]:
+) -> tuple[str | None, list[str], list[str], list[str], list[str]]:
     """Compute the safe ``name`` fix for *skill_md_path* without writing.
 
     Reads the SKILL.md, computes the safe name fix against the enclosing
@@ -216,24 +294,35 @@ def compute_name_fix_plan(
     this to report the would-be change, then calls :func:`write_name_fix`
     only when ``--apply`` is also passed.
 
-    Returns ``(new_name, applied, manual, errors)``:
+    Returns ``(new_name, applied, manual, errors, owned_fails)``:
 
     * ``new_name`` — the corrected ``name`` value when at least one safe
-      fix changes it, else ``None`` (nothing to apply).
+      fix changes it AND the result would pass ``validate_name`` cleanly
+      (a surviving dir-mismatch is surfaced as a manual finding, not as
+      a refusal).  ``None`` otherwise.
     * ``applied`` — ``INFO`` findings for each safe transformation that
       the fix would perform.
-    * ``manual`` — ``FAIL`` "manual fix needed" findings (directory
-      mismatch, over-length description).
+    * ``manual`` — ``FAIL`` "manual fix needed" findings: directory
+      mismatch, over-length description, the safe candidate still
+      violates the spec, or the raw ``name:`` line carries a quote /
+      inline ``#`` comment that a minimal line rewrite cannot preserve.
     * ``errors`` — ``FAIL`` findings for structural / I/O failures (file
-      missing / unreadable, no parseable frontmatter, no ``name:`` key).
-      These keep the function from raising for an I/O or structural
-      problem, matching the repo's "validation never raises" convention.
+      missing / unreadable, no parseable frontmatter, no ``name:`` key,
+      ``name:`` value is not a string scalar).  These keep the function
+      from raising for an I/O or structural problem, matching the
+      repo's "validation never raises" convention.
+    * ``owned_fails`` — the exact ``validate_name`` /
+      validate-description FAIL strings this plan takes ownership of;
+      the caller suppresses *only* these from its generic FAIL bucket
+      so a name FAIL the fixer does not resolve (empty name, length,
+      Windows reserved name, etc.) is never silently swallowed.
 
     The skill directory name is taken from the parent of *skill_md_path*.
     """
     applied: list[str] = []
     manual: list[str] = []
     errors: list[str] = []
+    owned: list[str] = []
 
     skill_dir = os.path.dirname(os.path.abspath(skill_md_path))
     dir_name = os.path.basename(skill_dir)
@@ -246,7 +335,7 @@ def compute_name_fix_plan(
             f"{LEVEL_FAIL}: [foundry] cannot read SKILL.md "
             f"({exc.__class__.__name__}: {exc})"
         )
-        return None, applied, manual, errors
+        return None, applied, manual, errors, owned
 
     frontmatter_raw, _body_raw = split_frontmatter(content)
     if frontmatter_raw is None:
@@ -254,21 +343,76 @@ def compute_name_fix_plan(
             f"{LEVEL_FAIL}: [spec] no YAML frontmatter found — "
             "cannot locate the 'name' field to fix"
         )
-        return None, applied, manual, errors
+        return None, applied, manual, errors, owned
 
-    current_name = _extract_name_value(content)
-    if current_name is None:
+    try:
+        parsed_fm = parse_yaml_subset(frontmatter_raw.strip())
+    except (ValueError, KeyError) as exc:
+        errors.append(
+            f"{LEVEL_FAIL}: [foundry] cannot parse SKILL.md frontmatter "
+            f"({exc.__class__.__name__}: {exc})"
+        )
+        return None, applied, manual, errors, owned
+
+    if "name" not in parsed_fm:
         errors.append(
             f"{LEVEL_FAIL}: [spec] no 'name' field in frontmatter — "
             "nothing to fix"
         )
-        return None, applied, manual, errors
+        return None, applied, manual, errors, owned
 
-    new_name, applied, manual = compute_name_fix(current_name, dir_name)
-    manual.extend(
-        compute_description_manual_finding(_extract_description_value(content))
+    raw_value_match = _RE_NAME_LINE.search(frontmatter_raw)
+    if raw_value_match is None:
+        # The parser saw a ``name`` key (flow-style mapping, alias, or
+        # similar) but the line-oriented rewriter cannot target a single
+        # physical line.  Refuse rather than guess.
+        errors.append(
+            f"{LEVEL_FAIL}: [foundry] 'name:' is not on its own line — "
+            "the minimal line rewriter cannot target it; normalize the "
+            "frontmatter by hand"
+        )
+        return None, applied, manual, errors, owned
+
+    current_name = parsed_fm["name"]
+    if not isinstance(current_name, str):
+        errors.append(
+            f"{LEVEL_FAIL}: [foundry] 'name' value is not a string "
+            f"scalar (got {type(current_name).__name__}) — cannot fix"
+        )
+        return None, applied, manual, errors, owned
+
+    raw_value = raw_value_match.group("value")
+    if _raw_value_blocks_rewrite(raw_value):
+        manual.append(
+            f"{LEVEL_FAIL}: [spec] manual fix needed — the 'name:' "
+            "line carries a quoted scalar or an inline '#' comment; "
+            "the minimal line rewriter would silently strip that "
+            "syntax — normalize the value by hand"
+        )
+        return None, applied, manual, errors, owned
+
+    new_name, applied, fix_manual, fix_owned = compute_name_fix(
+        current_name, dir_name,
     )
-    return new_name, applied, manual, errors
+    manual.extend(fix_manual)
+    owned.extend(fix_owned)
+
+    description = _extract_description_value(content, parsed_fm)
+    desc_manual = compute_description_manual_finding(description)
+    if desc_manual:
+        manual.extend(desc_manual)
+        # Own the exact FAIL string ``validate_skill`` emits so the
+        # caller does not double-report it.  Mirrors the wording in
+        # ``validate_skill.validate_frontmatter`` — the two strings
+        # must stay in sync.  ``description`` is the *parsed* scalar
+        # (quotes and inline comments already stripped) so its length
+        # matches the value the validator measures.
+        owned.append(
+            f"{LEVEL_FAIL}: [spec] 'description' exceeds "
+            f"{MAX_DESCRIPTION_CHARS} characters "
+            f"({len(description)} chars)"
+        )
+    return new_name, applied, manual, errors, owned
 
 
 def write_name_fix(
@@ -328,32 +472,52 @@ def write_name_fix(
     return True, errors
 
 
-def _extract_name_value(content: str) -> str | None:
-    """Return the raw ``name:`` value from the frontmatter, or ``None``.
+def _raw_value_blocks_rewrite(raw_value: str) -> bool:
+    """Return ``True`` when the raw ``name:`` line carries quote/comment syntax.
 
-    Reads only the frontmatter block so a ``name:`` literal in the body
-    is never picked up.  Returns the trimmed value (which may be an
-    empty string when the field is present but blank), or ``None`` when
-    no ``name:`` key exists in the frontmatter.
+    The minimal line rewriter cannot preserve a quoted scalar wrapper or
+    an inline ``# comment`` — applying it would silently strip both.
+    Detect either form on the captured value span so the planner can
+    refuse to rewrite rather than lose the source bytes.  ``#`` is only
+    flagged when preceded by whitespace, matching the YAML subset
+    parser's inline-comment recogniser; that keeps a ``#`` embedded in a
+    plain scalar (``name: foo#bar`` → YAML value ``foo#bar``) from being
+    misclassified.
     """
-    frontmatter_raw, _body_raw = split_frontmatter(content)
-    if frontmatter_raw is None:
-        return None
-    match = _RE_NAME_LINE.search(frontmatter_raw)
-    if match is None:
-        return None
-    return match.group("value").strip()
+    trimmed = raw_value.strip()
+    if (
+        len(trimmed) >= 2
+        and trimmed[0] in ('"', "'")
+        and trimmed[-1] == trimmed[0]
+    ):
+        return True
+    if trimmed[:1] in ('"', "'"):
+        # Opened a quote but did not close on the same line — out of
+        # scope for the minimal rewriter.
+        return True
+    for index in range(1, len(raw_value)):
+        if raw_value[index] == "#" and raw_value[index - 1] in (" ", "\t"):
+            return True
+    return False
 
 
-def _extract_description_value(content: str) -> str:
-    """Return a best-effort single-line ``description:`` value.
+def _extract_description_value(content: str, parsed_fm: dict) -> str:
+    """Return the inline ``description:`` value, parsed.
 
-    Used only to decide whether to emit the over-length manual finding,
-    so it does not need to reconstruct folded block scalars — it reads
-    the inline value on the ``description:`` line.  Returns an empty
-    string when no inline ``description:`` value is present (a folded
-    ``description: >`` block yields the empty marker line, which cannot
-    exceed the limit on its own and is left to the regular validator).
+    Used to decide whether to emit the over-length manual finding.  The
+    raw frontmatter is inspected only to distinguish inline scalars
+    from folded / literal block scalars — folded blocks are deliberately
+    left to the regular validator so a misjudged block-scalar layout
+    cannot produce a spurious manual finding here.  When the line is
+    inline, the *parsed* scalar from ``parsed_fm`` is returned so
+    quoted forms (``description: "..."``) and inline ``# comments`` are
+    accounted for the same way the validator measures them — keeping
+    the planner's owned over-length-description FAIL string
+    byte-identical with the validator's.
+
+    Returns ``""`` when there is no frontmatter, no ``description:``
+    key, when the key is on a folded / literal block scalar header
+    line, or when the parsed value is not a string scalar.
     """
     frontmatter_raw, _body_raw = split_frontmatter(content)
     if frontmatter_raw is None:
@@ -364,9 +528,13 @@ def _extract_description_value(content: str) -> str:
     match = desc_re.search(frontmatter_raw)
     if match is None:
         return ""
-    value = match.group("value").strip()
+    raw_value = match.group("value").strip()
     # A folded/literal block scalar marker (``>`` / ``|`` possibly with
-    # a chomping indicator) is not the description text itself.
-    if value in (">", "|", ">-", "|-", ">+", "|+"):
+    # a chomping indicator) is not the description text itself — leave
+    # block scalars to the validator.
+    if raw_value in (">", "|", ">-", "|-", ">+", "|+"):
+        return ""
+    value = parsed_fm.get("description", "")
+    if not isinstance(value, str):
         return ""
     return value

--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -1,0 +1,372 @@
+"""Safe, deterministic auto-fixes for the SKILL.md ``name`` frontmatter.
+
+When ``validate_name`` FAILs because the ``name`` field carries
+uppercase characters, underscores, or spaces, the corrected value is
+unambiguous: lowercase the letters, and replace ``_`` / `` `` with
+``-``.  This module computes that correction and applies it as a
+*minimal, targeted textual replacement* of the single ``name:`` value
+line in the on-disk ``SKILL.md`` — the rest of the file (the remaining
+frontmatter and the entire body) is preserved byte-for-byte.
+
+The foundry's stdlib-only YAML subset parser does **not** round-trip
+(comments, quoting style, key order, and block-scalar layout are lost on
+re-serialisation), so this module never re-serialises the frontmatter.
+It rewrites exactly one line.
+
+Two classes of problem are intentionally **not** auto-fixed because the
+correct resolution requires human judgement:
+
+* ``name`` does not match the directory name — the author must decide
+  whether to rename the directory or change the field.
+* the description exceeds the maximum length — truncating would lose
+  meaning.
+
+Both are reported as "manual fix needed" findings so a clean ``--fix``
+run is never mistaken for "the skill conforms".
+
+Name normalization is folded into the same ``validate_skill.py
+--fix``/``--fix --apply`` preview/apply flow that drives the
+path-resolution rewriter (``lib/path_rewriter.py``): ``compute_name_fix_plan``
+computes the would-be change without touching disk (the preview the bare
+``--fix`` reports), and ``write_name_fix`` performs the single-line
+rewrite under ``--fix --apply``.
+
+All functions return findings as ``(errors, passes)``-style tuples per
+the repo convention; none raise for a validation outcome.
+"""
+
+import os
+import re
+
+from .constants import (
+    LEVEL_FAIL,
+    LEVEL_INFO,
+    MAX_DESCRIPTION_CHARS,
+    RE_NAME_FORMAT,
+)
+from .frontmatter import split_frontmatter
+
+
+# Matches a frontmatter ``name:`` line and captures the three spans the
+# rewriter must preserve around the value: the ``name:`` key plus the
+# whitespace after the colon (group ``prefix``), the value itself
+# (group ``value``), and any trailing whitespace before the line
+# terminator (group ``trailing``).  Anchored at line start so a ``name:``
+# appearing inside a folded ``description`` block (which would be
+# indented) is never matched.  ``re.MULTILINE`` lets ``^``/``$`` bind to
+# physical line boundaries within the frontmatter text.
+_RE_NAME_LINE = re.compile(
+    r"^(?P<prefix>name:[ \t]*)(?P<value>.*?)(?P<trailing>[ \t]*)$",
+    re.MULTILINE,
+)
+
+
+def compute_safe_name(name: str) -> str:
+    """Return *name* with the three safe, deterministic fixes applied.
+
+    Lowercases every character and replaces underscores and spaces with
+    hyphens.  Tabs in a value are treated like spaces.  This is a pure
+    string transform — it does not consult the directory name, the
+    length limit, or the format regex; the caller decides whether the
+    result is worth writing.
+    """
+    fixed = name.lower()
+    fixed = fixed.replace("_", "-")
+    fixed = fixed.replace(" ", "-")
+    fixed = fixed.replace("\t", "-")
+    return fixed
+
+
+def compute_name_fix(
+    current_name: str, dir_name: str,
+) -> tuple[str | None, list[str], list[str]]:
+    """Compute the safe ``name`` fix and the findings for one skill.
+
+    Returns ``(new_name, applied, manual)`` where:
+
+    * ``new_name`` is the corrected ``name`` value when at least one
+      safe fix changes it, else ``None`` (nothing to write).
+    * ``applied`` is a list of ``INFO``-level finding strings describing
+      each safe transformation that fired.
+    * ``manual`` is a list of ``FAIL``-level finding strings for the
+      ambiguous problems this fixer deliberately does not touch
+      (directory mismatch).  Description-length is reported by
+      :func:`compute_description_manual_finding` because it needs the
+      description value, not the name.
+
+    Directory mismatch is evaluated against the *fixed* name so a skill
+    whose only divergence was casing/underscores does not report a
+    spurious mismatch after the fix lands.  An empty or whitespace-only
+    ``current_name`` yields no fix and no manual finding — that is a
+    spec FAIL the regular validator already reports, and inventing a
+    name here would be exactly the kind of judgement call this fixer
+    avoids.
+    """
+    applied: list[str] = []
+    manual: list[str] = []
+
+    if not current_name or not current_name.strip():
+        return None, applied, manual
+
+    fixed = compute_safe_name(current_name)
+
+    if fixed != current_name:
+        if current_name.lower() != current_name:
+            applied.append(
+                f"{LEVEL_INFO}: [foundry] 'name' lowercased "
+                f"from '{current_name}' to '{current_name.lower()}'"
+            )
+        if "_" in current_name:
+            applied.append(
+                f"{LEVEL_INFO}: [foundry] 'name' underscores replaced "
+                "with hyphens"
+            )
+        if " " in current_name or "\t" in current_name:
+            applied.append(
+                f"{LEVEL_INFO}: [foundry] 'name' spaces replaced "
+                "with hyphens"
+            )
+
+    effective_name = fixed if applied else current_name
+
+    if effective_name != dir_name:
+        manual.append(
+            f"{LEVEL_FAIL}: [spec] manual fix needed — 'name' "
+            f"('{effective_name}') does not match directory name "
+            f"('{dir_name}'); rename the directory or update the field "
+            "by hand"
+        )
+
+    new_name = fixed if applied else None
+    return new_name, applied, manual
+
+
+def compute_description_manual_finding(description: str) -> list[str]:
+    """Return a manual-fix finding when *description* is over the limit.
+
+    Truncating a description loses meaning, so the fixer never edits it;
+    it surfaces a ``FAIL``-level "manual fix needed" string instead.
+    Returns an empty list when the description is within the limit (or
+    empty — the regular validator already FAILs an empty description).
+    """
+    if description and len(description) > MAX_DESCRIPTION_CHARS:
+        return [
+            f"{LEVEL_FAIL}: [spec] manual fix needed — 'description' "
+            f"exceeds {MAX_DESCRIPTION_CHARS} characters "
+            f"({len(description)} chars); shorten it by hand"
+        ]
+    return []
+
+
+def rewrite_name_line(content: str, new_name: str) -> str | None:
+    """Return *content* with only the frontmatter ``name:`` value replaced.
+
+    The replacement is line-targeted: the ``name:`` key, the spacing
+    after the colon, and any trailing whitespace are preserved exactly;
+    only the value token changes.  Everything outside that one line —
+    the rest of the frontmatter and the entire body — is returned
+    byte-for-byte.
+
+    Returns the rewritten text, or ``None`` when the ``name:`` line
+    cannot be located inside the frontmatter block (no frontmatter, no
+    closing delimiter, or no ``name:`` key).  ``None`` signals the
+    caller to leave the file untouched rather than guess.
+    """
+    frontmatter_raw, _body_raw = split_frontmatter(content)
+    if frontmatter_raw is None:
+        return None
+
+    # Resolve the span of the frontmatter text inside *content* so the
+    # substitution is confined to it — a ``name:`` literal in the body
+    # (e.g. inside a fenced YAML example) must never be touched.  The
+    # opening delimiter is the first line; the frontmatter text follows
+    # it.  ``split_frontmatter`` returns the inner block verbatim, so
+    # locating it by ``find`` from just past the opener is exact.
+    open_end = content.find("\n")
+    if open_end == -1:
+        return None
+    fm_start = open_end + 1
+    fm_end = fm_start + len(frontmatter_raw)
+    fm_text = content[fm_start:fm_end]
+
+    replaced = False
+
+    def _sub(match: re.Match) -> str:
+        nonlocal replaced
+        if replaced:
+            return match.group(0)
+        replaced = True
+        return f"{match.group('prefix')}{new_name}{match.group('trailing')}"
+
+    new_fm = _RE_NAME_LINE.sub(_sub, fm_text, count=1)
+    if not replaced:
+        return None
+    return content[:fm_start] + new_fm + content[fm_end:]
+
+
+def compute_name_fix_plan(
+    skill_md_path: str,
+) -> tuple[str | None, list[str], list[str], list[str]]:
+    """Compute the safe ``name`` fix for *skill_md_path* without writing.
+
+    Reads the SKILL.md, computes the safe name fix against the enclosing
+    directory name, and reports the manual-fix-needed items — but never
+    touches disk.  This is the *preview* half of the unified
+    ``--fix``/``--fix --apply`` flow: ``validate_skill.py --fix`` calls
+    this to report the would-be change, then calls :func:`write_name_fix`
+    only when ``--apply`` is also passed.
+
+    Returns ``(new_name, applied, manual, errors)``:
+
+    * ``new_name`` — the corrected ``name`` value when at least one safe
+      fix changes it, else ``None`` (nothing to apply).
+    * ``applied`` — ``INFO`` findings for each safe transformation that
+      the fix would perform.
+    * ``manual`` — ``FAIL`` "manual fix needed" findings (directory
+      mismatch, over-length description).
+    * ``errors`` — ``FAIL`` findings for structural / I/O failures (file
+      missing / unreadable, no parseable frontmatter, no ``name:`` key).
+      These keep the function from raising for an I/O or structural
+      problem, matching the repo's "validation never raises" convention.
+
+    The skill directory name is taken from the parent of *skill_md_path*.
+    """
+    applied: list[str] = []
+    manual: list[str] = []
+    errors: list[str] = []
+
+    skill_dir = os.path.dirname(os.path.abspath(skill_md_path))
+    dir_name = os.path.basename(skill_dir)
+
+    try:
+        with open(skill_md_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, UnicodeError) as exc:
+        errors.append(
+            f"{LEVEL_FAIL}: [foundry] cannot read SKILL.md "
+            f"({exc.__class__.__name__}: {exc})"
+        )
+        return None, applied, manual, errors
+
+    frontmatter_raw, _body_raw = split_frontmatter(content)
+    if frontmatter_raw is None:
+        errors.append(
+            f"{LEVEL_FAIL}: [spec] no YAML frontmatter found — "
+            "cannot locate the 'name' field to fix"
+        )
+        return None, applied, manual, errors
+
+    current_name = _extract_name_value(content)
+    if current_name is None:
+        errors.append(
+            f"{LEVEL_FAIL}: [spec] no 'name' field in frontmatter — "
+            "nothing to fix"
+        )
+        return None, applied, manual, errors
+
+    new_name, applied, manual = compute_name_fix(current_name, dir_name)
+    manual.extend(
+        compute_description_manual_finding(_extract_description_value(content))
+    )
+    return new_name, applied, manual, errors
+
+
+def write_name_fix(
+    skill_md_path: str, new_name: str,
+) -> tuple[bool, list[str]]:
+    """Write *new_name* into the SKILL.md ``name:`` line at *skill_md_path*.
+
+    The *apply* half of the unified flow — called only under
+    ``--fix --apply`` with a *new_name* already computed by
+    :func:`compute_name_fix_plan`.  Rewrites the single ``name:`` line in
+    place (preserving the rest of the file byte-for-byte, written with
+    ``newline="\\n"``) and returns ``(modified, errors)``:
+
+    * ``modified`` — ``True`` only when the file was actually rewritten.
+    * ``errors`` — ``FAIL`` findings for an unreadable file, a
+      non-locatable ``name:`` line, or a write error.  Never raises for
+      an I/O or structural problem.
+
+    A computed value that already matches the on-disk bytes leaves the
+    file untouched (``modified`` is ``False``) — no read-modify-write of
+    identical bytes.
+    """
+    errors: list[str] = []
+
+    try:
+        with open(skill_md_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except (OSError, UnicodeError) as exc:
+        errors.append(
+            f"{LEVEL_FAIL}: [foundry] cannot read SKILL.md "
+            f"({exc.__class__.__name__}: {exc})"
+        )
+        return False, errors
+
+    rewritten = rewrite_name_line(content, new_name)
+    if rewritten is None:
+        errors.append(
+            f"{LEVEL_FAIL}: [foundry] could not locate the 'name:' line "
+            "for in-place rewrite — leaving the file untouched"
+        )
+        return False, errors
+
+    if rewritten == content:
+        # Defensive: the computed value matched what is already on disk.
+        return False, errors
+
+    try:
+        with open(skill_md_path, "w", encoding="utf-8", newline="\n") as f:
+            f.write(rewritten)
+    except (OSError, UnicodeError) as exc:
+        errors.append(
+            f"{LEVEL_FAIL}: [foundry] cannot write SKILL.md "
+            f"({exc.__class__.__name__}: {exc})"
+        )
+        return False, errors
+
+    return True, errors
+
+
+def _extract_name_value(content: str) -> str | None:
+    """Return the raw ``name:`` value from the frontmatter, or ``None``.
+
+    Reads only the frontmatter block so a ``name:`` literal in the body
+    is never picked up.  Returns the trimmed value (which may be an
+    empty string when the field is present but blank), or ``None`` when
+    no ``name:`` key exists in the frontmatter.
+    """
+    frontmatter_raw, _body_raw = split_frontmatter(content)
+    if frontmatter_raw is None:
+        return None
+    match = _RE_NAME_LINE.search(frontmatter_raw)
+    if match is None:
+        return None
+    return match.group("value").strip()
+
+
+def _extract_description_value(content: str) -> str:
+    """Return a best-effort single-line ``description:`` value.
+
+    Used only to decide whether to emit the over-length manual finding,
+    so it does not need to reconstruct folded block scalars — it reads
+    the inline value on the ``description:`` line.  Returns an empty
+    string when no inline ``description:`` value is present (a folded
+    ``description: >`` block yields the empty marker line, which cannot
+    exceed the limit on its own and is left to the regular validator).
+    """
+    frontmatter_raw, _body_raw = split_frontmatter(content)
+    if frontmatter_raw is None:
+        return ""
+    desc_re = re.compile(
+        r"^description:[ \t]*(?P<value>.*?)[ \t]*$", re.MULTILINE,
+    )
+    match = desc_re.search(frontmatter_raw)
+    if match is None:
+        return ""
+    value = match.group("value").strip()
+    # A folded/literal block scalar marker (``>`` / ``|`` possibly with
+    # a chomping indicator) is not the description text itself.
+    if value in (">", "|", ">-", "|-", ">+", "|+"):
+        return ""
+    return value

--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -57,8 +57,19 @@ the generic ``non_path_fails`` bucket — every other name-related FAIL
 flows through unchanged so a partial-fix run cannot mask unresolved
 spec violations.
 
-All functions return findings as ``(errors, passes)``-style tuples per
-the repo convention; none raise for a validation outcome.
+Public function shapes:
+
+* :func:`compute_safe_name` — ``str → str`` (pure transform).
+* :func:`compute_name_fix` — ``(new_name, applied, manual, owned_fails)``.
+* :func:`compute_description_manual_finding` — ``str → list[str]``.
+* :func:`compute_name_fix_plan` — ``(new_name, applied, manual, errors,
+  owned_fails)``.
+* :func:`rewrite_name_line` — ``(content, new_name) → str | None``.
+* :func:`write_name_fix` — ``(modified, errors)``.
+
+None of them raise for a validation, structural, or I/O outcome —
+errors are reported through the relevant tuple slot per the repo's
+"validation never raises" convention.
 """
 
 import os
@@ -251,13 +262,20 @@ def rewrite_name_line(content: str, new_name: str) -> str | None:
 
     Returns the rewritten text, or ``None`` when the ``name:`` line
     cannot be located inside the frontmatter block (no frontmatter, no
-    closing delimiter, no ``name:`` key) **or** when the raw value
-    carries a quoted scalar or an inline ``#`` comment that the
-    minimal line rewriter would silently strip.  ``None`` signals the
-    caller to leave the file untouched rather than guess.
+    closing ``---`` delimiter, more than one ``name:`` line, no
+    ``name:`` key) **or** when the raw value carries a quoted scalar
+    or an inline ``#`` comment that the minimal line rewriter would
+    silently strip.  ``None`` signals the caller to leave the file
+    untouched rather than guess.
     """
-    frontmatter_raw, _body_raw = split_frontmatter(content)
+    frontmatter_raw, body_raw = split_frontmatter(content)
     if frontmatter_raw is None:
+        return None
+    if body_raw is None:
+        # ``split_frontmatter`` returns ``(frontmatter, None)`` when an
+        # opening ``---`` is found but no closing ``---`` exists.  The
+        # file is structurally malformed; refuse to rewrite rather than
+        # touch a SKILL.md the parser cannot even bound.
         return None
 
     # Resolve the span of the frontmatter text inside *content* so the
@@ -357,11 +375,21 @@ def compute_name_fix_plan(
         )
         return None, applied, manual, errors, owned
 
-    frontmatter_raw, _body_raw = split_frontmatter(content)
+    frontmatter_raw, body_raw = split_frontmatter(content)
     if frontmatter_raw is None:
         errors.append(
             f"{LEVEL_FAIL}: [spec] no YAML frontmatter found — "
             "cannot locate the 'name' field to fix"
+        )
+        return None, applied, manual, errors, owned
+    if body_raw is None:
+        # Opening ``---`` without a closing delimiter: the frontmatter
+        # bounds are undefined, so any rewrite could land on the wrong
+        # side of the file.  Surface the structural failure and refuse
+        # rather than touch a SKILL.md the parser cannot even bound.
+        errors.append(
+            f"{LEVEL_FAIL}: [spec] frontmatter has no closing '---' "
+            "delimiter — cannot safely locate the 'name:' line"
         )
         return None, applied, manual, errors, owned
 
@@ -527,10 +555,13 @@ def _raw_value_blocks_rewrite(raw_value: str) -> bool:
     an inline ``# comment`` — applying it would silently strip both.
     Detect either form on the captured value span so the planner can
     refuse to rewrite rather than lose the source bytes.  ``#`` is only
-    flagged when preceded by whitespace, matching the YAML subset
-    parser's inline-comment recogniser; that keeps a ``#`` embedded in a
-    plain scalar (``name: foo#bar`` → YAML value ``foo#bar``) from being
-    misclassified.
+    flagged when preceded by a space, matching the exact rule
+    ``yaml_parser._strip_inline_comment`` applies (``text[i - 1] == " "``);
+    a ``#`` preceded by a tab or embedded in a plain scalar
+    (``name: foo#bar`` → YAML value ``foo#bar``) is left for the parser
+    to decide, since the parser treats it as part of the scalar and the
+    rewriter must not be stricter than the parser's view of "what is a
+    comment".
     """
     trimmed = raw_value.strip()
     if (
@@ -544,7 +575,7 @@ def _raw_value_blocks_rewrite(raw_value: str) -> bool:
         # scope for the minimal rewriter.
         return True
     for index in range(1, len(raw_value)):
-        if raw_value[index] == "#" and raw_value[index - 1] in (" ", "\t"):
+        if raw_value[index] == "#" and raw_value[index - 1] == " ":
             return True
     return False
 

--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -6,12 +6,25 @@ unambiguous: lowercase the letters, and replace ``_`` / `` `` with
 ``-``.  This module computes that correction and applies it as a
 *minimal, targeted textual replacement* of the single ``name:`` value
 line in the on-disk ``SKILL.md`` — the rest of the file (the remaining
-frontmatter and the entire body) is preserved byte-for-byte.
+frontmatter and the entire body) is preserved verbatim, with one
+caveat for CRLF checkouts (below).
 
 The foundry's stdlib-only YAML subset parser does **not** round-trip
 (comments, quoting style, key order, and block-scalar layout are lost on
 re-serialisation), so this module never re-serialises the frontmatter.
 It rewrites exactly one line.
+
+**Line-ending normalization.** ``write_name_fix`` reads SKILL.md in
+text mode (universal-newline translation collapses ``\\r\\n`` to
+``\\n`` on input) and writes back with ``newline="\\n"`` per the
+repo-wide LF-on-write convention (see ``CLAUDE.md``).  A CRLF-on-disk
+SKILL.md is therefore normalized to LF when any safe fix lands; the
+"preserve the rest of the file" guarantee holds at the *content* level
+(every body byte and every untouched frontmatter byte is preserved
+verbatim) but not at the *line-ending* level on a CRLF checkout.  The
+``--apply`` path is otherwise a no-op when the computed value already
+matches the on-disk bytes, so an LF-only checkout is touched only when
+the safe fix actually changes the ``name:`` value.
 
 Three classes of problem are intentionally **not** auto-fixed because
 the correct resolution requires human judgement or because the safe
@@ -405,19 +418,28 @@ def compute_name_fix_plan(
         )
         return None, applied, manual, errors, owned
 
+    new_name, applied, fix_manual, fix_owned = compute_name_fix(
+        current_name, dir_name,
+    )
+
+    # Quote / inline-comment syntax on the raw ``name:`` line only
+    # blocks the minimal-line rewriter — a perfectly valid quoted name
+    # (``name: "my-skill"``) does not need a rewrite at all, and
+    # ``--fix`` must not fail a conforming SKILL.md just because its
+    # author chose a quoted scalar.  Refuse only when ``compute_name_fix``
+    # is actually proposing a write (``new_name`` is not ``None``); in
+    # that case discard the would-be fix and surrender ownership so the
+    # regular validator's FAILs flow through unchanged.
     raw_value = raw_value_match.group("value")
-    if _raw_value_blocks_rewrite(raw_value):
+    if new_name is not None and _raw_value_blocks_rewrite(raw_value):
         manual.append(
             f"{LEVEL_FAIL}: [spec] manual fix needed — the 'name:' "
             "line carries a quoted scalar or an inline '#' comment; "
             "the minimal line rewriter would silently strip that "
             "syntax — normalize the value by hand"
         )
-        return None, applied, manual, errors, owned
+        return None, [], manual, errors, []
 
-    new_name, applied, fix_manual, fix_owned = compute_name_fix(
-        current_name, dir_name,
-    )
     manual.extend(fix_manual)
     owned.extend(fix_owned)
 
@@ -446,9 +468,11 @@ def write_name_fix(
 
     The *apply* half of the unified flow — called only under
     ``--fix --apply`` with a *new_name* already computed by
-    :func:`compute_name_fix_plan`.  Rewrites the single ``name:`` line in
-    place (preserving the rest of the file byte-for-byte, written with
-    ``newline="\\n"``) and returns ``(modified, errors)``:
+    :func:`compute_name_fix_plan`.  Rewrites the single ``name:`` line
+    in place (every body byte and every untouched frontmatter byte is
+    preserved verbatim, written with ``newline="\\n"`` per the
+    repo-wide LF-on-write convention — see the module docstring's
+    note on CRLF-on-disk checkouts) and returns ``(modified, errors)``:
 
     * ``modified`` — ``True`` only when the file was actually rewritten.
     * ``errors`` — ``FAIL`` findings for an unreadable file, a

--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -409,25 +409,12 @@ def compute_name_fix_plan(
         )
         return None, applied, manual, errors, owned
 
+    # Duplicate ``name:`` keys are unambiguously broken frontmatter
+    # regardless of whether the planner would propose a rewrite — the
+    # parser silently picks one and the rewriter would touch the
+    # other.  The error fires up front, before any other reasoning.
     raw_value_matches = list(_RE_NAME_LINE.finditer(frontmatter_raw))
-    if not raw_value_matches:
-        # The parser saw a ``name`` key (flow-style mapping, alias, or
-        # similar) but the line-oriented rewriter cannot target a single
-        # physical line.  Refuse rather than guess.
-        errors.append(
-            f"{LEVEL_FAIL}: [foundry] 'name:' is not on its own line — "
-            "the minimal line rewriter cannot target it; normalize the "
-            "frontmatter by hand"
-        )
-        return None, applied, manual, errors, owned
     if len(raw_value_matches) > 1:
-        # Duplicate ``name:`` keys: ``parse_yaml_subset`` resolves to
-        # the *last* mapping entry, but a line-targeted rewrite would
-        # only update the *first* — applying the fix would leave the
-        # effective value untouched while ownership-suppressing the
-        # validator FAILs, so ``--fix --apply`` could report success on
-        # a still-invalid skill.  The duplicate-key shape is itself a
-        # frontmatter authoring error the user needs to resolve by hand.
         errors.append(
             f"{LEVEL_FAIL}: [foundry] multiple 'name:' keys in "
             f"frontmatter ({len(raw_value_matches)} found) — "
@@ -436,7 +423,7 @@ def compute_name_fix_plan(
             "hand"
         )
         return None, applied, manual, errors, owned
-    raw_value_match = raw_value_matches[0]
+    raw_value_match = raw_value_matches[0] if raw_value_matches else None
 
     current_name = parsed_fm["name"]
     if not isinstance(current_name, str):
@@ -450,23 +437,34 @@ def compute_name_fix_plan(
         current_name, dir_name,
     )
 
-    # Quote / inline-comment syntax on the raw ``name:`` line only
-    # blocks the minimal-line rewriter — a perfectly valid quoted name
-    # (``name: "my-skill"``) does not need a rewrite at all, and
-    # ``--fix`` must not fail a conforming SKILL.md just because its
-    # author chose a quoted scalar.  Refuse only when ``compute_name_fix``
-    # is actually proposing a write (``new_name`` is not ``None``); in
-    # that case discard the would-be fix and surrender ownership so the
-    # regular validator's FAILs flow through unchanged.
-    raw_value = raw_value_match.group("value")
-    if new_name is not None and _raw_value_blocks_rewrite(raw_value):
-        manual.append(
-            f"{LEVEL_FAIL}: [spec] manual fix needed — the 'name:' "
-            "line carries a quoted scalar or an inline '#' comment; "
-            "the minimal line rewriter would silently strip that "
-            "syntax — normalize the value by hand"
-        )
-        return None, [], manual, errors, []
+    # Rewrite-mechanics guards (no locatable ``name:`` line, quoted
+    # scalar, inline ``#`` comment) only matter when the planner is
+    # actually proposing a write.  A SKILL.md whose ``name`` is
+    # already valid YAML and already passes ``validate_name`` —
+    # e.g. ``name : my-skill`` with whitespace before the colon, or
+    # ``name: "my-skill"`` as a quoted scalar — must not fail ``--fix``
+    # just because its formatting is unusual.  When the planner has
+    # nothing to apply (``new_name is None``), skip the guards so the
+    # plan returns clean; otherwise emit the relevant refusal, discard
+    # the would-be fix, and surrender ownership so the regular
+    # validator's FAILs flow through.
+    if new_name is not None:
+        if raw_value_match is None:
+            errors.append(
+                f"{LEVEL_FAIL}: [foundry] 'name:' is not on its own "
+                "line — the minimal line rewriter cannot target it; "
+                "normalize the frontmatter by hand"
+            )
+            return None, [], manual, errors, []
+        raw_value = raw_value_match.group("value")
+        if _raw_value_blocks_rewrite(raw_value):
+            manual.append(
+                f"{LEVEL_FAIL}: [spec] manual fix needed — the 'name:' "
+                "line carries a quoted scalar or an inline '#' "
+                "comment; the minimal line rewriter would silently "
+                "strip that syntax — normalize the value by hand"
+            )
+            return None, [], manual, errors, []
 
     manual.extend(fix_manual)
     owned.extend(fix_owned)

--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -6,25 +6,30 @@ corrected value is unambiguous: lowercase the letters, and replace
 ``_``, space, and tab with ``-``.  This module computes that
 correction and applies it as a *minimal, targeted textual replacement*
 of the single ``name:`` value line in the on-disk ``SKILL.md`` — the
-rest of the file (the remaining frontmatter and the entire body) is
-preserved verbatim, with one caveat for CRLF checkouts (below).
+rest of the file (the remaining frontmatter and the entire body) keeps
+its content unchanged.  Line endings round-trip through the helpers
+differently depending on the call path; see the note below.
 
 The foundry's stdlib-only YAML subset parser does **not** round-trip
 (comments, quoting style, key order, and block-scalar layout are lost on
 re-serialisation), so this module never re-serialises the frontmatter.
 It rewrites exactly one line.
 
-**Line-ending normalization.** ``write_name_fix`` reads SKILL.md in
-text mode (universal-newline translation collapses ``\\r\\n`` to
-``\\n`` on input) and writes back with ``newline="\\n"`` per the
-repo-wide LF-on-write convention (see ``CLAUDE.md``).  A CRLF-on-disk
-SKILL.md is therefore normalized to LF when any safe fix lands; the
-"preserve the rest of the file" guarantee holds at the *content* level
-(every body byte and every untouched frontmatter byte is preserved
-verbatim) but not at the *line-ending* level on a CRLF checkout.  The
-``--apply`` path is otherwise a no-op when the computed value already
-matches the on-disk bytes, so an LF-only checkout is touched only when
-the safe fix actually changes the ``name:`` value.
+**Line endings.** :func:`rewrite_name_line` operates directly on the
+input string; the regex captures the rewritten line's ``\\r?`` so a
+CRLF source line round-trips its terminator and an LF source line
+stays LF — direct callers see the full file's line endings preserved.
+:func:`write_name_fix` reads SKILL.md in text mode (universal-newline
+translation collapses ``\\r\\n`` to ``\\n`` on input) and writes back
+with ``newline="\\n"`` per the repo-wide LF-on-write convention (see
+``CLAUDE.md``); a CRLF-on-disk SKILL.md is therefore normalized to LF
+when any safe fix lands.  The content-preservation guarantee — every
+body line's text and every untouched frontmatter line's text — holds
+on both paths; only the line-ending shape of the surrounding file
+differs between them.  The ``--apply`` path is otherwise a no-op when
+the computed value already matches the on-disk bytes, so an LF-only
+checkout is touched only when the safe fix actually changes the
+``name:`` value.
 
 Three classes of problem are intentionally **not** auto-fixed because
 the correct resolution requires human judgement or because the safe
@@ -85,19 +90,34 @@ from .validation import validate_name
 from .yaml_parser import parse_yaml_subset
 
 
-# Matches a frontmatter ``name:`` line and captures the three spans the
+# Matches a frontmatter ``name:`` line and captures the four spans the
 # rewriter must preserve around the value: the ``name:`` key plus the
 # whitespace after the colon (group ``prefix``), the value itself
-# (group ``value``), and any trailing whitespace before the line
-# terminator (group ``trailing``).  Anchored at line start so a ``name:``
-# appearing inside a folded ``description`` block (which would be
-# indented) is never matched.  ``re.MULTILINE`` lets ``^``/``$`` bind to
-# physical line boundaries within the frontmatter text.  The colon must
-# be flush against ``name`` (no leading whitespace) because the
-# rewriter does an exact line replacement — see ``_RE_NAME_KEY_ANY``
-# below for the relaxed regex used by the duplicate-key guard.
+# (group ``value``), any trailing whitespace before the line terminator
+# (group ``trailing``), and an optional carriage return so a CRLF line
+# round-trips its terminator (group ``eol``).  Anchored at line start so
+# a ``name:`` appearing inside a folded ``description`` block (which
+# would be indented) is never matched.  ``re.MULTILINE`` lets ``^`` /
+# ``$`` bind to physical line boundaries within the frontmatter text;
+# ``$`` matches just before ``\n``, so the ``value`` group is
+# constrained to ``[^\r\n]*?`` to keep a stray ``\r`` out of it.
+# Without the explicit ``eol`` capture the ``\r`` from a CRLF
+# terminator would otherwise be left dangling outside the substitution
+# (the lazy ``.*?`` previously consumed it) and the rewritten line
+# would lose its carriage return while the rest of the file kept CRLF
+# — a contract violation for direct ``rewrite_name_line`` callers
+# (the CLI path goes through ``write_name_fix``'s text-mode read,
+# which strips ``\r`` before this regex sees the content; but the
+# helper's documented "preserves the surrounding line shape" contract
+# applies to direct callers too).  The colon must be flush against
+# ``name`` (no leading whitespace) because the rewriter does an exact
+# line replacement — see ``_RE_NAME_KEY_ANY`` below for the relaxed
+# regex used by the duplicate-key guard.
 _RE_NAME_LINE = re.compile(
-    r"^(?P<prefix>name:[ \t]*)(?P<value>.*?)(?P<trailing>[ \t]*)$",
+    r"^(?P<prefix>name:[ \t]*)"
+    r"(?P<value>[^\r\n]*?)"
+    r"(?P<trailing>[ \t]*)"
+    r"(?P<eol>\r?)$",
     re.MULTILINE,
 )
 
@@ -272,10 +292,14 @@ def rewrite_name_line(content: str, new_name: str) -> str | None:
     """Return *content* with only the frontmatter ``name:`` value replaced.
 
     The replacement is line-targeted: the ``name:`` key, the spacing
-    after the colon, and any trailing whitespace are preserved exactly;
-    only the value token changes.  Everything outside that one line —
-    the rest of the frontmatter and the entire body — is returned
-    byte-for-byte.
+    after the colon, any trailing whitespace, and the line terminator
+    (``\\r?\\n``) are all preserved exactly; only the value token
+    changes.  Everything outside that one line — the rest of the
+    frontmatter and the entire body — is returned byte-for-byte,
+    including the file's existing line-ending shape (LF or CRLF).
+    The end-to-end ``write_name_fix`` path normalizes to LF separately
+    via ``newline="\\n"`` on write — see the module docstring's *Line
+    endings* note.
 
     Returns the rewritten text, or ``None`` when the ``name:`` line
     cannot be located inside the frontmatter block (no frontmatter, no
@@ -332,7 +356,14 @@ def rewrite_name_line(content: str, new_name: str) -> str | None:
         if replaced:
             return match.group(0)
         replaced = True
-        return f"{match.group('prefix')}{new_name}{match.group('trailing')}"
+        # ``eol`` is the optional ``\r`` captured by ``_RE_NAME_LINE``
+        # so a CRLF source line keeps its carriage return; for LF
+        # input it is the empty string and the substitution is a
+        # no-op on line endings.
+        return (
+            f"{match.group('prefix')}{new_name}"
+            f"{match.group('trailing')}{match.group('eol')}"
+        )
 
     new_fm = _RE_NAME_LINE.sub(_sub, fm_text, count=1)
     if not replaced:
@@ -538,10 +569,12 @@ def write_name_fix(
     The *apply* half of the unified flow — called only under
     ``--fix --apply`` with a *new_name* already computed by
     :func:`compute_name_fix_plan`.  Rewrites the single ``name:`` line
-    in place (every body byte and every untouched frontmatter byte is
-    preserved verbatim, written with ``newline="\\n"`` per the
-    repo-wide LF-on-write convention — see the module docstring's
-    note on CRLF-on-disk checkouts) and returns ``(modified, errors)``:
+    in place; every body line's content and every untouched
+    frontmatter line's content is preserved.  The file is written with
+    ``newline="\\n"`` per the repo-wide LF-on-write convention, so a
+    CRLF-on-disk SKILL.md comes back LF-only — see the module
+    docstring's *Line endings* note for the contract on each helper.
+    Returns ``(modified, errors)``:
 
     * ``modified`` — ``True`` only when the file was actually rewritten.
     * ``errors`` — ``FAIL`` findings for an unreadable file, a

--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -462,17 +462,46 @@ def compute_name_fix_plan(
         current_name, dir_name,
     )
 
+    # Over-length-description is independent of every name-rewrite
+    # condition the planner can encounter, so compute it once up
+    # front.  The refusal branches below all need to surface this
+    # finding (and own the matching validator FAIL) the same way the
+    # non-refusal path does — otherwise a SKILL.md that has *both* a
+    # quoted/commented/block-scalar name *and* an over-length
+    # description would lose the description finding under
+    # ``name_fix.manual_fix_needed`` because the refusal returned
+    # before the description check ran.  ``description`` is the
+    # *parsed* scalar (quotes and inline comments already stripped)
+    # so its length matches what ``validate_skill.validate_description``
+    # measures.
+    description = _extract_description_value(parsed_fm)
+    desc_manual = compute_description_manual_finding(description)
+    desc_owned: list[str] = []
+    if desc_manual:
+        # Mirrors the wording in ``validate_skill.validate_description``
+        # — the two strings must stay in sync.  Owning the validator's
+        # exact FAIL string keeps it from being double-reported under
+        # ``non_path_fails`` once the planner has surfaced the manual
+        # finding.
+        desc_owned.append(
+            f"{LEVEL_FAIL}: [spec] 'description' exceeds "
+            f"{MAX_DESCRIPTION_CHARS} characters "
+            f"({len(description)} chars)"
+        )
+
     # Rewrite-mechanics guards (no locatable ``name:`` line, quoted
-    # scalar, inline ``#`` comment) only matter when the planner is
-    # actually proposing a write.  A SKILL.md whose ``name`` is
-    # already valid YAML and already passes ``validate_name`` —
-    # e.g. ``name : my-skill`` with whitespace before the colon, or
-    # ``name: "my-skill"`` as a quoted scalar — must not fail ``--fix``
-    # just because its formatting is unusual.  When the planner has
-    # nothing to apply (``new_name is None``), skip the guards so the
-    # plan returns clean; otherwise emit the relevant refusal, discard
-    # the would-be fix, and surrender ownership so the regular
-    # validator's FAILs flow through.
+    # scalar, inline ``#`` comment, block-scalar header) only matter
+    # when the planner is actually proposing a write.  A SKILL.md
+    # whose ``name`` is already valid YAML and already passes
+    # ``validate_name`` — e.g. ``name : my-skill`` with whitespace
+    # before the colon, or ``name: "my-skill"`` as a quoted scalar —
+    # must not fail ``--fix`` just because its formatting is unusual.
+    # When the planner has nothing to apply (``new_name is None``),
+    # skip the guards so the plan returns clean; otherwise emit the
+    # relevant refusal, discard the would-be fix, surrender name
+    # ownership so the regular validator's FAILs flow through, and
+    # *still* carry the description finding and its ownership through
+    # — those are an independent manual condition.
     if new_name is not None:
         if raw_value_match is None:
             errors.append(
@@ -480,7 +509,7 @@ def compute_name_fix_plan(
                 "line — the minimal line rewriter cannot target it; "
                 "normalize the frontmatter by hand"
             )
-            return None, [], manual, errors, []
+            return None, [], desc_manual, errors, list(desc_owned)
         raw_value = raw_value_match.group("value")
         if _raw_value_blocks_rewrite(raw_value):
             manual.append(
@@ -491,26 +520,13 @@ def compute_name_fix_plan(
                 "syntax or leave the indented scalar body behind — "
                 "normalize the value by hand"
             )
-            return None, [], manual, errors, []
+            manual.extend(desc_manual)
+            return None, [], manual, errors, list(desc_owned)
 
     manual.extend(fix_manual)
     owned.extend(fix_owned)
-
-    description = _extract_description_value(parsed_fm)
-    desc_manual = compute_description_manual_finding(description)
-    if desc_manual:
-        manual.extend(desc_manual)
-        # Own the exact FAIL string ``validate_skill`` emits so the
-        # caller does not double-report it.  Mirrors the wording in
-        # ``validate_skill.validate_description`` — the two strings
-        # must stay in sync.  ``description`` is the *parsed* scalar
-        # (quotes and inline comments already stripped) so its length
-        # matches the value the validator measures.
-        owned.append(
-            f"{LEVEL_FAIL}: [spec] 'description' exceeds "
-            f"{MAX_DESCRIPTION_CHARS} characters "
-            f"({len(description)} chars)"
-        )
+    manual.extend(desc_manual)
+    owned.extend(desc_owned)
     return new_name, applied, manual, errors, owned
 
 

--- a/skill-system-foundry/scripts/lib/name_fixer.py
+++ b/skill-system-foundry/scripts/lib/name_fixer.py
@@ -1,13 +1,13 @@
 """Safe, deterministic auto-fixes for the SKILL.md ``name`` frontmatter.
 
 When ``validate_name`` FAILs because the ``name`` field carries
-uppercase characters, underscores, or spaces, the corrected value is
-unambiguous: lowercase the letters, and replace ``_`` / `` `` with
-``-``.  This module computes that correction and applies it as a
-*minimal, targeted textual replacement* of the single ``name:`` value
-line in the on-disk ``SKILL.md`` — the rest of the file (the remaining
-frontmatter and the entire body) is preserved verbatim, with one
-caveat for CRLF checkouts (below).
+uppercase characters, underscores, or in-value whitespace, the
+corrected value is unambiguous: lowercase the letters, and replace
+``_``, space, and tab with ``-``.  This module computes that
+correction and applies it as a *minimal, targeted textual replacement*
+of the single ``name:`` value line in the on-disk ``SKILL.md`` — the
+rest of the file (the remaining frontmatter and the entire body) is
+preserved verbatim, with one caveat for CRLF checkouts (below).
 
 The foundry's stdlib-only YAML subset parser does **not** round-trip
 (comments, quoting style, key order, and block-scalar layout are lost on
@@ -204,8 +204,11 @@ def compute_name_fix(
                 "with hyphens"
             )
         if " " in current_name or "\t" in current_name:
+            # Tabs and spaces are both replaced by hyphens; the
+            # message uses "whitespace" so the wording does not
+            # imply only space characters triggered the rewrite.
             transforms.append(
-                f"{LEVEL_INFO}: [foundry] 'name' spaces replaced "
+                f"{LEVEL_INFO}: [foundry] 'name' whitespace replaced "
                 "with hyphens"
             )
 

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -839,9 +839,13 @@ def validate_skill(
     try:
         frontmatter, body, scalar_findings = load_frontmatter(skill_md)
     except (OSError, UnicodeError) as exc:
+        # Include the full path so CI logs and nested-tree audits can
+        # identify which skill's entry file failed to load — a bare
+        # ``cannot read SKILL.md`` is ambiguous across a deployed
+        # ``skills/`` tree.
         errors.append(
-            f"{LEVEL_FAIL}: [foundry] cannot read {entry_filename} "
-            f"({exc.__class__.__name__}: {exc})"
+            f"{LEVEL_FAIL}: [foundry] cannot read {entry_filename} at "
+            f"{to_posix(skill_md)} ({exc.__class__.__name__}: {exc})"
         )
         return errors, passes
 
@@ -1269,11 +1273,11 @@ def _build_parser() -> argparse.ArgumentParser:
             "reference rewrites into canonical file-relative form (per "
             "references/path-resolution.md) AND safe SKILL.md 'name' "
             "frontmatter normalization (lowercase; underscores and "
-            "spaces to hyphens).  Dry-run by default — no files are "
-            "modified.  Ambiguous problems (name does not match "
-            "directory; description over the length limit) are reported "
-            "as 'manual fix needed' and never auto-applied.  Use --fix "
-            "--apply to write the changes."
+            "in-value whitespace — spaces and tabs — to hyphens).  "
+            "Dry-run by default — no files are modified.  Ambiguous "
+            "problems (name does not match directory; description over "
+            "the length limit) are reported as 'manual fix needed' and "
+            "never auto-applied.  Use --fix --apply to write the changes."
         ),
     )
     parser.add_argument(

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -829,20 +829,23 @@ def validate_skill(
         errors.append(f"{LEVEL_FAIL}: [spec] No {entry_filename} found in {skill_path}")
         return errors, passes
 
-    # Parse frontmatter.  An unreadable / undecodable SKILL.md is
-    # surfaced as a structured FAIL rather than allowed to propagate as
-    # an unhandled OSError / UnicodeError — ``validate_skill`` is
-    # contracted to "never raise" so its callers (including the
-    # ``--fix`` driver's pre-planner probe) can rely on a clean
-    # ``(errors, passes)`` return for any input the filesystem can
-    # surface.
+    # Parse frontmatter.  An unreadable / undecodable entry markdown
+    # file (``SKILL.md`` for a registered skill, ``capability.md`` for
+    # a capability) is surfaced as a structured FAIL rather than
+    # allowed to propagate as an unhandled ``OSError`` / ``UnicodeError``
+    # — ``validate_skill`` is contracted to "never raise" so its
+    # callers (including the ``--fix`` driver's pre-planner probe)
+    # can rely on a clean ``(errors, passes)`` return for any input
+    # the filesystem can surface.
     try:
         frontmatter, body, scalar_findings = load_frontmatter(skill_md)
     except (OSError, UnicodeError) as exc:
         # Include the full path so CI logs and nested-tree audits can
         # identify which skill's entry file failed to load — a bare
-        # ``cannot read SKILL.md`` is ambiguous across a deployed
-        # ``skills/`` tree.
+        # ``cannot read <entry_filename>`` is ambiguous across a
+        # deployed ``skills/`` tree, and the filename alone does not
+        # distinguish a ``SKILL.md`` (skill root) from a
+        # ``capability.md`` (capability mode).
         errors.append(
             f"{LEVEL_FAIL}: [foundry] cannot read {entry_filename} at "
             f"{to_posix(skill_md)} ({exc.__class__.__name__}: {exc})"

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -829,8 +829,21 @@ def validate_skill(
         errors.append(f"{LEVEL_FAIL}: [spec] No {entry_filename} found in {skill_path}")
         return errors, passes
 
-    # Parse frontmatter
-    frontmatter, body, scalar_findings = load_frontmatter(skill_md)
+    # Parse frontmatter.  An unreadable / undecodable SKILL.md is
+    # surfaced as a structured FAIL rather than allowed to propagate as
+    # an unhandled OSError / UnicodeError — ``validate_skill`` is
+    # contracted to "never raise" so its callers (including the
+    # ``--fix`` driver's pre-planner probe) can rely on a clean
+    # ``(errors, passes)`` return for any input the filesystem can
+    # surface.
+    try:
+        frontmatter, body, scalar_findings = load_frontmatter(skill_md)
+    except (OSError, UnicodeError) as exc:
+        errors.append(
+            f"{LEVEL_FAIL}: [foundry] cannot read {entry_filename} "
+            f"({exc.__class__.__name__}: {exc})"
+        )
+        return errors, passes
 
     if frontmatter is None and not is_capability:
         errors.append(f"{LEVEL_FAIL}: [spec] No YAML frontmatter found (must start with ---)")
@@ -1441,8 +1454,11 @@ def main() -> None:
                     and "name" in fm_probe
                 )
             except (OSError, UnicodeError):
-                # An I/O error here is also covered by the validator
-                # below; let it surface there alone.
+                # An I/O / decoding failure on SKILL.md is surfaced as
+                # a FAIL by ``validate_skill`` below (which wraps
+                # ``load_frontmatter`` in the same ``try`` shape).
+                # Skip the planner so the same root cause is not
+                # restated in two slots of the JSON payload.
                 should_plan = False
             if should_plan:
                 (
@@ -1568,24 +1584,28 @@ def main() -> None:
 
         # Apply the safe ``name`` normalization under ``--apply`` too —
         # the single-line in-place rewrite computed above.  Gated behind
-        # ``not name_manual and not name_errors`` so a planned safe fix
-        # is *not* written when the planner also surfaced an ambiguous
-        # problem (directory mismatch, over-length description, the
-        # computed candidate still violates the spec, the raw line
-        # carries quote/comment syntax that would be stripped) or a
-        # structural / I/O failure.  This matches the documented contract
-        # that ambiguous problems are "never auto-applied" — without the
-        # gate a name rewrite would land on a SKILL.md that the run is
-        # *also* failing for a manual reason, mutating the file under a
-        # red light.  ``write_name_fix`` never raises (I/O / structural
-        # problems come back as findings), so its errors join
-        # ``name_errors`` and gate ``fix_success`` exactly like a
+        # ``apply_error is None and not name_manual and not name_errors``
+        # so a planned safe fix is *not* written when the path-rewriter
+        # already raised (``apply_error`` set), when the planner also
+        # surfaced an ambiguous problem (directory mismatch, over-length
+        # description, the computed candidate still violates the spec,
+        # the raw line carries quote/comment syntax that would be
+        # stripped), or when a structural / I/O failure was recorded.
+        # The ``apply_error`` clause prevents a second fix category from
+        # widening the partial-apply state after the first phase has
+        # already failed — a ``--fix --apply`` run that already errors
+        # must not also mutate ``SKILL.md`` from a later phase.  This
+        # matches the documented contract that ambiguous problems are
+        # "never auto-applied".  ``write_name_fix`` never raises (I/O /
+        # structural problems come back as findings), so its errors
+        # join ``name_errors`` and gate ``fix_success`` exactly like a
         # path-rewrite apply error.  Counts the SKILL.md as one modified
         # file when the write lands so the human/JSON ``modified`` total
         # reflects both categories.
         name_modified = False
         if (
             args.apply
+            and apply_error is None
             and name_new is not None
             and not name_manual
             and not name_errors

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -1614,7 +1614,17 @@ def main() -> None:
                 skill_md_for_name, name_new,
             )
             name_errors.extend(write_errors)
-            if name_modified:
+            # ``apply_fixes`` returns the number of *unique* files
+            # mutated by the path rewriter, so only credit a separate
+            # file when the name fix landed on a SKILL.md the path
+            # rewriter did not already touch.  Without this guard a
+            # SKILL.md carrying both a legacy reference and an
+            # invalid name would be counted twice in the human
+            # ``Modified N file(s)`` line and in the JSON
+            # ``modified`` field.
+            if name_modified and not any(
+                row["file"] == skill_md_for_name for row in rows
+            ):
                 modified += 1
 
         # Single source of truth for the fix-mode pass/fail predicate.

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -1418,11 +1418,16 @@ def main() -> None:
         name_applied: list[str] = []
         name_manual: list[str] = []
         name_errors: list[str] = []
+        name_owned_fails: list[str] = []
         skill_md_for_name = os.path.join(rewrite_root, FILE_SKILL_MD)
         if os.path.isfile(skill_md_for_name):
-            name_new, name_applied, name_manual, name_errors = (
-                compute_name_fix_plan(skill_md_for_name)
-            )
+            (
+                name_new,
+                name_applied,
+                name_manual,
+                name_errors,
+                name_owned_fails,
+            ) = compute_name_fix_plan(skill_md_for_name)
         # Validate the same tree the rewriter operates on.  In
         # capability mode the rewriter walks the enclosing skill root,
         # so the validator must too — otherwise unfixable findings or
@@ -1495,40 +1500,22 @@ def main() -> None:
             and (err.startswith(LEVEL_FAIL) or err.startswith(LEVEL_WARN))
             and not _is_covered_by_rewriter(err)
         ]
-        # Name-frontmatter ``[spec]`` FAILs are owned by the name-fix
-        # category, not the generic ``non_path_fails`` bucket — exactly
-        # as ``_is_covered_by_rewriter`` keeps rewriter-handled
+        # Name-fix-owned FAILs are suppressed from the generic
+        # ``non_path_fails`` bucket — mirroring how
+        # ``_is_covered_by_rewriter`` keeps rewriter-handled
         # path-resolution findings out of ``unfixable_findings``.  The
-        # safe fixer's lexical corrections (uppercase, underscores,
-        # spaces, invalid format) are reported through ``name_applied`` /
-        # ``name_new`` and cleared on ``--apply``; the dir-mismatch FAIL
-        # and the over-length-description FAIL are reported through
-        # ``name_manual`` (which gates ``fix_success`` on its own).
-        # Dropping these from ``non_path_fails`` prevents double-reporting
-        # and lets a fully-safe, dir-matching name fix preview clean.
-        #
-        # The ``'name'`` FAILs are always name-fix-owned.  The
-        # over-length-description FAIL is dropped only when the name-fix
-        # plan actually surfaced it (``_name_owns_description``) — the
-        # plan's inline extractor leaves a *folded* ``description: >``
-        # block to the regular validator, so a folded over-length
-        # description keeps its FAIL in ``non_path_fails`` as a genuine
-        # gate rather than being silently swallowed.  The un-tagged
-        # Windows-reserved-name FAIL (which the safe fixer does NOT
-        # resolve) lacks ``[spec]`` and stays in ``non_path_fails`` too.
-        _name_owns_description = any(
-            "description" in finding for finding in name_manual
-        )
-
-        def _is_name_spec_fail(err: str) -> bool:
-            if not err.startswith(LEVEL_FAIL):
-                return False
-            if "[spec] 'name'" in err:
-                return True
-            return (
-                _name_owns_description
-                and "[spec] 'description' exceeds" in err
-            )
+        # ownership set is computed by ``compute_name_fix_plan`` (in
+        # ``name_owned_fails``) and contains the *exact* validator FAIL
+        # strings the planner takes responsibility for: every FAIL the
+        # safe fix would resolve (uppercase, underscore, space, invalid
+        # format), the dir-mismatch FAIL when the planner surfaces it
+        # as a manual finding, and the over-length-description FAIL
+        # when the inline extractor sees it.  Any other name FAIL —
+        # empty name, length exceeded, consecutive hyphens that the
+        # safe fix would not clear, the un-tagged Windows-reserved-name
+        # FAIL — is *not* owned and therefore flows through unchanged
+        # so a partial-fix run cannot mask an unresolved spec violation.
+        owned_fail_set = set(name_owned_fails)
 
         # Compute the broader-validity gate up front so JSON consumers
         # see the same gate the human output reflects.  Without it
@@ -1539,7 +1526,7 @@ def main() -> None:
             err for err in validation_errors
             if err.startswith(LEVEL_FAIL)
             and f"[{PATH_RESOLUTION_RULE_NAME}]" not in err
-            and not _is_name_spec_fail(err)
+            and err not in owned_fail_set
         ]
         # Apply rewrites *before* emitting any output so the result —
         # success or failure — can be represented in both human and
@@ -1556,14 +1543,29 @@ def main() -> None:
                 apply_error = f"{exc.__class__.__name__}: {exc}"
 
         # Apply the safe ``name`` normalization under ``--apply`` too —
-        # the single-line in-place rewrite computed above.  ``write_name_fix``
-        # never raises (I/O / structural problems come back as findings),
-        # so its errors join ``name_errors`` and gate ``fix_success``
-        # exactly like a path-rewrite apply error.  Counts the SKILL.md as
-        # one modified file when the write lands so the human/JSON
-        # ``modified`` total reflects both categories.
+        # the single-line in-place rewrite computed above.  Gated behind
+        # ``not name_manual and not name_errors`` so a planned safe fix
+        # is *not* written when the planner also surfaced an ambiguous
+        # problem (directory mismatch, over-length description, the
+        # computed candidate still violates the spec, the raw line
+        # carries quote/comment syntax that would be stripped) or a
+        # structural / I/O failure.  This matches the documented contract
+        # that ambiguous problems are "never auto-applied" — without the
+        # gate a name rewrite would land on a SKILL.md that the run is
+        # *also* failing for a manual reason, mutating the file under a
+        # red light.  ``write_name_fix`` never raises (I/O / structural
+        # problems come back as findings), so its errors join
+        # ``name_errors`` and gate ``fix_success`` exactly like a
+        # path-rewrite apply error.  Counts the SKILL.md as one modified
+        # file when the write lands so the human/JSON ``modified`` total
+        # reflects both categories.
         name_modified = False
-        if args.apply and name_new is not None:
+        if (
+            args.apply
+            and name_new is not None
+            and not name_manual
+            and not name_errors
+        ):
             name_modified, write_errors = write_name_fix(
                 skill_md_for_name, name_new,
             )
@@ -1591,19 +1593,26 @@ def main() -> None:
                 "tool": "validate_skill",
                 "mode": "fix",
                 "success": fix_success,
-                # ``applied`` reflects an actual successful write —
-                # true only when ``--apply`` ran, the rewriter found
-                # something to apply (``rows`` non-empty), and the
-                # write completed without raising.  An I/O error or
-                # an empty ``rows`` list keeps it false so consumers
-                # do not interpret ``applied: true`` as "files were
-                # touched" when the run was actually a no-op or a
-                # partial / failed rewrite.  ``apply_requested``
+                # ``applied`` reflects an actual successful write in
+                # *either* fix category — true only when ``--apply``
+                # ran, at least one write landed (a path-resolution
+                # rewrite via ``rows`` or the SKILL.md ``name:`` line
+                # via ``name_modified``), and the path-rewrite step
+                # completed without raising.  Without the
+                # ``name_modified`` clause a ``--fix --apply --json``
+                # run that only normalized SKILL.md would report
+                # ``applied: false`` while ``name_fix.modified: true``
+                # and ``modified: 1`` — contradictory machine output
+                # for an automation consumer.  ``apply_requested``
                 # carries the user's intent (whether ``--apply`` was
                 # passed) for consumers that need to disambiguate
                 # "no fixes needed" from "did not request apply".
                 "apply_requested": bool(args.apply),
-                "applied": bool(args.apply) and bool(rows) and apply_error is None,
+                "applied": (
+                    bool(args.apply)
+                    and (bool(rows) or name_modified)
+                    and apply_error is None
+                ),
                 "modified": modified,
                 "fixes": [
                     {

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -1619,16 +1619,24 @@ def main() -> None:
         # ``name_manual`` so the run reports failure), but it does not
         # affect whether the safe name rewrite can land — this matches
         # the path rewriter, which still applies safe rewrites while
-        # reporting remaining non-path failures.  The marker is the
-        # ``'description'`` token: every description-only manual
-        # finding in this module is emitted by
-        # ``compute_description_manual_finding`` and carries that
-        # exact substring, while every name-rewrite-blocking finding
-        # is emitted by ``compute_name_fix`` /
-        # ``compute_name_fix_plan`` and carries ``'name'`` or
-        # ``'name:'`` instead.
+        # reporting remaining non-path failures.  Identification is
+        # anchored to the start of the message: every description-only
+        # manual finding is emitted by
+        # ``compute_description_manual_finding`` and begins exactly
+        # ``FAIL: [spec] manual fix needed — 'description' ``, while
+        # every name-rewrite-blocking finding begins with ``'name'``
+        # (or has a different prefix entirely).  A bare-substring scan
+        # for ``'description'`` would mis-classify a dir-mismatch
+        # whose normalized name happens to be ``description``, since
+        # the manual dir-mismatch message embeds the value in quotes
+        # (``manual fix needed — 'name' ('description') does not match
+        # …``); the prefix anchor is the only safe discriminator.
+        _DESC_MANUAL_PREFIX = (
+            f"{LEVEL_FAIL}: [spec] manual fix needed — 'description' "
+        )
         name_rewrite_blockers = [
-            f for f in name_manual if "'description'" not in f
+            f for f in name_manual
+            if not f.startswith(_DESC_MANUAL_PREFIX)
         ]
         name_modified = False
         if (
@@ -1764,12 +1772,19 @@ def main() -> None:
                     )
             if name_new is not None:
                 # Label by the actual write, not the user's intent —
-                # under ``--apply`` the name write is gated behind
-                # ``not name_manual and not name_errors`` (above), so a
-                # computed ``new_name`` can be deliberately *not*
-                # applied.  Printing "Applied" in that case would
-                # contradict the human-output narrative; the manual /
-                # error blocks below explain why the write was skipped.
+                # under ``--apply`` the name write is gated by
+                # ``apply_error is None``, ``new_name`` being set,
+                # ``not name_rewrite_blockers`` (manual findings that
+                # specifically prevent the line rewrite — see the
+                # filter above), and ``not name_errors`` (operational
+                # I/O / structural problems).  A computed ``new_name``
+                # can therefore be deliberately *not* applied — for
+                # example, a dir-mismatch manual finding gates the
+                # write while an over-length-description finding
+                # alone does not.  Printing "Applied" in the gated
+                # case would contradict the human-output narrative;
+                # the manual / error blocks below explain why the
+                # write was skipped.
                 action = "Applied" if name_modified else "Would apply"
                 print(f"\n{action} name normalization:")
                 for finding in name_applied:

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -1252,11 +1252,15 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         dest="fix",
         help=(
-            "Preview mechanical rewrites that bring legacy "
-            "skill-root-form references into canonical file-relative "
-            "form (per references/path-resolution.md).  Dry-run by "
-            "default — no files are modified.  Use --fix --apply to "
-            "write the changes."
+            "Preview all mechanical fixes: legacy skill-root-form "
+            "reference rewrites into canonical file-relative form (per "
+            "references/path-resolution.md) AND safe SKILL.md 'name' "
+            "frontmatter normalization (lowercase; underscores and "
+            "spaces to hyphens).  Dry-run by default — no files are "
+            "modified.  Ambiguous problems (name does not match "
+            "directory; description over the length limit) are reported "
+            "as 'manual fix needed' and never auto-applied.  Use --fix "
+            "--apply to write the changes."
         ),
     )
     parser.add_argument(
@@ -1264,8 +1268,8 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         dest="apply",
         help=(
-            "Apply the rewrites previewed by --fix.  No-op without "
-            "--fix.  Modifies source files in place."
+            "Apply the fixes previewed by --fix.  No-op without --fix.  "
+            "Modifies source files in place."
         ),
     )
     return parser
@@ -1355,6 +1359,7 @@ def main() -> None:
             find_ambiguous_legacy_refs,
             find_fixable_references,
         )
+        from lib.name_fixer import compute_name_fix_plan, write_name_fix
 
         # In capability mode the supplied path is a capability directory
         # — walking only that subtree would miss legacy refs in the
@@ -1397,6 +1402,27 @@ def main() -> None:
         # a separate finding bucket and gate exit code so CI cannot
         # silently accept the retargeting.
         ambiguous_rows = find_ambiguous_legacy_refs(rewrite_root)
+        # Safe SKILL.md ``name`` normalization, folded into the same
+        # preview/apply flow as the path-resolution rewriter above.
+        # ``compute_name_fix_plan`` computes the would-be change without
+        # touching disk — the preview the bare ``--fix`` reports; the
+        # actual single-line write happens later, only under ``--apply``,
+        # via ``write_name_fix``.  Name fixing is a SKILL.md concern, so
+        # it runs against the resolved skill root (``rewrite_root``),
+        # which is the enclosing skill root in ``--capability`` mode too.
+        # Only probe when SKILL.md actually exists — a non-skill target
+        # already surfaces its "No SKILL.md found" FAIL through
+        # ``non_path_fails`` below, and computing the plan on a missing
+        # file would double-report a "cannot read SKILL.md" finding.
+        name_new: str | None = None
+        name_applied: list[str] = []
+        name_manual: list[str] = []
+        name_errors: list[str] = []
+        skill_md_for_name = os.path.join(rewrite_root, FILE_SKILL_MD)
+        if os.path.isfile(skill_md_for_name):
+            name_new, name_applied, name_manual, name_errors = (
+                compute_name_fix_plan(skill_md_for_name)
+            )
         # Validate the same tree the rewriter operates on.  In
         # capability mode the rewriter walks the enclosing skill root,
         # so the validator must too — otherwise unfixable findings or
@@ -1469,6 +1495,41 @@ def main() -> None:
             and (err.startswith(LEVEL_FAIL) or err.startswith(LEVEL_WARN))
             and not _is_covered_by_rewriter(err)
         ]
+        # Name-frontmatter ``[spec]`` FAILs are owned by the name-fix
+        # category, not the generic ``non_path_fails`` bucket — exactly
+        # as ``_is_covered_by_rewriter`` keeps rewriter-handled
+        # path-resolution findings out of ``unfixable_findings``.  The
+        # safe fixer's lexical corrections (uppercase, underscores,
+        # spaces, invalid format) are reported through ``name_applied`` /
+        # ``name_new`` and cleared on ``--apply``; the dir-mismatch FAIL
+        # and the over-length-description FAIL are reported through
+        # ``name_manual`` (which gates ``fix_success`` on its own).
+        # Dropping these from ``non_path_fails`` prevents double-reporting
+        # and lets a fully-safe, dir-matching name fix preview clean.
+        #
+        # The ``'name'`` FAILs are always name-fix-owned.  The
+        # over-length-description FAIL is dropped only when the name-fix
+        # plan actually surfaced it (``_name_owns_description``) — the
+        # plan's inline extractor leaves a *folded* ``description: >``
+        # block to the regular validator, so a folded over-length
+        # description keeps its FAIL in ``non_path_fails`` as a genuine
+        # gate rather than being silently swallowed.  The un-tagged
+        # Windows-reserved-name FAIL (which the safe fixer does NOT
+        # resolve) lacks ``[spec]`` and stays in ``non_path_fails`` too.
+        _name_owns_description = any(
+            "description" in finding for finding in name_manual
+        )
+
+        def _is_name_spec_fail(err: str) -> bool:
+            if not err.startswith(LEVEL_FAIL):
+                return False
+            if "[spec] 'name'" in err:
+                return True
+            return (
+                _name_owns_description
+                and "[spec] 'description' exceeds" in err
+            )
+
         # Compute the broader-validity gate up front so JSON consumers
         # see the same gate the human output reflects.  Without it
         # ``--fix`` could exit 0 on a non-skill directory with no
@@ -1478,6 +1539,7 @@ def main() -> None:
             err for err in validation_errors
             if err.startswith(LEVEL_FAIL)
             and f"[{PATH_RESOLUTION_RULE_NAME}]" not in err
+            and not _is_name_spec_fail(err)
         ]
         # Apply rewrites *before* emitting any output so the result —
         # success or failure — can be represented in both human and
@@ -1493,15 +1555,35 @@ def main() -> None:
             except (OSError, UnicodeError) as exc:
                 apply_error = f"{exc.__class__.__name__}: {exc}"
 
+        # Apply the safe ``name`` normalization under ``--apply`` too —
+        # the single-line in-place rewrite computed above.  ``write_name_fix``
+        # never raises (I/O / structural problems come back as findings),
+        # so its errors join ``name_errors`` and gate ``fix_success``
+        # exactly like a path-rewrite apply error.  Counts the SKILL.md as
+        # one modified file when the write lands so the human/JSON
+        # ``modified`` total reflects both categories.
+        name_modified = False
+        if args.apply and name_new is not None:
+            name_modified, write_errors = write_name_fix(
+                skill_md_for_name, name_new,
+            )
+            name_errors.extend(write_errors)
+            if name_modified:
+                modified += 1
+
         # Single source of truth for the fix-mode pass/fail predicate.
         # The exit-code branch and the JSON ``success`` field both
         # consume this so machine consumers can read the outcome from
         # the captured payload without inspecting the process status.
+        # Name-normalization manual items and operational name errors
+        # gate the run the same way the path-resolution findings do.
         fix_success = not (
             path_resolution_findings
             or non_path_fails
             or ambiguous_rows
             or apply_error is not None
+            or name_manual
+            or name_errors
         )
 
         if json_output:
@@ -1543,6 +1625,24 @@ def main() -> None:
                     }
                     for a in ambiguous_rows
                 ],
+                # Safe SKILL.md ``name`` normalization, reported as a
+                # peer category to the path-resolution rewrites.
+                # ``new_name`` is the would-be value (null when the name
+                # is already valid); ``applied`` lists the INFO findings
+                # for each transformation; ``manual_fix_needed`` carries
+                # the FAIL items the fixer never auto-applies (directory
+                # mismatch, over-length description); ``modified`` is true
+                # only when the SKILL.md was actually rewritten under
+                # ``--apply``; ``errors`` carries operational name-fix
+                # failures (unreadable file, unlocatable ``name:`` line,
+                # write error).
+                "name_fix": {
+                    "new_name": name_new,
+                    "applied": name_applied,
+                    "manual_fix_needed": name_manual,
+                    "modified": name_modified,
+                    "errors": name_errors,
+                },
                 "non_path_fails": non_path_fails,
                 "path_resolution": {
                     "rule_name": PATH_RESOLUTION_RULE_NAME,
@@ -1558,8 +1658,11 @@ def main() -> None:
                 and not path_resolution_findings
                 and not non_path_fails
                 and not ambiguous_rows
+                and name_new is None
+                and not name_manual
+                and not name_errors
             ):
-                print("No mechanical rewrites needed — skill conforms.")
+                print("No mechanical fixes needed — skill conforms.")
             elif rows:
                 action = "Applied" if args.apply else "Would apply"
                 print(f"{action} {len(rows)} rewrites:")
@@ -1568,6 +1671,24 @@ def main() -> None:
                         f"  {r['file_rel']}:{r['line']} "
                         f"'{r['original']}' → '{r['replacement']}'"
                     )
+            if name_new is not None:
+                action = "Applied" if args.apply else "Would apply"
+                print(f"\n{action} name normalization:")
+                for finding in name_applied:
+                    print_error_line(finding)
+            if name_manual:
+                print(
+                    f"\n{len(name_manual)} name finding(s) needing manual "
+                    f"fix — not auto-applied:"
+                )
+                for finding in name_manual:
+                    print_error_line(finding)
+            if name_errors:
+                print(
+                    f"\n{len(name_errors)} name-fix error(s):"
+                )
+                for finding in name_errors:
+                    print_error_line(finding)
             if path_resolution_findings:
                 print(
                     f"\n{len(path_resolution_findings)} path-resolution "
@@ -1599,7 +1720,7 @@ def main() -> None:
                 )
                 for finding in non_path_fails:
                     print_error_line(finding)
-            if args.apply and rows:
+            if args.apply and (rows or name_modified):
                 if apply_error is None:
                     print(f"Modified {modified} file(s).")
                 else:

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -1421,13 +1421,37 @@ def main() -> None:
         name_owned_fails: list[str] = []
         skill_md_for_name = os.path.join(rewrite_root, FILE_SKILL_MD)
         if os.path.isfile(skill_md_for_name):
-            (
-                name_new,
-                name_applied,
-                name_manual,
-                name_errors,
-                name_owned_fails,
-            ) = compute_name_fix_plan(skill_md_for_name)
+            # Skip the name-fix plan when the frontmatter is
+            # structurally invalid: no frontmatter delimiters, a YAML
+            # parse error, or no ``name`` key.  The regular validator
+            # already FAILs on each of those (see ``validate_skill``
+            # below) and the planner would only restate the same root
+            # cause under ``name_fix.errors`` — duplicating output and
+            # adding a second exit gate that carries no actionable fix
+            # information.  ``load_frontmatter`` is the same loader the
+            # validator uses, so the gates stay in lockstep.
+            should_plan = False
+            try:
+                fm_probe, _body_probe, _scan = load_frontmatter(
+                    skill_md_for_name,
+                )
+                should_plan = (
+                    isinstance(fm_probe, dict)
+                    and "_parse_error" not in fm_probe
+                    and "name" in fm_probe
+                )
+            except (OSError, UnicodeError):
+                # An I/O error here is also covered by the validator
+                # below; let it surface there alone.
+                should_plan = False
+            if should_plan:
+                (
+                    name_new,
+                    name_applied,
+                    name_manual,
+                    name_errors,
+                    name_owned_fails,
+                ) = compute_name_fix_plan(skill_md_for_name)
         # Validate the same tree the rewriter operates on.  In
         # capability mode the rewriter walks the enclosing skill root,
         # so the validator must too — otherwise unfixable findings or
@@ -1681,7 +1705,14 @@ def main() -> None:
                         f"'{r['original']}' → '{r['replacement']}'"
                     )
             if name_new is not None:
-                action = "Applied" if args.apply else "Would apply"
+                # Label by the actual write, not the user's intent —
+                # under ``--apply`` the name write is gated behind
+                # ``not name_manual and not name_errors`` (above), so a
+                # computed ``new_name`` can be deliberately *not*
+                # applied.  Printing "Applied" in that case would
+                # contradict the human-output narrative; the manual /
+                # error blocks below explain why the write was skipped.
+                action = "Applied" if name_modified else "Would apply"
                 print(f"\n{action} name normalization:")
                 for finding in name_applied:
                     print_error_line(finding)

--- a/skill-system-foundry/scripts/validate_skill.py
+++ b/skill-system-foundry/scripts/validate_skill.py
@@ -1584,13 +1584,16 @@ def main() -> None:
 
         # Apply the safe ``name`` normalization under ``--apply`` too —
         # the single-line in-place rewrite computed above.  Gated behind
-        # ``apply_error is None and not name_manual and not name_errors``
-        # so a planned safe fix is *not* written when the path-rewriter
-        # already raised (``apply_error`` set), when the planner also
-        # surfaced an ambiguous problem (directory mismatch, over-length
-        # description, the computed candidate still violates the spec,
-        # the raw line carries quote/comment syntax that would be
-        # stripped), or when a structural / I/O failure was recorded.
+        # ``apply_error is None and not name_rewrite_blockers and not
+        # name_errors`` so a planned safe fix is *not* written when the
+        # path-rewriter already raised (``apply_error`` set), when the
+        # planner surfaced a name-rewrite-blocking ambiguous problem
+        # (directory mismatch, the computed candidate still violates
+        # the spec, the raw line carries quote / inline-# / block-
+        # scalar syntax that would be corrupted), or when a structural /
+        # I/O failure was recorded.  Over-length ``description`` is in
+        # ``name_manual`` for human reporting but does not block the
+        # name write — see the ``name_rewrite_blockers`` filter below.
         # The ``apply_error`` clause prevents a second fix category from
         # widening the partial-apply state after the first phase has
         # already failed — a ``--fix --apply`` run that already errors
@@ -1602,12 +1605,33 @@ def main() -> None:
         # path-rewrite apply error.  Counts the SKILL.md as one modified
         # file when the write lands so the human/JSON ``modified`` total
         # reflects both categories.
+        # The apply gate only blocks on findings that make the
+        # ``name:`` line rewrite itself unsafe — directory mismatch
+        # (resolution requires human judgement), the safe-fix
+        # candidate still violates the spec (residual FAILs), and
+        # quoted / inline-# / block-scalar shapes the minimal line
+        # rewriter cannot preserve.  An over-length ``description``
+        # finding is exit-gating only (``fix_success`` still includes
+        # ``name_manual`` so the run reports failure), but it does not
+        # affect whether the safe name rewrite can land — this matches
+        # the path rewriter, which still applies safe rewrites while
+        # reporting remaining non-path failures.  The marker is the
+        # ``'description'`` token: every description-only manual
+        # finding in this module is emitted by
+        # ``compute_description_manual_finding`` and carries that
+        # exact substring, while every name-rewrite-blocking finding
+        # is emitted by ``compute_name_fix`` /
+        # ``compute_name_fix_plan`` and carries ``'name'`` or
+        # ``'name:'`` instead.
+        name_rewrite_blockers = [
+            f for f in name_manual if "'description'" not in f
+        ]
         name_modified = False
         if (
             args.apply
             and apply_error is None
             and name_new is not None
-            and not name_manual
+            and not name_rewrite_blockers
             and not name_errors
         ):
             name_modified, write_errors = write_name_fix(

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -312,10 +312,12 @@ class ComputeNameFixPlanTests(unittest.TestCase):
             _new_name, _applied, manual, _errors, _owned = compute_name_fix_plan(path)
             self.assertTrue(any("description" in f for f in manual))
 
-    def test_folded_description_block_no_false_over_length(self) -> None:
-        # A folded ``description: >`` block must not be flagged as
-        # over-length by the inline extractor — the marker line itself
-        # is short, and the fixer leaves folded blocks to the validator.
+    def test_folded_description_block_over_length_is_manual(self) -> None:
+        # A folded ``description: >`` block whose assembled text
+        # exceeds the limit must surface as a manual finding the same
+        # way an inline over-length description does — the planner
+        # reads the parsed scalar, so style-of-write does not change
+        # the contract.
         long_body = "x" * (MAX_DESCRIPTION_CHARS + 50)
         with tempfile.TemporaryDirectory() as tmp:
             sdir = os.path.join(tmp, "my-skill")
@@ -324,8 +326,15 @@ class ComputeNameFixPlanTests(unittest.TestCase):
                 sdir,
                 f"name: my-skill\ndescription: >\n  {long_body}",
             )
-            _new_name, _applied, manual, _errors, _owned = compute_name_fix_plan(path)
-            self.assertEqual(manual, [])
+            _new_name, _applied, manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertTrue(any("description" in f for f in manual))
+        # The owned FAIL is the validator's exact wording so the
+        # generic ``non_path_fails`` bucket does not double-report it.
+        self.assertTrue(any(
+            "'description' exceeds" in f for f in owned
+        ))
 
     def test_missing_file_is_error_not_raise(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -683,7 +692,6 @@ class ParsedNameValueTests(unittest.TestCase):
             "---\nname: MySkill  # legacy\ndescription: A demo.\n---\n\nbody\n"
         )
         self.assertIsNone(rewrite_name_line(content, "myskill"))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -2,11 +2,11 @@
 engine folded into ``validate_skill.py --fix`` / ``--fix --apply``.
 
 Safe fixes: lowercase the ``name``, replace underscores with hyphens,
-replace spaces with hyphens.  Ambiguous problems (directory mismatch,
-over-length description) are reported as "manual fix needed" and never
-auto-applied.  The rewrite is a minimal, line-targeted textual
-replacement of the single frontmatter ``name:`` line — the rest of the
-file is preserved byte-for-byte.
+replace in-value whitespace (spaces and tabs) with hyphens.  Ambiguous
+problems (directory mismatch, over-length description) are reported as
+"manual fix needed" and never auto-applied.  The rewrite is a minimal,
+line-targeted textual replacement of the single frontmatter ``name:``
+line — the rest of the file is preserved byte-for-byte.
 
 The module splits the work into a preview half (``compute_name_fix_plan``
 — reads and computes, never writes) and an apply half (``write_name_fix``
@@ -93,7 +93,7 @@ class ComputeNameFixTests(unittest.TestCase):
     def test_space_reported_and_applied(self) -> None:
         new_name, applied, _manual, _owned = compute_name_fix("my skill", "my-skill")
         self.assertEqual(new_name, "my-skill")
-        self.assertTrue(any("spaces" in f for f in applied))
+        self.assertTrue(any("whitespace" in f for f in applied))
 
     def test_combined_reports_each_fix(self) -> None:
         new_name, applied, _manual, _owned = compute_name_fix(
@@ -450,7 +450,12 @@ class WriteNameFixTests(unittest.TestCase):
             path = _write_skill(sdir, "name: My_Skill\ndescription: A demo.")
             real_open = open
 
-            def _open(file, mode="r", *args, **kwargs):
+            def _open(
+                file: str,
+                mode: str = "r",
+                *args: object,
+                **kwargs: object,
+            ) -> object:
                 if file == path and "w" in mode:
                     raise OSError("disk full")
                 return real_open(file, mode, *args, **kwargs)

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -902,6 +902,38 @@ class WriteCRLFNormalizationTests(unittest.TestCase):
         # normalization per the repo-wide newline="\n" convention.
         self.assertNotIn(b"\r\n", raw)
 
+    def test_rewrite_name_line_preserves_crlf_for_direct_callers(self) -> None:
+        # ``rewrite_name_line`` operates on the supplied string —
+        # direct callers must see the rewritten line's CRLF terminator
+        # preserved (the regex captures ``\r?`` and the substitution
+        # re-emits it).  Without that, the rewritten line would drop
+        # its ``\r`` while every other line kept CRLF, producing mixed
+        # line endings in the returned content even though the helper
+        # documents the file's line-ending shape as preserved.  The
+        # end-to-end ``write_name_fix`` path still normalizes to LF
+        # via the text-mode I/O; this contract is for the line
+        # rewriter in isolation (Codex follow-up F-18).
+        content = (
+            "---\r\nname: My_Skill\r\ndescription: A demo.\r\n"
+            "---\r\n\r\n# Body\r\nProse stays.\r\n"
+        )
+        result = rewrite_name_line(content, "my-skill")
+        self.assertIsNotNone(result)
+        assert result is not None
+        # The rewritten line keeps its ``\r\n`` terminator.
+        self.assertIn("name: my-skill\r\n", result)
+        # No bare-LF line endings were introduced — every CRLF in the
+        # source survives in the output.
+        bare_lf = [
+            i for i, ch in enumerate(result)
+            if ch == "\n" and (i == 0 or result[i - 1] != "\r")
+        ]
+        self.assertEqual(bare_lf, [], msg=f"bare LF at indices {bare_lf}")
+        # And the rest of the file is byte-identical to the input.
+        self.assertEqual(
+            result, content.replace("My_Skill", "my-skill", 1),
+        )
+
 
 # ===================================================================
 # Missing closing ``---`` delimiter — Codex follow-up F-8.  The planner

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -964,5 +964,62 @@ class InlineCommentAlignmentTests(unittest.TestCase):
         self.assertFalse(any("inline '#' comment" in f for f in manual))
 
 
+# ===================================================================
+# Unusual-but-valid YAML formatting (whitespace before ``:``) must not
+# fail the run when no rewrite is needed — Copilot follow-up C-10.
+# Rewrite-mechanics guards only fire when ``new_name is not None``.
+# ===================================================================
+
+
+class UnusualButValidYAMLTests(unittest.TestCase):
+    def test_space_before_colon_valid_name_is_silent(self) -> None:
+        # ``name : my-skill`` (with space before colon) — valid YAML
+        # mapping that ``parse_yaml_subset`` accepts, but the line
+        # regex requires ``name:`` with no leading whitespace.  When
+        # the parsed value is already valid (no rewrite needed) the
+        # planner must stay silent rather than emit a "not on its own
+        # line" error that would fail ``--fix``.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname : my-skill\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            new_name, applied, manual, errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertEqual(manual, [])
+        self.assertEqual(errors, [])
+        self.assertEqual(owned, [])
+
+    def test_space_before_colon_invalid_name_refuses_with_error(self) -> None:
+        # ``name : MySkill`` — parser sees ``MySkill``, validate_name
+        # FAILs.  compute_name_fix would propose ``myskill``, but the
+        # line regex cannot target ``name : MySkill`` for rewrite, so
+        # the planner refuses and surrenders ownership; the regular
+        # validator's FAILs flow through.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "myskill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname : MySkill\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            new_name, applied, _manual, errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertTrue(any(
+            "not on its own line" in e for e in errors
+        ), msg=f"errors={errors!r}")
+        self.assertEqual(owned, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -792,5 +792,111 @@ class FoldedDescriptionTests(unittest.TestCase):
         self.assertFalse(any("description" in f for f in manual))
 
 
+# ===================================================================
+# Quoted / inline-comment name lines that are *already valid* must
+# not fail the fix run — the refusal is only meaningful when the
+# planner would actually try to rewrite (Codex follow-up F-5).
+# ===================================================================
+
+
+class QuotedValidNameTests(unittest.TestCase):
+    def test_quoted_already_valid_name_is_silent(self) -> None:
+        # ``name: "my-skill"`` in dir ``my-skill`` — the parsed value
+        # is valid, no rewrite is needed, so the quote-syntax guard
+        # must not fire.  ``manual`` stays empty and the planner
+        # silently reports nothing to do.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname: \"my-skill\"\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            new_name, applied, manual, errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertEqual(manual, [])
+        self.assertEqual(errors, [])
+        self.assertEqual(owned, [])
+
+    def test_inline_comment_already_valid_name_is_silent(self) -> None:
+        # ``name: my-skill  # note`` — same scenario via inline comment.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname: my-skill  # note\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            new_name, applied, manual, errors, _owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertEqual(manual, [])
+        self.assertEqual(errors, [])
+
+    def test_quoted_invalid_name_still_refuses(self) -> None:
+        # ``name: "My_Skill"`` — quoted but the parsed value FAILs
+        # validate_name; the planner refuses to propose a write,
+        # surrenders ownership, and the validator FAILs flow through.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname: \"My_Skill\"\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            new_name, applied, manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertTrue(any("quoted scalar" in f for f in manual))
+        self.assertEqual(owned, [])
+
+
+# ===================================================================
+# CRLF normalization — write_name_fix writes with newline="\n", so a
+# CRLF-on-disk SKILL.md is normalized to LF when any safe fix lands.
+# The contract is documented in the module docstring; this test pins
+# the behavior so it cannot silently drift (Copilot follow-up C-6).
+# ===================================================================
+
+
+class WriteCRLFNormalizationTests(unittest.TestCase):
+    def test_crlf_file_is_normalized_to_lf_on_write(self) -> None:
+        # Write SKILL.md with CRLF terminators, run the apply, and
+        # expect the on-disk file to come back with LF terminators
+        # everywhere (no surviving \r\n pairs).
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "myskill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            # Bypass write_text (which writes LF) by writing in binary
+            # mode with CRLF terminators on every line.
+            content_lf = (
+                "---\nname: MySkill\ndescription: A demo.\n---\n\n"
+                "# Body\nProse stays.\n"
+            )
+            with open(path, "wb") as f:
+                f.write(content_lf.replace("\n", "\r\n").encode("utf-8"))
+            modified, errors = write_name_fix(path, "myskill")
+            with open(path, "rb") as f:
+                raw = f.read()
+        self.assertTrue(modified)
+        self.assertEqual(errors, [])
+        # The name was rewritten.
+        self.assertIn(b"name: myskill\n", raw)
+        # And every CRLF terminator is gone — documented LF
+        # normalization per the repo-wide newline="\n" convention.
+        self.assertNotIn(b"\r\n", raw)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -78,32 +78,32 @@ class ComputeNameFixTests(unittest.TestCase):
     """Findings and the corrected value for a single skill."""
 
     def test_lowercase_reported_and_applied(self) -> None:
-        new_name, applied, manual = compute_name_fix("MySkill", "myskill")
+        new_name, applied, manual, _owned = compute_name_fix("MySkill", "myskill")
         self.assertEqual(new_name, "myskill")
         self.assertTrue(any("lowercased" in f for f in applied))
         self.assertTrue(all(f.startswith(LEVEL_INFO) for f in applied))
         self.assertEqual(manual, [])
 
     def test_underscore_reported_and_applied(self) -> None:
-        new_name, applied, manual = compute_name_fix("my_skill", "my-skill")
+        new_name, applied, manual, _owned = compute_name_fix("my_skill", "my-skill")
         self.assertEqual(new_name, "my-skill")
         self.assertTrue(any("underscores" in f for f in applied))
         self.assertEqual(manual, [])
 
     def test_space_reported_and_applied(self) -> None:
-        new_name, applied, _manual = compute_name_fix("my skill", "my-skill")
+        new_name, applied, _manual, _owned = compute_name_fix("my skill", "my-skill")
         self.assertEqual(new_name, "my-skill")
         self.assertTrue(any("spaces" in f for f in applied))
 
     def test_combined_reports_each_fix(self) -> None:
-        new_name, applied, _manual = compute_name_fix(
+        new_name, applied, _manual, _owned = compute_name_fix(
             "My_Skill Name", "my-skill-name",
         )
         self.assertEqual(new_name, "my-skill-name")
         self.assertEqual(len(applied), 3)
 
     def test_noop_returns_none(self) -> None:
-        new_name, applied, manual = compute_name_fix("my-skill", "my-skill")
+        new_name, applied, manual, _owned = compute_name_fix("my-skill", "my-skill")
         self.assertIsNone(new_name)
         self.assertEqual(applied, [])
         self.assertEqual(manual, [])
@@ -111,7 +111,7 @@ class ComputeNameFixTests(unittest.TestCase):
     def test_dir_mismatch_is_manual_after_fix(self) -> None:
         # Fixing casing produces 'my-skill' but the directory is
         # 'other-dir' — the mismatch is reported against the FIXED name.
-        new_name, applied, manual = compute_name_fix("My-Skill", "other-dir")
+        new_name, applied, manual, _owned = compute_name_fix("My-Skill", "other-dir")
         self.assertEqual(new_name, "my-skill")
         self.assertTrue(applied)
         self.assertEqual(len(manual), 1)
@@ -123,14 +123,14 @@ class ComputeNameFixTests(unittest.TestCase):
     def test_dir_mismatch_without_safe_fix_uses_current_name(self) -> None:
         # No safe fix applies, but the (already valid) name differs from
         # the directory — still a manual finding, against the live name.
-        new_name, applied, manual = compute_name_fix("my-skill", "other-dir")
+        new_name, applied, manual, _owned = compute_name_fix("my-skill", "other-dir")
         self.assertIsNone(new_name)
         self.assertEqual(applied, [])
         self.assertEqual(len(manual), 1)
         self.assertIn("my-skill", manual[0])
 
     def test_empty_name_no_fix_no_manual(self) -> None:
-        new_name, applied, manual = compute_name_fix("", "demo")
+        new_name, applied, manual, _owned = compute_name_fix("", "demo")
         self.assertIsNone(new_name)
         self.assertEqual(applied, [])
         self.assertEqual(manual, [])
@@ -256,7 +256,7 @@ class ComputeNameFixPlanTests(unittest.TestCase):
             with open(path, "r", encoding="utf-8") as f:
                 before = f.read()
             stat_before = os.stat(path)
-            new_name, applied, manual, errors = compute_name_fix_plan(path)
+            new_name, applied, manual, errors, _owned = compute_name_fix_plan(path)
             self.assertEqual(new_name, "myskill")
             self.assertTrue(applied)
             self.assertEqual(manual, [])
@@ -273,7 +273,7 @@ class ComputeNameFixPlanTests(unittest.TestCase):
             path = _write_skill(
                 sdir, "name: My_Skill Name\ndescription: A demo.",
             )
-            new_name, applied, manual, _errors = compute_name_fix_plan(path)
+            new_name, applied, manual, _errors, _owned = compute_name_fix_plan(path)
             self.assertEqual(new_name, "my-skill-name")
             self.assertEqual(len(applied), 3)
             self.assertEqual(manual, [])
@@ -283,7 +283,7 @@ class ComputeNameFixPlanTests(unittest.TestCase):
             sdir = os.path.join(tmp, "my-skill")
             os.makedirs(sdir)
             path = _write_skill(sdir, "name: my-skill\ndescription: A demo.")
-            new_name, applied, manual, errors = compute_name_fix_plan(path)
+            new_name, applied, manual, errors, _owned = compute_name_fix_plan(path)
             self.assertIsNone(new_name)
             self.assertEqual(applied, [])
             self.assertEqual(manual, [])
@@ -294,7 +294,7 @@ class ComputeNameFixPlanTests(unittest.TestCase):
             sdir = os.path.join(tmp, "expected-dir")
             os.makedirs(sdir)
             path = _write_skill(sdir, "name: actual-name\ndescription: A demo.")
-            new_name, applied, manual, errors = compute_name_fix_plan(path)
+            new_name, applied, manual, errors, _owned = compute_name_fix_plan(path)
             self.assertIsNone(new_name)
             self.assertEqual(applied, [])
             self.assertEqual(len(manual), 1)
@@ -309,7 +309,7 @@ class ComputeNameFixPlanTests(unittest.TestCase):
             path = _write_skill(
                 sdir, f"name: my-skill\ndescription: {long_desc}",
             )
-            _new_name, _applied, manual, _errors = compute_name_fix_plan(path)
+            _new_name, _applied, manual, _errors, _owned = compute_name_fix_plan(path)
             self.assertTrue(any("description" in f for f in manual))
 
     def test_folded_description_block_no_false_over_length(self) -> None:
@@ -324,7 +324,7 @@ class ComputeNameFixPlanTests(unittest.TestCase):
                 sdir,
                 f"name: my-skill\ndescription: >\n  {long_body}",
             )
-            _new_name, _applied, manual, _errors = compute_name_fix_plan(path)
+            _new_name, _applied, manual, _errors, _owned = compute_name_fix_plan(path)
             self.assertEqual(manual, [])
 
     def test_missing_file_is_error_not_raise(self) -> None:
@@ -332,7 +332,7 @@ class ComputeNameFixPlanTests(unittest.TestCase):
             sdir = os.path.join(tmp, "my-skill")
             os.makedirs(sdir)
             path = os.path.join(sdir, "SKILL.md")  # never created
-            new_name, _applied, _manual, errors = compute_name_fix_plan(path)
+            new_name, _applied, _manual, errors, _owned = compute_name_fix_plan(path)
             self.assertIsNone(new_name)
             self.assertEqual(len(errors), 1)
             self.assertTrue(errors[0].startswith(LEVEL_FAIL))
@@ -343,7 +343,7 @@ class ComputeNameFixPlanTests(unittest.TestCase):
             os.makedirs(sdir)
             path = os.path.join(sdir, "SKILL.md")
             write_text(path, "# No frontmatter here\n")
-            new_name, _applied, _manual, errors = compute_name_fix_plan(path)
+            new_name, _applied, _manual, errors, _owned = compute_name_fix_plan(path)
             self.assertIsNone(new_name)
             self.assertTrue(any("frontmatter" in f for f in errors))
 
@@ -352,7 +352,7 @@ class ComputeNameFixPlanTests(unittest.TestCase):
             sdir = os.path.join(tmp, "my-skill")
             os.makedirs(sdir)
             path = _write_skill(sdir, "description: A demo with no name key.")
-            new_name, _applied, _manual, errors = compute_name_fix_plan(path)
+            new_name, _applied, _manual, errors, _owned = compute_name_fix_plan(path)
             self.assertIsNone(new_name)
             self.assertTrue(any("'name'" in f for f in errors))
 

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -452,5 +452,238 @@ class WriteNameFixTests(unittest.TestCase):
             self.assertTrue(any("cannot write" in f for f in errors))
 
 
+# ===================================================================
+# Ownership semantics — the planner must own exactly the validator
+# FAIL strings its fix resolves, never the unrelated ones (Codex F-1
+# / Copilot C-1).
+# ===================================================================
+
+
+class OwnedFailsTests(unittest.TestCase):
+    """``compute_name_fix_plan`` returns the exact ``validate_name``
+    FAIL strings it takes ownership of so the ``validate_skill.py``
+    driver can suppress *only* those — never an unrelated name FAIL.
+    """
+
+    def test_owns_uppercase_underscore_and_format(self) -> None:
+        # ``Demo_Skill`` FAILs on uppercase, underscore, and (because
+        # both push the value off ``RE_NAME_FORMAT``) invalid format.
+        # The fix produces ``demo-skill`` which passes — all three
+        # FAILs are resolved and therefore owned.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "demo-skill")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "name: Demo_Skill\ndescription: A demo.")
+            _new_name, _applied, _manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        owned_text = "\n".join(owned)
+        self.assertIn("uppercase", owned_text)
+        self.assertIn("underscores", owned_text)
+        self.assertIn("invalid format", owned_text)
+
+    def test_does_not_own_empty_name_fail(self) -> None:
+        # ``name:`` empty → safe fixer cannot fix it.  The validator's
+        # "field is empty" FAIL must flow through the caller's generic
+        # bucket; the planner owns nothing.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "demo-skill")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "name: \ndescription: A demo.")
+            new_name, _applied, _manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(owned, [])
+
+    def test_does_not_own_consecutive_hyphen_fail(self) -> None:
+        # ``my--skill`` is invalid (consecutive hyphens, invalid
+        # format) and no safe transform produces a clean result —
+        # the safe transforms are all no-ops on a lowercase
+        # hyphen-only value, so the fix would be a no-op and the
+        # planner takes no ownership.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my--skill")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "name: my--skill\ndescription: A demo.")
+            new_name, _applied, _manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(owned, [])
+
+    def test_does_not_own_overlong_name_fail(self) -> None:
+        long_name = "a" * 200
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, long_name)
+            os.makedirs(sdir)
+            path = _write_skill(
+                sdir, f"name: {long_name}\ndescription: A demo.",
+            )
+            new_name, _applied, _manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(owned, [])
+
+    def test_owns_dir_mismatch_when_manual_surfaces_it(self) -> None:
+        # The dir-mismatch FAIL is owned only when the planner emits a
+        # manual finding for it (i.e. the planner is taking
+        # responsibility for surfacing the issue).
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "expected-dir")
+            os.makedirs(sdir)
+            path = _write_skill(
+                sdir, "name: Actual_Name\ndescription: A demo.",
+            )
+            _new_name, _applied, manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertTrue(any("does not match directory" in f for f in manual))
+        self.assertTrue(
+            any("does not match directory name" in f for f in owned)
+        )
+
+    def test_owns_inline_overlong_description_fail(self) -> None:
+        long_desc = "x" * (MAX_DESCRIPTION_CHARS + 5)
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = _write_skill(
+                sdir, f"name: my-skill\ndescription: {long_desc}",
+            )
+            _new_name, _applied, manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertTrue(any("description" in f for f in manual))
+        self.assertTrue(
+            any("'description' exceeds" in f for f in owned)
+        )
+
+    def test_consecutive_hyphen_residual_refuses_fix(self) -> None:
+        # ``my__skill`` would normalize to ``my--skill`` (consecutive
+        # hyphens) — the candidate still violates the spec, so the
+        # planner refuses to propose the fix.  Original FAILs flow
+        # through the caller.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my--skill")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "name: my__skill\ndescription: A demo.")
+            new_name, applied, manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertTrue(any(
+            "cannot be safely normalized" in f for f in manual
+        ))
+        self.assertEqual(owned, [])
+
+    def test_compute_name_fix_returns_owned(self) -> None:
+        # Direct check on the lower-level entry point: the same
+        # ownership contract holds without reading from disk.
+        new_name, _applied, _manual, owned = compute_name_fix(
+            "My_Skill", "my-skill",
+        )
+        self.assertEqual(new_name, "my-skill")
+        owned_text = "\n".join(owned)
+        self.assertIn("uppercase", owned_text)
+        self.assertIn("underscores", owned_text)
+
+
+# ===================================================================
+# YAML-aware value extraction — quoted scalars and inline comments
+# (Codex F-2 / Copilot C-4).
+# ===================================================================
+
+
+class ParsedNameValueTests(unittest.TestCase):
+    """The fixer uses the parsed YAML scalar so quoted values and
+    inline comments are recognised without their syntax characters
+    being treated as part of the value.
+    """
+
+    def test_quoted_value_is_extracted_via_parser(self) -> None:
+        # ``name: "MySkill"`` — the validator sees ``MySkill`` (parser
+        # unquotes), so the planner must too.  A naive raw extractor
+        # would compute against ``"MySkill"`` (literal quotes) and
+        # report a false directory mismatch against ``myskill``.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "myskill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname: \"MySkill\"\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            new_name, _applied, manual, _errors, _owned = (
+                compute_name_fix_plan(path)
+            )
+        # Manual finding fires because the line carries a quoted scalar
+        # the minimal rewriter cannot preserve — but the *value*
+        # extracted (for any other reasoning) is the parsed
+        # ``MySkill``, not the literal ``"MySkill"``.  No false
+        # dir-mismatch against ``myskill`` should appear.
+        self.assertIsNone(new_name)
+        self.assertTrue(any("quoted scalar" in f for f in manual))
+        self.assertFalse(any(
+            "does not match directory" in f for f in manual
+        ))
+
+    def test_inline_comment_blocks_rewrite(self) -> None:
+        # ``name: MySkill  # legacy`` — value parses to ``MySkill`` but
+        # the raw line carries an inline comment the minimal rewriter
+        # would strip.  Refuse to propose a fix.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "myskill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname: MySkill  # legacy\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            new_name, applied, manual, _errors, _owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertTrue(any("inline '#' comment" in f for f in manual))
+
+    def test_hash_inside_plain_scalar_does_not_block_rewrite(self) -> None:
+        # ``name: foo#bar`` — YAML parses this as the literal value
+        # ``foo#bar`` (no space before ``#``), so the inline-comment
+        # detector must NOT flag it.  The rewrite proceeds normally.
+        # ``foo#bar`` itself FAILs RE_NAME_FORMAT, so the residual gate
+        # refuses the fix — but that is the *content* failing, not the
+        # rewrite block path.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "foobar")
+            os.makedirs(sdir)
+            path = _write_skill(
+                sdir, "name: foo#bar\ndescription: A demo.",
+            )
+            _new_name, _applied, manual, _errors, _owned = (
+                compute_name_fix_plan(path)
+            )
+        # No 'inline comment' manual finding — the ``#`` is inside the
+        # plain scalar, not a comment marker.
+        self.assertFalse(any("inline '#' comment" in f for f in manual))
+
+    def test_rewrite_line_returns_none_on_quoted(self) -> None:
+        # The line-level rewriter refuses to touch a quoted value
+        # directly, defending the byte-for-byte contract even if the
+        # planner ever delegated without its own gate.
+        content = (
+            "---\nname: \"MySkill\"\ndescription: A demo.\n---\n\nbody\n"
+        )
+        self.assertIsNone(rewrite_name_line(content, "myskill"))
+
+    def test_rewrite_line_returns_none_on_inline_comment(self) -> None:
+        content = (
+            "---\nname: MySkill  # legacy\ndescription: A demo.\n---\n\nbody\n"
+        )
+        self.assertIsNone(rewrite_name_line(content, "myskill"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -1,0 +1,456 @@
+"""Tests for ``lib/name_fixer.py`` — the safe name-frontmatter auto-fix
+engine folded into ``validate_skill.py --fix`` / ``--fix --apply``.
+
+Safe fixes: lowercase the ``name``, replace underscores with hyphens,
+replace spaces with hyphens.  Ambiguous problems (directory mismatch,
+over-length description) are reported as "manual fix needed" and never
+auto-applied.  The rewrite is a minimal, line-targeted textual
+replacement of the single frontmatter ``name:`` line — the rest of the
+file is preserved byte-for-byte.
+
+The module splits the work into a preview half (``compute_name_fix_plan``
+— reads and computes, never writes) and an apply half (``write_name_fix``
+— performs the single-line in-place rewrite), mirroring the
+preview/apply structure of the path-resolution rewriter.
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCRIPTS = os.path.join(_REPO_ROOT, "skill-system-foundry", "scripts")
+if _SCRIPTS not in sys.path:
+    sys.path.insert(0, _SCRIPTS)
+
+from lib.name_fixer import (  # noqa: E402
+    compute_description_manual_finding,
+    compute_name_fix,
+    compute_name_fix_plan,
+    compute_safe_name,
+    rewrite_name_line,
+    write_name_fix,
+)
+from lib.constants import (  # noqa: E402
+    LEVEL_FAIL,
+    LEVEL_INFO,
+    MAX_DESCRIPTION_CHARS,
+)
+
+from helpers import write_text  # noqa: E402
+
+
+# ===================================================================
+# compute_safe_name
+# ===================================================================
+
+
+class ComputeSafeNameTests(unittest.TestCase):
+    """The pure transform applies the three safe fixes only."""
+
+    def test_lowercases(self) -> None:
+        self.assertEqual(compute_safe_name("MySkill"), "myskill")
+
+    def test_underscores_to_hyphens(self) -> None:
+        self.assertEqual(compute_safe_name("my_skill"), "my-skill")
+
+    def test_spaces_to_hyphens(self) -> None:
+        self.assertEqual(compute_safe_name("my skill"), "my-skill")
+
+    def test_combined(self) -> None:
+        self.assertEqual(compute_safe_name("My_Skill Name"), "my-skill-name")
+
+    def test_tabs_to_hyphens(self) -> None:
+        self.assertEqual(compute_safe_name("my\tskill"), "my-skill")
+
+    def test_already_valid_unchanged(self) -> None:
+        self.assertEqual(compute_safe_name("my-skill"), "my-skill")
+
+
+# ===================================================================
+# compute_name_fix
+# ===================================================================
+
+
+class ComputeNameFixTests(unittest.TestCase):
+    """Findings and the corrected value for a single skill."""
+
+    def test_lowercase_reported_and_applied(self) -> None:
+        new_name, applied, manual = compute_name_fix("MySkill", "myskill")
+        self.assertEqual(new_name, "myskill")
+        self.assertTrue(any("lowercased" in f for f in applied))
+        self.assertTrue(all(f.startswith(LEVEL_INFO) for f in applied))
+        self.assertEqual(manual, [])
+
+    def test_underscore_reported_and_applied(self) -> None:
+        new_name, applied, manual = compute_name_fix("my_skill", "my-skill")
+        self.assertEqual(new_name, "my-skill")
+        self.assertTrue(any("underscores" in f for f in applied))
+        self.assertEqual(manual, [])
+
+    def test_space_reported_and_applied(self) -> None:
+        new_name, applied, _manual = compute_name_fix("my skill", "my-skill")
+        self.assertEqual(new_name, "my-skill")
+        self.assertTrue(any("spaces" in f for f in applied))
+
+    def test_combined_reports_each_fix(self) -> None:
+        new_name, applied, _manual = compute_name_fix(
+            "My_Skill Name", "my-skill-name",
+        )
+        self.assertEqual(new_name, "my-skill-name")
+        self.assertEqual(len(applied), 3)
+
+    def test_noop_returns_none(self) -> None:
+        new_name, applied, manual = compute_name_fix("my-skill", "my-skill")
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertEqual(manual, [])
+
+    def test_dir_mismatch_is_manual_after_fix(self) -> None:
+        # Fixing casing produces 'my-skill' but the directory is
+        # 'other-dir' — the mismatch is reported against the FIXED name.
+        new_name, applied, manual = compute_name_fix("My-Skill", "other-dir")
+        self.assertEqual(new_name, "my-skill")
+        self.assertTrue(applied)
+        self.assertEqual(len(manual), 1)
+        self.assertTrue(manual[0].startswith(LEVEL_FAIL))
+        self.assertIn("manual fix needed", manual[0])
+        self.assertIn("my-skill", manual[0])
+        self.assertIn("other-dir", manual[0])
+
+    def test_dir_mismatch_without_safe_fix_uses_current_name(self) -> None:
+        # No safe fix applies, but the (already valid) name differs from
+        # the directory — still a manual finding, against the live name.
+        new_name, applied, manual = compute_name_fix("my-skill", "other-dir")
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertEqual(len(manual), 1)
+        self.assertIn("my-skill", manual[0])
+
+    def test_empty_name_no_fix_no_manual(self) -> None:
+        new_name, applied, manual = compute_name_fix("", "demo")
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertEqual(manual, [])
+
+
+# ===================================================================
+# compute_description_manual_finding
+# ===================================================================
+
+
+class ComputeDescriptionManualFindingTests(unittest.TestCase):
+    def test_within_limit_no_finding(self) -> None:
+        self.assertEqual(compute_description_manual_finding("short"), [])
+
+    def test_over_limit_is_manual_fail(self) -> None:
+        long_desc = "x" * (MAX_DESCRIPTION_CHARS + 1)
+        findings = compute_description_manual_finding(long_desc)
+        self.assertEqual(len(findings), 1)
+        self.assertTrue(findings[0].startswith(LEVEL_FAIL))
+        self.assertIn("manual fix needed", findings[0])
+        self.assertIn("description", findings[0])
+
+    def test_empty_no_finding(self) -> None:
+        self.assertEqual(compute_description_manual_finding(""), [])
+
+
+# ===================================================================
+# rewrite_name_line
+# ===================================================================
+
+
+class RewriteNameLineTests(unittest.TestCase):
+    """Only the frontmatter name: value changes; everything else is kept."""
+
+    def test_rewrites_only_frontmatter_name(self) -> None:
+        content = (
+            "---\n"
+            "name: My_Skill\n"
+            "description: A demo.\n"
+            "---\n"
+            "\n"
+            "# Body\n"
+            "Prose mentioning name: keep-this verbatim.\n"
+        )
+        result = rewrite_name_line(content, "my-skill")
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertIn("name: my-skill\n", result)
+        # Body mention untouched.
+        self.assertIn("name: keep-this verbatim.", result)
+        # Description untouched.
+        self.assertIn("description: A demo.\n", result)
+
+    def test_preserves_surrounding_bytes_exactly(self) -> None:
+        content = (
+            "---\n"
+            "name: My_Skill\n"
+            "description: A demo.\n"
+            "metadata:\n"
+            "  version: 1.0.0\n"
+            "---\n"
+            "\n"
+            "# Body content stays.\n"
+        )
+        result = rewrite_name_line(content, "my-skill")
+        assert result is not None
+        # The only difference between input and output is the name value.
+        self.assertEqual(result, content.replace("My_Skill", "my-skill", 1))
+
+    def test_preserves_trailing_whitespace_and_spacing(self) -> None:
+        content = "---\nname:    My_Skill   \ndescription: d\n---\n\nbody\n"
+        result = rewrite_name_line(content, "my-skill")
+        assert result is not None
+        # Prefix spacing (4 spaces) and trailing spaces preserved.
+        self.assertIn("name:    my-skill   \n", result)
+
+    def test_returns_none_when_no_frontmatter(self) -> None:
+        self.assertIsNone(rewrite_name_line("# No frontmatter\n", "x"))
+
+    def test_returns_none_when_no_name_key(self) -> None:
+        content = "---\ndescription: d\n---\n\nbody\n"
+        self.assertIsNone(rewrite_name_line(content, "x"))
+
+    def test_does_not_match_indented_name_in_block_scalar(self) -> None:
+        # A folded description carrying an indented 'name:' must not be
+        # mistaken for the frontmatter name field.
+        content = (
+            "---\n"
+            "description: >\n"
+            "  This mentions name: foo inside the description.\n"
+            "name: My_Skill\n"
+            "---\n"
+            "\n"
+            "body\n"
+        )
+        result = rewrite_name_line(content, "my-skill")
+        assert result is not None
+        self.assertIn("name: my-skill\n", result)
+        self.assertIn("mentions name: foo inside", result)
+
+
+# ===================================================================
+# compute_name_fix_plan (preview half — reads, never writes)
+# ===================================================================
+
+
+def _write_skill(skill_dir: str, frontmatter: str, body: str = "# Body\n") -> str:
+    """Write a SKILL.md with a raw *frontmatter* block; return its path."""
+    content = f"---\n{frontmatter}\n---\n\n{body}"
+    path = os.path.join(skill_dir, "SKILL.md")
+    write_text(path, content)
+    return path
+
+
+class ComputeNameFixPlanTests(unittest.TestCase):
+    """The preview half computes the plan and never touches disk."""
+
+    def test_lowercase_planned_no_write(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "myskill")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "name: MySkill\ndescription: A demo.")
+            with open(path, "r", encoding="utf-8") as f:
+                before = f.read()
+            stat_before = os.stat(path)
+            new_name, applied, manual, errors = compute_name_fix_plan(path)
+            self.assertEqual(new_name, "myskill")
+            self.assertTrue(applied)
+            self.assertEqual(manual, [])
+            self.assertEqual(errors, [])
+            # Preview must not write — bytes and mtime unchanged.
+            with open(path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), before)
+            self.assertEqual(os.stat(path).st_mtime_ns, stat_before.st_mtime_ns)
+
+    def test_combined_plans_each_fix(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill-name")
+            os.makedirs(sdir)
+            path = _write_skill(
+                sdir, "name: My_Skill Name\ndescription: A demo.",
+            )
+            new_name, applied, manual, _errors = compute_name_fix_plan(path)
+            self.assertEqual(new_name, "my-skill-name")
+            self.assertEqual(len(applied), 3)
+            self.assertEqual(manual, [])
+
+    def test_noop_returns_none_new_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "name: my-skill\ndescription: A demo.")
+            new_name, applied, manual, errors = compute_name_fix_plan(path)
+            self.assertIsNone(new_name)
+            self.assertEqual(applied, [])
+            self.assertEqual(manual, [])
+            self.assertEqual(errors, [])
+
+    def test_dir_mismatch_is_manual(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "expected-dir")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "name: actual-name\ndescription: A demo.")
+            new_name, applied, manual, errors = compute_name_fix_plan(path)
+            self.assertIsNone(new_name)
+            self.assertEqual(applied, [])
+            self.assertEqual(len(manual), 1)
+            self.assertIn("does not match directory", manual[0])
+            self.assertEqual(errors, [])
+
+    def test_over_length_description_is_manual(self) -> None:
+        long_desc = "x" * (MAX_DESCRIPTION_CHARS + 5)
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = _write_skill(
+                sdir, f"name: my-skill\ndescription: {long_desc}",
+            )
+            _new_name, _applied, manual, _errors = compute_name_fix_plan(path)
+            self.assertTrue(any("description" in f for f in manual))
+
+    def test_folded_description_block_no_false_over_length(self) -> None:
+        # A folded ``description: >`` block must not be flagged as
+        # over-length by the inline extractor — the marker line itself
+        # is short, and the fixer leaves folded blocks to the validator.
+        long_body = "x" * (MAX_DESCRIPTION_CHARS + 50)
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = _write_skill(
+                sdir,
+                f"name: my-skill\ndescription: >\n  {long_body}",
+            )
+            _new_name, _applied, manual, _errors = compute_name_fix_plan(path)
+            self.assertEqual(manual, [])
+
+    def test_missing_file_is_error_not_raise(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")  # never created
+            new_name, _applied, _manual, errors = compute_name_fix_plan(path)
+            self.assertIsNone(new_name)
+            self.assertEqual(len(errors), 1)
+            self.assertTrue(errors[0].startswith(LEVEL_FAIL))
+
+    def test_no_frontmatter_is_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(path, "# No frontmatter here\n")
+            new_name, _applied, _manual, errors = compute_name_fix_plan(path)
+            self.assertIsNone(new_name)
+            self.assertTrue(any("frontmatter" in f for f in errors))
+
+    def test_no_name_key_is_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "description: A demo with no name key.")
+            new_name, _applied, _manual, errors = compute_name_fix_plan(path)
+            self.assertIsNone(new_name)
+            self.assertTrue(any("'name'" in f for f in errors))
+
+
+# ===================================================================
+# write_name_fix (apply half — performs the in-place rewrite)
+# ===================================================================
+
+
+class WriteNameFixTests(unittest.TestCase):
+    """The apply half writes the single ``name:`` line in place."""
+
+    def test_writes_new_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "myskill")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "name: MySkill\ndescription: A demo.")
+            modified, errors = write_name_fix(path, "myskill")
+            self.assertTrue(modified)
+            self.assertEqual(errors, [])
+            with open(path, "r", encoding="utf-8") as f:
+                self.assertIn("name: myskill\n", f.read())
+
+    def test_body_preserved_exactly(self) -> None:
+        body = (
+            "# Demo Skill\n\n"
+            "This body has name: should-not-change and other prose.\n\n"
+            "```yaml\nname: also_not_changed\n```\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = _write_skill(
+                sdir, "name: My_Skill\ndescription: A demo.", body=body,
+            )
+            with open(path, "r", encoding="utf-8") as f:
+                before = f.read()
+            modified, _errors = write_name_fix(path, "my-skill")
+            self.assertTrue(modified)
+            with open(path, "r", encoding="utf-8") as f:
+                after = f.read()
+            # The only change is the single frontmatter name value.
+            self.assertEqual(after, before.replace("My_Skill", "my-skill", 1))
+            self.assertIn("name: should-not-change", after)
+            self.assertIn("name: also_not_changed", after)
+
+    def test_identical_value_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "name: my-skill\ndescription: A demo.")
+            stat_before = os.stat(path)
+            with open(path, "r", encoding="utf-8") as f:
+                before = f.read()
+            # Writing the value already on disk is a defensive no-op.
+            modified, errors = write_name_fix(path, "my-skill")
+            self.assertFalse(modified)
+            self.assertEqual(errors, [])
+            with open(path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read(), before)
+            self.assertEqual(os.stat(path).st_mtime_ns, stat_before.st_mtime_ns)
+
+    def test_unlocatable_name_line_is_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            # No name: key in the frontmatter — rewrite cannot locate it.
+            path = _write_skill(sdir, "description: A demo with no name key.")
+            modified, errors = write_name_fix(path, "my-skill")
+            self.assertFalse(modified)
+            self.assertTrue(any("name:" in f for f in errors))
+
+    def test_read_error_reported_not_raised(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")  # never created
+            modified, errors = write_name_fix(path, "my-skill")
+            self.assertFalse(modified)
+            self.assertTrue(any("cannot read" in f for f in errors))
+
+    def test_write_error_reported_not_raised(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = _write_skill(sdir, "name: My_Skill\ndescription: A demo.")
+            real_open = open
+
+            def _open(file, mode="r", *args, **kwargs):
+                if file == path and "w" in mode:
+                    raise OSError("disk full")
+                return real_open(file, mode, *args, **kwargs)
+
+            with mock.patch("builtins.open", _open):
+                modified, errors = write_name_fix(path, "my-skill")
+            self.assertFalse(modified)
+            self.assertTrue(any("cannot write" in f for f in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -898,5 +898,71 @@ class WriteCRLFNormalizationTests(unittest.TestCase):
         self.assertNotIn(b"\r\n", raw)
 
 
+# ===================================================================
+# Missing closing ``---`` delimiter — Codex follow-up F-8.  The planner
+# and line rewriter must treat ``split_frontmatter`` returning
+# ``(frontmatter, None)`` as a structural failure and refuse rather
+# than rewrite a SKILL.md the parser cannot bound.
+# ===================================================================
+
+
+class MissingClosingDelimiterTests(unittest.TestCase):
+    def test_plan_refuses_missing_closing_delimiter(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            # Opening delimiter only — no closing ``---`` line.
+            write_text(path, "---\nname: My_Skill\ndescription: d\n# body\n")
+            new_name, applied, manual, errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertEqual(manual, [])
+        self.assertEqual(owned, [])
+        self.assertTrue(any(
+            "no closing '---' delimiter" in f for f in errors
+        ), msg=f"errors={errors!r}")
+
+    def test_rewrite_line_returns_none_on_missing_closing_delimiter(self) -> None:
+        # The line rewriter itself enforces the same guard so a direct
+        # ``write_name_fix`` call on a malformed SKILL.md is a no-op.
+        content = "---\nname: My_Skill\ndescription: d\n# body without closer\n"
+        self.assertIsNone(rewrite_name_line(content, "my-skill"))
+
+
+# ===================================================================
+# Inline-# alignment with yaml_parser — Copilot follow-up C-8.
+# ``yaml_parser._strip_inline_comment`` only flags ``#`` when preceded
+# by a *space*; the detector must match so the rewriter is not
+# stricter than the parser.
+# ===================================================================
+
+
+class InlineCommentAlignmentTests(unittest.TestCase):
+    def test_tab_before_hash_is_not_a_comment_marker(self) -> None:
+        # ``name: invalid\t#bar`` — yaml_parser treats the value as
+        # ``invalid\t#bar`` (no comment stripped because the rule is
+        # space-only).  The detector must agree, leaving the
+        # comment-syntax refusal silent.  The candidate is invalid
+        # regardless, so the planner refuses via the residual gate
+        # (with a different manual message), but the rewriter's
+        # quote/comment guard does not fire.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "invalid-bar")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname: invalid\t#bar\ndescription: d\n---\n\n# Body\n",
+            )
+            _new_name, _applied, manual, _errors, _owned = (
+                compute_name_fix_plan(path)
+            )
+        # The comment-syntax manual finding must NOT fire on tab-#.
+        self.assertFalse(any("inline '#' comment" in f for f in manual))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -693,5 +693,104 @@ class ParsedNameValueTests(unittest.TestCase):
         )
         self.assertIsNone(rewrite_name_line(content, "myskill"))
 
+
+# ===================================================================
+# Duplicate ``name:`` keys — Codex + Copilot follow-up.
+# ``parse_yaml_subset`` resolves to the *last* mapping entry but a
+# line-targeted rewrite would touch the *first*, so the planner refuses
+# the fix outright rather than rewrite the wrong line and exit clean.
+# ===================================================================
+
+
+class DuplicateNameKeyTests(unittest.TestCase):
+    """Frontmatter with duplicate ``name:`` keys is refused by both the
+    planner and the line rewriter — the parser and the rewriter would
+    target different lines, which would leave the effective ``name``
+    unchanged while the planner owned the validator FAILs.
+    """
+
+    def test_plan_refuses_duplicate_name_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            # parse_yaml_subset reads the last ``name:`` value
+            # (``Last_Name``), but ``_RE_NAME_LINE.search`` would
+            # target the first physical line (``First_Name``) — the
+            # planner must refuse instead of rewriting the wrong line.
+            write_text(
+                path,
+                "---\nname: First_Name\nname: Last_Name\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            with open(path, encoding="utf-8") as f:
+                before = f.read()
+            new_name, applied, _manual, errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertTrue(any(
+            "multiple 'name:' keys" in f for f in errors
+        ), msg=f"errors={errors!r}")
+        # No ownership — the validator FAILs flow through unchanged so
+        # the caller's exit gate fires.
+        self.assertEqual(owned, [])
+
+    def test_rewrite_line_returns_none_on_duplicate_keys(self) -> None:
+        # Defense-in-depth: the line rewriter itself refuses to touch a
+        # frontmatter block carrying duplicate ``name:`` lines.
+        content = (
+            "---\nname: First_Name\nname: Last_Name\ndescription: d\n---\n\nbody\n"
+        )
+        self.assertIsNone(rewrite_name_line(content, "any-value"))
+
+
+# ===================================================================
+# Folded / literal block scalar descriptions — Copilot follow-up.
+# The planner uses the parsed scalar so the over-length manual finding
+# fires regardless of scalar style, keeping the ``--fix`` help text's
+# "manual fix needed" claim honest.
+# ===================================================================
+
+
+class FoldedDescriptionTests(unittest.TestCase):
+    def test_literal_block_overlong_description_is_manual(self) -> None:
+        # ``description: |-`` literal-style block scalar over the limit
+        # must surface as manual the same as inline / folded forms.
+        long_body = "x" * (MAX_DESCRIPTION_CHARS + 5)
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = _write_skill(
+                sdir,
+                f"name: my-skill\ndescription: |-\n  {long_body}",
+            )
+            _new_name, _applied, manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertTrue(any(
+            "manual fix needed" in f and "description" in f for f in manual
+        ))
+        self.assertTrue(any(
+            "'description' exceeds" in f for f in owned
+        ))
+
+    def test_folded_description_within_limit_no_manual(self) -> None:
+        # Folded but within the limit — no manual finding, planner is
+        # silent on description.
+        short_body = "x" * 50
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = _write_skill(
+                sdir,
+                f"name: my-skill\ndescription: >\n  {short_body}",
+            )
+            _new_name, _applied, manual, _errors, _owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertFalse(any("description" in f for f in manual))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -1143,5 +1143,66 @@ class MixedFormDuplicateTests(unittest.TestCase):
         self.assertIsNone(rewrite_name_line(content, "any-value"))
 
 
+# ===================================================================
+# Description manual on refusal paths — Codex follow-up F-17.
+# Refusing a quoted / commented / block-scalar name rewrite must not
+# suppress reporting of an independent over-length description; both
+# are manual-fix conditions and both belong under name_fix.manual_fix_needed.
+# ===================================================================
+
+
+class DescriptionOnRefusalTests(unittest.TestCase):
+    def test_quoted_name_refusal_still_reports_overlong_description(self) -> None:
+        # ``name: "My_Skill"`` triggers the quoted-scalar refusal; the
+        # description is also over-length.  Both findings must surface
+        # under ``manual`` and the description FAIL must be owned so
+        # the validator's copy is suppressed from ``non_path_fails``.
+        long_desc = "x" * (MAX_DESCRIPTION_CHARS + 5)
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                f"---\nname: \"My_Skill\"\ndescription: {long_desc}\n---\n\n# Body\n",
+            )
+            new_name, applied, manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        # Both manual findings present.
+        self.assertTrue(any("quoted scalar" in f for f in manual))
+        self.assertTrue(any(
+            "'description' exceeds" in f or "description" in f and "manual fix needed" in f
+            for f in manual
+        ), msg=f"manual={manual!r}")
+        # Description FAIL owned (so non_path_fails does not double-report).
+        self.assertTrue(any(
+            "'description' exceeds" in f for f in owned
+        ), msg=f"owned={owned!r}")
+        # Name FAILs not owned — they flow through to non_path_fails.
+        self.assertFalse(any("'name'" in f for f in owned))
+
+    def test_block_scalar_name_refusal_still_reports_overlong_description(self) -> None:
+        # Same contract for the block-scalar refusal path.
+        long_desc = "x" * (MAX_DESCRIPTION_CHARS + 5)
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                f"---\nname: >\n  My_Skill\ndescription: {long_desc}\n---\n\n# Body\n",
+            )
+            _new_name, _applied, manual, _errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertTrue(any("block-scalar header" in f for f in manual))
+        self.assertTrue(any(
+            "'description' exceeds" in f for f in owned
+        ))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_name_fixer.py
+++ b/tests/test_name_fixer.py
@@ -1021,5 +1021,122 @@ class UnusualButValidYAMLTests(unittest.TestCase):
         self.assertEqual(owned, [])
 
 
+# ===================================================================
+# Block scalar name values — Codex follow-up F-12.  The rewriter only
+# touches the ``name:`` header line; a block-scalar value (``>`` /
+# ``|`` and chomping variants) carries its content on subsequent
+# indented lines and would be corrupted by a header-only rewrite.
+# ===================================================================
+
+
+class BlockScalarNameTests(unittest.TestCase):
+    def test_folded_name_value_refuses_apply(self) -> None:
+        # ``name: >`` with an indented folded body — parse_yaml_subset
+        # assembles "MySkill", planner would propose "myskill", but
+        # rewriting only the header line would leave the indented body
+        # behind as stray YAML.  The block-scalar guard refuses.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "myskill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname: >\n  MySkill\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            new_name, applied, manual, errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertEqual(applied, [])
+        self.assertTrue(any(
+            "block-scalar header" in f for f in manual
+        ), msg=f"manual={manual!r}")
+        self.assertEqual(owned, [])
+
+    def test_literal_name_value_refuses_apply(self) -> None:
+        # ``name: |-`` literal-style block scalar — same refusal.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "myskill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname: |-\n  My_Skill\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            new_name, _applied, manual, _errors, _owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertTrue(any(
+            "block-scalar header" in f for f in manual
+        ))
+
+    def test_rewrite_line_returns_none_on_block_scalar_header(self) -> None:
+        # The line rewriter itself refuses to touch a block-scalar
+        # header line — defense-in-depth for any future caller.
+        content = (
+            "---\nname: >\n  MySkill\ndescription: d\n---\n\nbody\n"
+        )
+        self.assertIsNone(rewrite_name_line(content, "myskill"))
+
+
+# ===================================================================
+# Mixed-form duplicate name keys — Codex follow-up F-13.
+# parse_yaml_subset accepts both ``name:`` and ``name :`` (whitespace
+# before the colon), so the duplicate guard must count both forms or
+# a mixed-form pair would let the planner read the *last* parsed key
+# while the rewriter touches the *first* strict-form key.
+# ===================================================================
+
+
+class MixedFormDuplicateTests(unittest.TestCase):
+    def test_strict_plus_spaced_colon_is_duplicate(self) -> None:
+        # ``name: First`` then ``name : Last`` — the strict regex only
+        # matches the first line, so the previous guard would miss the
+        # duplicate.  The relaxed-form guard catches both.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname: First_Name\nname : Last_Name\ndescription: d\n---\n\n# Body\n",
+            )
+            new_name, _applied, _manual, errors, owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertTrue(any(
+            "multiple 'name:' keys" in f for f in errors
+        ), msg=f"errors={errors!r}")
+        self.assertEqual(owned, [])
+
+    def test_spaced_plus_strict_colon_is_duplicate(self) -> None:
+        # And the reverse ordering — the parser would use ``Strict_Name``
+        # but the strict regex would target ``Spaced_Name`` if the
+        # duplicate check only saw the strict form.
+        with tempfile.TemporaryDirectory() as tmp:
+            sdir = os.path.join(tmp, "my-skill")
+            os.makedirs(sdir)
+            path = os.path.join(sdir, "SKILL.md")
+            write_text(
+                path,
+                "---\nname : Spaced_Name\nname: Strict_Name\ndescription: d\n---\n\n# Body\n",
+            )
+            new_name, _applied, _manual, errors, _owned = (
+                compute_name_fix_plan(path)
+            )
+        self.assertIsNone(new_name)
+        self.assertTrue(any(
+            "multiple 'name:' keys" in f for f in errors
+        ))
+
+    def test_rewrite_line_returns_none_on_mixed_form_duplicate(self) -> None:
+        content = (
+            "---\nname: First_Name\nname : Last_Name\ndescription: d\n---\n\nbody\n"
+        )
+        self.assertIsNone(rewrite_name_line(content, "any-value"))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -5896,6 +5896,99 @@ class FixNameNormalizationTests(unittest.TestCase):
         self.assertTrue(payload["success"])
         self.assertEqual(payload["name_fix"]["manual_fix_needed"], [])
 
+    # --- Codex F-7: name write gated on apply_error is None ---------
+
+    def test_apply_error_blocks_name_write(self) -> None:
+        # If ``apply_fixes`` raises during the path-rewrite phase, the
+        # name write must not proceed — otherwise a failing
+        # ``--fix --apply`` run can still mutate SKILL.md, widening the
+        # partial-apply state.  Patch ``apply_fixes`` to raise after
+        # arranging a SKILL.md that proposes a safe name fix.
+        from unittest import mock
+        from helpers import write_text as _wt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "myskill")
+            os.makedirs(skill_dir)
+            # Name needs normalization (uppercase) so the planner
+            # proposes a write.  A path-rewriter row is also present
+            # so apply_fixes runs and the patched raise lands.
+            write_skill_md(skill_dir, name="MySkill")
+            cap_dir = os.path.join(skill_dir, "capabilities", "demo")
+            _wt(
+                os.path.join(skill_dir, "references", "guide.md"),
+                "# Guide\n",
+            )
+            _wt(
+                os.path.join(cap_dir, "capability.md"),
+                "# Demo\n\nSee [g](references/guide.md).\n",
+            )
+            skill_md = os.path.join(skill_dir, "SKILL.md")
+            with open(skill_md, encoding="utf-8") as f:
+                before = f.read()
+            mtime_before = os.stat(skill_md).st_mtime_ns
+            with mock.patch(
+                "lib.path_rewriter.apply_fixes",
+                side_effect=OSError("simulated apply failure"),
+            ):
+                code, out, _ = _run_main(
+                    [
+                        "validate_skill.py", skill_dir,
+                        "--fix", "--apply", "--json",
+                    ],
+                )
+            with open(skill_md, encoding="utf-8") as f:
+                after = f.read()
+            mtime_after = os.stat(skill_md).st_mtime_ns
+        payload = json.loads(out)
+        self.assertEqual(code, 1, msg=out)
+        self.assertIn("error", payload, msg=out)
+        # Name write must not have landed under the apply_error gate.
+        self.assertFalse(payload["name_fix"]["modified"])
+        # And the SKILL.md is byte-identical / mtime-unchanged.
+        self.assertEqual(after, before)
+        self.assertEqual(mtime_after, mtime_before)
+
+    # --- Copilot C-9: load_frontmatter I/O failure surfaces FAIL ----
+
+    def test_validate_skill_io_error_does_not_raise(self) -> None:
+        # An unreadable SKILL.md must surface as a structured FAIL
+        # finding, not propagate as an OSError traceback.  Mock the
+        # ``load_frontmatter`` symbol the validator imports so the
+        # filesystem layer is exercised at the right boundary.
+        from unittest import mock
+        from helpers import write_text as _wt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-skill")
+            os.makedirs(skill_dir)
+            _wt(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: my-skill\ndescription: d\n---\n\n# Body\n",
+            )
+            # Patch the name where ``validate_skill`` looked it up —
+            # ``from lib.frontmatter import load_frontmatter`` rebinds
+            # the symbol in ``validate_skill``'s namespace, so patching
+            # ``lib.frontmatter.load_frontmatter`` would miss the
+            # already-bound reference.
+            import validate_skill as _vs
+            with mock.patch.object(
+                _vs, "load_frontmatter",
+                side_effect=OSError("simulated read failure"),
+            ):
+                code, out, _ = _run_main(
+                    ["validate_skill.py", skill_dir, "--json"],
+                )
+        payload = json.loads(out)
+        self.assertEqual(code, 1, msg=out)
+        self.assertFalse(payload["success"])
+        # The FAIL describes the I/O failure rather than a traceback.
+        fails = payload["errors"]["failures"]
+        self.assertTrue(any(
+            "cannot read SKILL.md" in t and "simulated read failure" in t
+            for t in fails
+        ), msg=f"failures={fails!r}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -5659,6 +5659,113 @@ class FixNameNormalizationTests(unittest.TestCase):
         self.assertEqual(payload["name_fix"]["new_name"], "demo-skill")
         self.assertIn("name: demo-skill\n", after)
 
+    # --- Codex F-1 / Copilot C-1: unresolved name FAILs flow through -
+
+    def test_empty_name_fail_flows_through_to_non_path_fails(self) -> None:
+        # An empty ``name:`` is not something the safe fixer resolves —
+        # the regular validator's "field is empty" FAIL must NOT be
+        # swallowed by the name-fix ownership filter.  Without the
+        # ownership-set fix this FAIL was silently suppressed and
+        # ``--fix`` exited 0 on an invalid skill.
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-skill")
+            os.makedirs(skill_dir)
+            # Write a SKILL.md with an empty ``name:`` value.
+            from helpers import write_text as _wt
+            _wt(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: \ndescription: short stub\n---\n\n# Body\n",
+            )
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--json"],
+            )
+        payload = json.loads(out)
+        self.assertEqual(code, 1, msg=out)
+        # The empty-name FAIL must surface — either as part of the
+        # validator's "[spec] 'name' field is empty" or directly under
+        # non_path_fails.  It must NOT be hidden by name_fix.
+        self.assertTrue(any(
+            "'name' field is empty" in f
+            for f in payload["non_path_fails"]
+        ), msg=f"non_path_fails={payload['non_path_fails']}")
+
+    def test_overlong_name_fail_flows_through_to_non_path_fails(self) -> None:
+        # An over-length ``name`` is also outside the safe fixer's
+        # coverage — its FAIL must not be swallowed.
+        long_name = "a" * 200
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, long_name)
+            os.makedirs(skill_dir)
+            from helpers import write_text as _wt
+            _wt(
+                os.path.join(skill_dir, "SKILL.md"),
+                f"---\nname: {long_name}\ndescription: short stub\n---\n\n# Body\n",
+            )
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--json"],
+            )
+        payload = json.loads(out)
+        self.assertEqual(code, 1, msg=out)
+        self.assertTrue(any(
+            "exceeds" in f and "characters" in f and "'name'" in f
+            for f in payload["non_path_fails"]
+        ))
+
+    # --- Copilot C-2: --apply gated when name_manual non-empty -------
+
+    def test_apply_does_not_write_when_name_manual_present(self) -> None:
+        # ``Demo_Skill`` would normalize to ``demo-skill`` but the
+        # directory is ``other-dir`` — dir-mismatch is a manual finding
+        # the fixer never auto-applies.  ``--apply`` must therefore
+        # *not* write SKILL.md, even though ``new_name`` is computed.
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "other-dir")
+            os.makedirs(skill_dir)
+            write_skill_md(skill_dir, name="Demo_Skill")
+            path = os.path.join(skill_dir, "SKILL.md")
+            with open(path, encoding="utf-8") as f:
+                before = f.read()
+            mtime_before = os.stat(path).st_mtime_ns
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply", "--json"],
+            )
+            with open(path, encoding="utf-8") as f:
+                after = f.read()
+            mtime_after = os.stat(path).st_mtime_ns
+        payload = json.loads(out)
+        self.assertEqual(code, 1, msg=out)
+        # File unchanged — mtime untouched.
+        self.assertEqual(after, before)
+        self.assertEqual(mtime_after, mtime_before)
+        # JSON reflects the gated apply.
+        self.assertFalse(payload["name_fix"]["modified"])
+        self.assertFalse(payload["applied"])
+        self.assertTrue(any(
+            "does not match directory" in f
+            for f in payload["name_fix"]["manual_fix_needed"]
+        ))
+
+    # --- Codex F-3: top-level applied true for name-only writes ------
+
+    def test_name_only_apply_marks_top_level_applied_true(self) -> None:
+        # ``--fix --apply --json`` that only rewrites the SKILL.md name
+        # must report ``applied: true`` at the top level so automation
+        # consumers do not get contradictory output (``modified: 1``,
+        # ``name_fix.modified: true``, but ``applied: false``).
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "myskill")
+            os.makedirs(skill_dir)
+            write_skill_md(skill_dir, name="MySkill")
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply", "--json"],
+            )
+        payload = json.loads(out)
+        self.assertEqual(code, 0, msg=out)
+        self.assertTrue(payload["applied"], msg=out)
+        self.assertTrue(payload["name_fix"]["modified"])
+        self.assertEqual(payload["modified"], 1)
+        self.assertEqual(payload["fixes"], [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -5413,7 +5413,10 @@ class FixNameNormalizationTests(unittest.TestCase):
             after = self._read_skill_md(skill_dir)
         self.assertEqual(code, 0)
         self.assertIn("underscores", out)
-        self.assertIn("spaces", out)
+        # The whitespace transform fires for both spaces and tabs, so
+        # the INFO finding speaks in those terms rather than narrowing
+        # to "spaces" — see ``compute_name_fix``.
+        self.assertIn("whitespace", out)
         self.assertEqual(after, before)
 
     # --- apply (--fix --apply): writes name fixes -------------------

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -5990,5 +5990,84 @@ class FixNameNormalizationTests(unittest.TestCase):
         ), msg=f"failures={fails!r}")
 
 
+    # --- Codex F-10: SKILL.md not double-counted in modified --------
+
+    def test_modified_count_no_double_count_when_skill_md_in_both(self) -> None:
+        # When the path-rewriter rows include SKILL.md *and* the name
+        # fix also writes SKILL.md, ``modified`` must report the file
+        # once.  Constructing a real-world case where ``compute_recommended_replacement``
+        # rewrites SKILL.md itself is awkward (skill-root form ==
+        # file-relative form for the root file), so we directly probe
+        # the modified-count gate by forcing the rewriter to return a
+        # SKILL.md row and the path-apply to "modify" 1 file.
+        from unittest import mock
+        from helpers import write_text as _wt
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "myskill")
+            os.makedirs(skill_dir)
+            skill_md = os.path.join(skill_dir, "SKILL.md")
+            # Name normalization needed (MySkill → myskill).
+            write_skill_md(skill_dir, name="MySkill")
+            row = {
+                "file": skill_md,
+                "file_rel": "SKILL.md",
+                "original": "ref.md",
+                "replacement": "./ref.md",
+                "line": 1,
+            }
+            # ``validate_skill`` imports these inside the ``--fix``
+            # branch, so the bound name lives in the ``lib.path_rewriter``
+            # module — patch there.
+            from lib import path_rewriter as _pr
+            with (
+                mock.patch.object(
+                    _pr, "find_fixable_references",
+                    return_value=[row],
+                ),
+                mock.patch.object(
+                    _pr, "find_ambiguous_legacy_refs",
+                    return_value=[],
+                ),
+                mock.patch.object(
+                    _pr, "apply_fixes",
+                    return_value=1,
+                ),
+            ):
+                code, out, _ = _run_main(
+                    [
+                        "validate_skill.py", skill_dir,
+                        "--fix", "--apply", "--json",
+                    ],
+                )
+        payload = json.loads(out)
+        # Both fix categories ran: rewriter "modified" SKILL.md (mock)
+        # and the name fix also rewrote SKILL.md.
+        self.assertTrue(payload["name_fix"]["modified"], msg=out)
+        # ``modified`` reports SKILL.md exactly once.
+        self.assertEqual(payload["modified"], 1, msg=out)
+
+    # --- Copilot C-10: unusual-but-valid YAML does not fail --fix ---
+
+    def test_space_before_colon_valid_name_exits_zero(self) -> None:
+        # ``name : my-skill`` — valid YAML, valid name, no rewrite
+        # needed → --fix must exit 0.
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-skill")
+            os.makedirs(skill_dir)
+            from helpers import write_text as _wt
+            _wt(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname : my-skill\ndescription: A short demo.\n---\n\n# Body\n",
+            )
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--json"],
+            )
+        payload = json.loads(out)
+        self.assertEqual(code, 0, msg=out)
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["name_fix"]["errors"], [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -5985,10 +5985,15 @@ class FixNameNormalizationTests(unittest.TestCase):
         payload = json.loads(out)
         self.assertEqual(code, 1, msg=out)
         self.assertFalse(payload["success"])
-        # The FAIL describes the I/O failure rather than a traceback.
+        # The FAIL describes the I/O failure rather than a traceback,
+        # and includes the failing path so CI logs can identify the
+        # skill (Copilot follow-up C-15).
         fails = payload["errors"]["failures"]
+        skill_md_path = os.path.join(skill_dir, "SKILL.md")
         self.assertTrue(any(
-            "cannot read SKILL.md" in t and "simulated read failure" in t
+            "cannot read SKILL.md" in t
+            and "simulated read failure" in t
+            and skill_md_path.replace(os.sep, "/") in t
             for t in fails
         ), msg=f"failures={fails!r}")
 

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -5807,6 +5807,95 @@ class FixNameNormalizationTests(unittest.TestCase):
             "'name'" in f for f in payload["non_path_fails"]
         ))
 
+    # --- Codex F-6: human label tracks the actual write -------------
+
+    def test_apply_with_manual_does_not_label_as_applied(self) -> None:
+        # Dir-mismatch surfaces a manual finding → name write is
+        # gated → human output must say "Would apply", not "Applied".
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "other-dir")
+            os.makedirs(skill_dir)
+            write_skill_md(skill_dir, name="Demo_Skill")
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply"],
+            )
+        self.assertEqual(code, 1, msg=out)
+        self.assertIn("Would apply name normalization", out)
+        self.assertNotIn("Applied name normalization", out)
+
+    # --- Copilot C-5: planner skipped on structural failures --------
+
+    def test_no_frontmatter_no_duplicate_name_fix_errors(self) -> None:
+        # A SKILL.md with no frontmatter at all FAILs the regular
+        # validator with its own "No YAML frontmatter found" — the
+        # planner must not restate the same root cause under
+        # name_fix.errors.
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-skill")
+            os.makedirs(skill_dir)
+            from helpers import write_text as _wt
+            _wt(
+                os.path.join(skill_dir, "SKILL.md"),
+                "# Body only, no frontmatter\n",
+            )
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--json"],
+            )
+        payload = json.loads(out)
+        self.assertEqual(code, 1, msg=out)
+        # Validator surfaces the structural FAIL.
+        self.assertTrue(any(
+            "No YAML frontmatter found" in f
+            for f in payload["non_path_fails"]
+        ))
+        # And the planner does not double-report it.
+        self.assertEqual(payload["name_fix"]["errors"], [])
+
+    def test_missing_name_no_duplicate_name_fix_errors(self) -> None:
+        # Frontmatter present but no ``name`` key — validator FAILs on
+        # "Missing required 'name' field"; planner stays silent.
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-skill")
+            os.makedirs(skill_dir)
+            from helpers import write_text as _wt
+            _wt(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\ndescription: A demo.\n---\n\n# Body\n",
+            )
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--json"],
+            )
+        payload = json.loads(out)
+        self.assertEqual(code, 1, msg=out)
+        self.assertTrue(any(
+            "Missing required 'name' field" in f
+            for f in payload["non_path_fails"]
+        ))
+        self.assertEqual(payload["name_fix"]["errors"], [])
+
+    # --- Codex F-5: quoted-but-valid name does not fail --fix -------
+
+    def test_quoted_valid_name_does_not_fail_fix(self) -> None:
+        # ``name: "my-skill"`` in dir ``my-skill`` — the parsed value
+        # is valid, no rewrite is proposed, so --fix must exit 0
+        # rather than emit a manual finding just because the value is
+        # quoted.
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-skill")
+            os.makedirs(skill_dir)
+            from helpers import write_text as _wt
+            _wt(
+                os.path.join(skill_dir, "SKILL.md"),
+                "---\nname: \"my-skill\"\ndescription: A short demo.\n---\n\n# Body\n",
+            )
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--json"],
+            )
+        payload = json.loads(out)
+        self.assertEqual(code, 0, msg=out)
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["name_fix"]["manual_fix_needed"], [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -5365,5 +5365,300 @@ class DanglingSymlinkReferenceTests(unittest.TestCase):
             )
 
 
+# ===================================================================
+# --fix name normalization (folded into the unified --fix/--apply flow)
+# ===================================================================
+
+
+class FixNameNormalizationTests(unittest.TestCase):
+    """``validate_skill.py --fix`` previews safe SKILL.md ``name``
+    normalization (lowercase; underscores and spaces to hyphens) and
+    ``--fix --apply`` writes it — the same preview/apply structure that
+    drives the path-resolution rewriter.  Ambiguous problems (name does
+    not match directory; over-length description) are reported as
+    "manual fix needed" and never auto-applied.
+    """
+
+    def _make_skill(self, parent: str, dir_name: str, name: str) -> str:
+        skill_dir = os.path.join(parent, dir_name)
+        os.makedirs(skill_dir)
+        write_skill_md(skill_dir, name=name)
+        return skill_dir
+
+    def _read_skill_md(self, skill_dir: str) -> str:
+        with open(os.path.join(skill_dir, "SKILL.md"), encoding="utf-8") as f:
+            return f.read()
+
+    # --- preview (--fix, no --apply): reports but never writes -------
+
+    def test_preview_reports_name_fix_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self._make_skill(tmp, "myskill", "MySkill")
+            before = self._read_skill_md(skill_dir)
+            code, out, _ = _run_main(["validate_skill.py", skill_dir, "--fix"])
+            after = self._read_skill_md(skill_dir)
+        # dir 'myskill' matches the fixed name 'myskill' → clean preview.
+        self.assertEqual(code, 0)
+        self.assertIn("Would apply name normalization", out)
+        self.assertIn("lowercased", out)
+        # Dry-run must not modify the source.
+        self.assertEqual(after, before)
+        self.assertIn("name: MySkill\n", after)
+
+    def test_preview_underscore_and_space_reported(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self._make_skill(tmp, "my-skill-name", "My_Skill Name")
+            before = self._read_skill_md(skill_dir)
+            code, out, _ = _run_main(["validate_skill.py", skill_dir, "--fix"])
+            after = self._read_skill_md(skill_dir)
+        self.assertEqual(code, 0)
+        self.assertIn("underscores", out)
+        self.assertIn("spaces", out)
+        self.assertEqual(after, before)
+
+    # --- apply (--fix --apply): writes name fixes -------------------
+
+    def test_apply_writes_lowercase(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self._make_skill(tmp, "myskill", "MySkill")
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply"],
+            )
+            after = self._read_skill_md(skill_dir)
+        self.assertEqual(code, 0)
+        self.assertIn("Applied name normalization", out)
+        self.assertIn("name: myskill\n", after)
+
+    def test_apply_writes_underscores_to_hyphens(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self._make_skill(tmp, "my-skill", "my_skill")
+            code, _out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply"],
+            )
+            after = self._read_skill_md(skill_dir)
+        self.assertEqual(code, 0)
+        self.assertIn("name: my-skill\n", after)
+
+    def test_apply_writes_combined(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self._make_skill(tmp, "my-skill-name", "My_Skill Name")
+            code, _out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply"],
+            )
+            after = self._read_skill_md(skill_dir)
+        self.assertEqual(code, 0)
+        self.assertIn("name: my-skill-name\n", after)
+
+    def test_apply_preserves_body_byte_for_byte_except_name(self) -> None:
+        body = (
+            "# Demo\n\nProse name: keep-this stays.\n\n"
+            "```yaml\nname: also_kept\n```\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-skill")
+            os.makedirs(skill_dir)
+            write_skill_md(skill_dir, name="My_Skill", body=body)
+            path = os.path.join(skill_dir, "SKILL.md")
+            with open(path, encoding="utf-8") as f:
+                before = f.read()
+            code, _out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply"],
+            )
+            with open(path, encoding="utf-8") as f:
+                after = f.read()
+        self.assertEqual(code, 0)
+        self.assertEqual(after, before.replace("My_Skill", "my-skill", 1))
+        self.assertIn("name: keep-this stays.", after)
+        self.assertIn("name: also_kept", after)
+
+    # --- combined: both a path-ref fix AND a name fix ---------------
+
+    def test_preview_both_path_and_name_fixes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "demo-skill")
+            cap_dir = os.path.join(skill_dir, "capabilities", "demo")
+            # Name needs normalization; dir 'demo-skill' matches the fix.
+            write_skill_md(skill_dir, name="Demo_Skill")
+            write_text(
+                os.path.join(skill_dir, "references", "guide.md"), "# Guide\n",
+            )
+            cap_md = os.path.join(cap_dir, "capability.md")
+            write_text(cap_md, "# Demo\n\nSee [g](references/guide.md).\n")
+            with open(cap_md, encoding="utf-8") as f:
+                before_cap = f.read()
+            before_skill = self._read_skill_md(skill_dir)
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--json"],
+            )
+            with open(cap_md, encoding="utf-8") as f:
+                after_cap = f.read()
+            after_skill = self._read_skill_md(skill_dir)
+        payload = json.loads(out)
+        self.assertEqual(code, 0, msg=out)
+        # Both categories present in one coherent payload.
+        self.assertEqual(len(payload["fixes"]), 1)
+        self.assertEqual(payload["name_fix"]["new_name"], "demo-skill")
+        self.assertTrue(payload["name_fix"]["applied"])
+        self.assertEqual(payload["name_fix"]["manual_fix_needed"], [])
+        self.assertFalse(payload["name_fix"]["modified"])
+        # Nothing written under preview — both sources unchanged.
+        self.assertEqual(after_cap, before_cap)
+        self.assertEqual(after_skill, before_skill)
+
+    def test_apply_both_path_and_name_fixes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "demo-skill")
+            cap_dir = os.path.join(skill_dir, "capabilities", "demo")
+            write_skill_md(skill_dir, name="Demo_Skill")
+            write_text(
+                os.path.join(skill_dir, "references", "guide.md"), "# Guide\n",
+            )
+            cap_md = os.path.join(cap_dir, "capability.md")
+            write_text(cap_md, "# Demo\n\nSee [g](references/guide.md).\n")
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply", "--json"],
+            )
+            with open(cap_md, encoding="utf-8") as f:
+                after_cap = f.read()
+            after_skill = self._read_skill_md(skill_dir)
+        payload = json.loads(out)
+        self.assertEqual(code, 0, msg=out)
+        # Both writes landed; the modified count covers both files.
+        self.assertTrue(payload["applied"])
+        self.assertTrue(payload["name_fix"]["modified"])
+        self.assertEqual(payload["modified"], 2)
+        self.assertIn("[g](../../references/guide.md)", after_cap)
+        self.assertIn("name: demo-skill\n", after_skill)
+
+    # --- no-op: name already valid leaves the file untouched --------
+
+    def test_noop_when_name_already_valid_leaves_file_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self._make_skill(tmp, "my-skill", "my-skill")
+            path = os.path.join(skill_dir, "SKILL.md")
+            with open(path, encoding="utf-8") as f:
+                before = f.read()
+            mtime_before = os.stat(path).st_mtime_ns
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply"],
+            )
+            with open(path, encoding="utf-8") as f:
+                after = f.read()
+            mtime_after = os.stat(path).st_mtime_ns
+        self.assertEqual(code, 0)
+        self.assertIn("No mechanical fixes needed", out)
+        self.assertEqual(after, before)
+        # File never opened for writing — mtime unchanged.
+        self.assertEqual(mtime_after, mtime_before)
+
+    # --- manual-fix-needed: dir mismatch and over-length description -
+
+    def test_dir_mismatch_reported_manual_not_applied(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self._make_skill(tmp, "expected-dir", "actual-name")
+            path = os.path.join(skill_dir, "SKILL.md")
+            with open(path, encoding="utf-8") as f:
+                before = f.read()
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply"],
+            )
+            with open(path, encoding="utf-8") as f:
+                after = f.read()
+        # Manual finding gates the run; nothing auto-applied.
+        self.assertEqual(code, 1)
+        self.assertIn("manual fix", out.lower())
+        self.assertIn("does not match directory", out)
+        self.assertEqual(after, before)
+
+    def test_over_length_description_reported_manual(self) -> None:
+        long_desc = "x" * (MAX_DESCRIPTION_CHARS + 5)
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-skill")
+            os.makedirs(skill_dir)
+            write_skill_md(skill_dir, name="my-skill", description=long_desc)
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--json"],
+            )
+        payload = json.loads(out)
+        self.assertEqual(code, 1, msg=out)
+        # The over-length description is owned by the name-fix category,
+        # not double-reported under non_path_fails.
+        self.assertTrue(any(
+            "description" in f for f in payload["name_fix"]["manual_fix_needed"]
+        ))
+        self.assertFalse(any(
+            "description' exceeds" in f for f in payload["non_path_fails"]
+        ))
+
+    # --- JSON shape carries both categories -------------------------
+
+    def test_json_shape_includes_name_fix_block(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self._make_skill(tmp, "myskill", "MySkill")
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply", "--json"],
+            )
+        payload = json.loads(out)
+        self.assertEqual(code, 0)
+        self.assertEqual(payload["mode"], "fix")
+        self.assertTrue(payload["success"])
+        # The name_fix block is a peer category to fixes/ambiguous.
+        nf = payload["name_fix"]
+        self.assertEqual(nf["new_name"], "myskill")
+        self.assertTrue(nf["applied"])
+        self.assertEqual(nf["manual_fix_needed"], [])
+        self.assertTrue(nf["modified"])
+        self.assertEqual(nf["errors"], [])
+        # Path-resolution categories still present alongside it.
+        self.assertIn("fixes", payload)
+        self.assertIn("ambiguous_findings", payload)
+        self.assertEqual(
+            payload["path_resolution"]["rule_name"], "path-resolution",
+        )
+
+    def test_name_dir_mismatch_not_double_reported_in_non_path_fails(self) -> None:
+        # The name-frontmatter [spec] FAILs are owned by name_fix, not
+        # the generic non_path_fails bucket.
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = self._make_skill(tmp, "expected-dir", "Actual_Name")
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--json"],
+            )
+        payload = json.loads(out)
+        self.assertEqual(code, 1, msg=out)
+        # Lexical fix proposed; dir-mismatch surfaced as manual.
+        self.assertEqual(payload["name_fix"]["new_name"], "actual-name")
+        self.assertTrue(any(
+            "does not match directory" in f
+            for f in payload["name_fix"]["manual_fix_needed"]
+        ))
+        # No name [spec] FAIL leaked into non_path_fails.
+        self.assertFalse(any(
+            "[spec] 'name'" in f for f in payload["non_path_fails"]
+        ))
+
+    # --- capability mode targets the enclosing skill root's name ----
+
+    def test_capability_mode_fixes_enclosing_skill_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "demo-skill")
+            cap_dir = os.path.join(skill_dir, "capabilities", "demo")
+            write_skill_md(skill_dir, name="Demo_Skill")
+            write_text(os.path.join(cap_dir, "capability.md"), "# Demo\n")
+            code, out, _ = _run_main(
+                ["validate_skill.py", cap_dir, "--capability", "--fix",
+                 "--apply", "--json"],
+            )
+            with open(
+                os.path.join(skill_dir, "SKILL.md"), encoding="utf-8",
+            ) as f:
+                after = f.read()
+        payload = json.loads(out)
+        self.assertEqual(code, 0, msg=out)
+        # Name fixing runs against the enclosing skill root's SKILL.md.
+        self.assertEqual(payload["name_fix"]["new_name"], "demo-skill")
+        self.assertIn("name: demo-skill\n", after)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -6116,6 +6116,45 @@ class FixNameNormalizationTests(unittest.TestCase):
             for f in payload["name_fix"]["manual_fix_needed"]
         ))
 
+    # --- Codex F-16: description-blocker filter anchored to prefix --
+
+    def test_dir_mismatch_for_name_description_still_blocks(self) -> None:
+        # A SKILL.md whose normalized ``name`` is the literal value
+        # ``description`` in a non-matching directory must NOT be
+        # auto-applied: the dir-mismatch manual finding embeds the
+        # value in quotes (``'name' ('description') does not match …``)
+        # so a bare-substring scan for ``'description'`` would
+        # mis-classify it as exit-gating-only and let the write land.
+        # The prefix-anchored blocker filter keeps dir-mismatch as a
+        # name-rewrite blocker even when the value happens to be
+        # ``description``.
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "other-dir")
+            os.makedirs(skill_dir)
+            write_skill_md(skill_dir, name="Description")
+            skill_md = os.path.join(skill_dir, "SKILL.md")
+            with open(skill_md, encoding="utf-8") as f:
+                before = f.read()
+            mtime_before = os.stat(skill_md).st_mtime_ns
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply", "--json"],
+            )
+            with open(skill_md, encoding="utf-8") as f:
+                after = f.read()
+            mtime_after = os.stat(skill_md).st_mtime_ns
+        payload = json.loads(out)
+        # Exit 1 because of the dir-mismatch manual finding.
+        self.assertEqual(code, 1, msg=out)
+        # File untouched — mtime unchanged.
+        self.assertEqual(after, before)
+        self.assertEqual(mtime_after, mtime_before)
+        # JSON reflects the gated apply.
+        self.assertFalse(payload["name_fix"]["modified"], msg=out)
+        self.assertTrue(any(
+            "does not match directory" in f
+            for f in payload["name_fix"]["manual_fix_needed"]
+        ))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -5766,6 +5766,47 @@ class FixNameNormalizationTests(unittest.TestCase):
         self.assertEqual(payload["modified"], 1)
         self.assertEqual(payload["fixes"], [])
 
+    # --- Codex + Copilot follow-up: duplicate name: keys -------------
+
+    def test_duplicate_name_keys_refuses_apply(self) -> None:
+        # Frontmatter with two ``name:`` lines: ``parse_yaml_subset``
+        # reads the last, ``_RE_NAME_LINE`` matches the first.  ``--fix
+        # --apply`` must refuse rather than rewrite the wrong line and
+        # report success while the effective name is still invalid.
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-skill")
+            os.makedirs(skill_dir)
+            from helpers import write_text as _wt
+            path = os.path.join(skill_dir, "SKILL.md")
+            _wt(
+                path,
+                "---\nname: First_Name\nname: Last_Name\ndescription: short stub\n---\n\n# Body\n",
+            )
+            with open(path, encoding="utf-8") as f:
+                before = f.read()
+            mtime_before = os.stat(path).st_mtime_ns
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply", "--json"],
+            )
+            with open(path, encoding="utf-8") as f:
+                after = f.read()
+            mtime_after = os.stat(path).st_mtime_ns
+        payload = json.loads(out)
+        self.assertEqual(code, 1, msg=out)
+        # File untouched.
+        self.assertEqual(after, before)
+        self.assertEqual(mtime_after, mtime_before)
+        # No silent success — name_fix.errors surfaces the refusal.
+        self.assertTrue(any(
+            "multiple 'name:' keys" in f
+            for f in payload["name_fix"]["errors"]
+        ))
+        # And the validator's name FAILs still surface in
+        # non_path_fails (no ownership while refused).
+        self.assertTrue(any(
+            "'name'" in f for f in payload["non_path_fails"]
+        ))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validate_skill.py
+++ b/tests/test_validate_skill.py
@@ -6071,6 +6071,46 @@ class FixNameNormalizationTests(unittest.TestCase):
         self.assertTrue(payload["success"])
         self.assertEqual(payload["name_fix"]["errors"], [])
 
+    # --- Codex F-15: description over-length must NOT block --------
+    # --- the safe name rewrite under --apply -----------------------
+
+    def test_apply_writes_name_when_only_description_is_manual(self) -> None:
+        # ``name: My_Skill`` in dir ``my-skill`` is safely normalizable
+        # (no dir-mismatch on the fixed value).  The description is
+        # over the length limit, so name_manual carries the
+        # description finding for human reporting — but that finding
+        # is independent of whether the name: line can be safely
+        # rewritten.  ``--fix --apply`` must still land the name fix;
+        # the run still exits 1 because the description FAIL gates
+        # fix_success via the validator's own findings.
+        long_desc = "x" * (MAX_DESCRIPTION_CHARS + 50)
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = os.path.join(tmp, "my-skill")
+            os.makedirs(skill_dir)
+            write_skill_md(skill_dir, name="My_Skill", description=long_desc)
+            skill_md = os.path.join(skill_dir, "SKILL.md")
+            with open(skill_md, encoding="utf-8") as f:
+                before = f.read()
+            code, out, _ = _run_main(
+                ["validate_skill.py", skill_dir, "--fix", "--apply", "--json"],
+            )
+            with open(skill_md, encoding="utf-8") as f:
+                after = f.read()
+        payload = json.loads(out)
+        # Exit 1 because the description over-length still gates
+        # fix_success (the manual finding is in name_manual).
+        self.assertEqual(code, 1, msg=out)
+        # But the safe name write landed — the file changed and the
+        # JSON reports the apply.
+        self.assertTrue(payload["name_fix"]["modified"], msg=out)
+        self.assertIn("name: my-skill\n", after)
+        self.assertNotEqual(after, before)
+        # Description manual finding is still surfaced for the user.
+        self.assertTrue(any(
+            "'description'" in f
+            for f in payload["name_fix"]["manual_fix_needed"]
+        ))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Extends `validate_skill.py --fix` to also preview safe SKILL.md `name` frontmatter normalization — lowercasing an uppercase name and replacing underscores and spaces with hyphens — alongside the existing legacy path-reference rewrites (FINDINGS F-09). Both fix categories now share one preview-then-apply surface: `--fix` previews everything and writes nothing; `--fix --apply` writes both. Ambiguous problems (name not matching the directory, description over the length limit) are reported as "manual fix needed" and never auto-applied. The name rewrite is a minimal line-anchored substitution confined to the frontmatter span — the stdlib YAML subset parser does not round-trip, so the remaining frontmatter and the entire body, including any `name:` literal inside a fenced example, are preserved byte-for-byte, and the file is only rewritten when a safe fix actually changes the value. Name FAILs already emitted by regular validation are routed into a `name_fix` JSON category so they are not double-reported. Behavior with neither flag is byte-for-byte unchanged from base. Full suite green, meta-skill self-validation clean (0 failures, 0 warnings).
