### PR TITLE
Add finding-7 pipe-led regression test pins for tool-catalog-drift

### DIFF
--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -456,12 +456,21 @@ class ExtractToolsTests(unittest.TestCase):
     # Finding 7 pipe-led contract pins.
     #
     # The four ``test_single_row_pipe_led_*`` and ``test_pipe_less_*`` tests in
-    # this class pin the helper's "pipe-led table required" contract by exercising
-    # each extraction stage against a pipe-less variant. Other shape-drift axes
-    # (e.g., HTML body cells, column reordering, header column-count change)
-    # remain implicitly covered only by the zero-PascalCase guard at the end of
-    # extract_tools. Widening pins to cover those axes is out of scope for
-    # Finding 7.
+    # this class pin the helper's "pipe-led table required" contract by
+    # exercising each extraction stage against a pipe-less variant. Other
+    # shape-drift axes are caught by their own guards in extract_tools and are
+    # pinned by the negative tests above this group: a header that no longer
+    # matches ``Tool | Description |`` (column rename, reorder, or count
+    # change) trips ``RE_TABLE_HEADER`` and is pinned by
+    # ``test_no_header_row_raises``; a header followed by something other than
+    # a ``| :--- | :--- |`` row trips ``RE_TABLE_SEPARATOR`` and is pinned by
+    # ``test_header_without_separator_raises``; HTML body cells or any other
+    # non-backticked first-cell content trips the malformed-body-row branch
+    # and is pinned by ``test_unbackticked_row_raises``; and backticked
+    # identifiers that all fail the PascalCase shape trip the final
+    # zero-PascalCase guard and are pinned by
+    # ``test_zero_pascalcase_matches_raises``. Widening any of those pins to
+    # cover finer-grained sub-cases is out of scope for Finding 7.
     #
     # These tests use full-phrase error substrings (vs. the short substrings
     # used elsewhere in this class) so each pipe-less stage's ParseError is

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -476,23 +476,26 @@ class ExtractToolsTests(unittest.TestCase):
 
     # Finding 7 pipe-led contract pins.
     #
-    # The four ``test_single_row_pipe_led_*`` and ``test_pipe_less_*`` tests in
-    # this class pin the helper's "pipe-led table required" contract by
-    # exercising each extraction stage against either a fully pipe-less table
-    # or a partial-flip table that keeps earlier rows pipe-led so a later
-    # stage's guard becomes load-bearing. Specifically:
-    # ``test_pipe_less_header_rejected`` feeds a fully pipe-less table (no
-    # leading or trailing ``|`` anywhere, matching the canonical GFM form
-    # called out in ``tool-catalog-drift.py``'s ``RE_TABLE_ROW_FIRST_CELL``
-    # contract comment) and trips ``RE_TABLE_HEADER`` at line 0;
-    # ``test_pipe_less_separator_rejected`` is a partial flip — pipe-led
-    # header + pipe-less separator — that trips ``RE_TABLE_SEPARATOR``;
-    # ``test_pipe_less_body_rows_rejected`` is a partial flip — pipe-led
-    # header and separator + pipe-less body rows — that breaks the body-row
-    # loop's ``startswith("|")`` guard and falls through to the
-    # zero-PascalCase guard; and ``test_pipe_less_upstream_exits_three`` is
-    # the fully pipe-less form again, but routed through ``main`` to pin the
-    # exit-3 contract. Other shape-drift axes are caught by their own guards
+    # Three ``test_pipe_less_*`` unit tests in this class plus
+    # ``test_single_row_pipe_led_table_extracts`` (also in this class) and
+    # one ``main``-boundary integration pin in ``MainTests``
+    # (``test_pipe_less_upstream_exits_three``) together pin the helper's
+    # "pipe-led table required" contract by exercising each extraction stage
+    # against either a fully pipe-less table or a partial-flip table that
+    # keeps earlier rows pipe-led so a later stage's guard becomes
+    # load-bearing. Specifically: ``test_pipe_less_header_rejected`` feeds a
+    # fully pipe-less table (no leading or trailing ``|`` anywhere, matching
+    # the canonical GFM form called out in ``tool-catalog-drift.py``'s
+    # ``RE_TABLE_ROW_FIRST_CELL`` contract comment) and trips
+    # ``RE_TABLE_HEADER`` at line 0; ``test_pipe_less_separator_rejected`` is
+    # a partial flip — pipe-led header + pipe-less separator — that trips
+    # ``RE_TABLE_SEPARATOR``; ``test_pipe_less_body_rows_rejected`` is a
+    # partial flip — pipe-led header and separator + pipe-less body rows —
+    # that breaks the body-row loop's ``startswith("|")`` guard and falls
+    # through to the zero-PascalCase guard; and
+    # ``test_pipe_less_upstream_exits_three`` in ``MainTests`` is the fully
+    # pipe-less form again, but routed through ``main`` to pin the exit-3
+    # contract. Other shape-drift axes are caught by their own guards
     # in extract_tools: a header that no longer matches ``Tool | Description |``
     # (column rename, reorder, or count change) trips ``RE_TABLE_HEADER`` —
     # the same missing-header error path is covered by

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -453,6 +453,100 @@ class ExtractToolsTests(unittest.TestCase):
         tools = mod.extract_tools(markdown)
         self.assertEqual(tools, {"Bash"})
 
+    # Finding 7 pipe-led contract pins.
+    #
+    # The four ``test_single_row_pipe_led_*`` and ``test_pipe_less_*`` tests in
+    # this class pin the helper's "pipe-led table required" contract by exercising
+    # each extraction stage against a pipe-less variant. Other shape-drift axes
+    # (e.g., HTML body cells, column reordering, header column-count change)
+    # remain implicitly covered only by the zero-PascalCase guard at the end of
+    # extract_tools. Widening pins to cover those axes is out of scope for
+    # Finding 7.
+    #
+    # These tests use full-phrase error substrings (vs. the short substrings
+    # used elsewhere in this class) so each pipe-less stage's ParseError is
+    # unambiguously attributed in CI logs — the short forms ("header row",
+    # "separator", "zero") collide with the existing
+    # ``test_no_header_row_raises``, ``test_header_without_separator_raises``,
+    # and ``test_zero_pascalcase_matches_raises`` respectively.
+
+    def test_single_row_pipe_led_table_extracts(self) -> None:
+        """Pin: extract_tools accepts a 1-row pipe-led table.
+
+        Complements ``test_real_fixture_yields_canonical_set`` (50+ rows) by
+        pinning that the parser accepts a 1-row table — a minimum-viable-shape
+        contract the real fixture's row count cannot witness. Do not
+        consolidate with the real-fixture test; their failure modes are
+        distinct (regex regression vs. fixture refresh).
+        """
+        markdown = (
+            "| Tool | Description |\n"
+            "| :--- | :---------- |\n"
+            "| `ToolA` | first |\n"
+        )
+        self.assertEqual(mod.extract_tools(markdown), {"ToolA"})
+
+    def test_pipe_less_header_rejected(self) -> None:
+        """Pin: a pipe-less GFM table is rejected at the header check.
+
+        If upstream ``tools-reference.md`` flips to pipe-less rendering (HTML
+        conversion, theme migration, table rebuild), this test starts failing.
+        That is the intended signal — widen ``RE_TABLE_HEADER`` and the
+        contract comment block at ``RE_TABLE_ROW_FIRST_CELL`` deliberately
+        when it fires. Silent absorption would risk hiding other simultaneous
+        shape changes.
+        """
+        markdown = (
+            "Tool | Description |\n"
+            "--- | ---\n"
+            "`ToolA` | first |\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.extract_tools(markdown)
+        message = str(ctx.exception)
+        self.assertIn("header row", message)
+        self.assertIn("`| Tool | Description |", message)
+
+    def test_pipe_less_separator_rejected(self) -> None:
+        """Pin: pipe-led header + pipe-less separator is rejected at the separator check.
+
+        Partial-flip case: upstream keeps the header pipe-led but rewrites
+        the separator without leading pipes. The body row below is pipe-led
+        for realistic-narrative purposes only — the function raises at the
+        separator check before reaching it. Widen ``RE_TABLE_SEPARATOR``
+        deliberately if this fires.
+        """
+        markdown = (
+            "| Tool | Description |\n"
+            "--- | ---\n"
+            "| `ToolA` | first |\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.extract_tools(markdown)
+        self.assertIn("not followed by a separator", str(ctx.exception))
+
+    def test_pipe_less_body_rows_rejected(self) -> None:
+        """Pin: pipe-led header + separator with pipe-less body rows is rejected.
+
+        Body-only flip case (likely real-world drift shape — a CDN keeping
+        the header pipe-led but rewriting body rows). The body-row loop
+        breaks on the first non-``|`` line, leaving the extracted set empty,
+        which trips the zero-PascalCase guard. The ``startswith("|")``
+        guard is the load-bearing check for this path (the regex never
+        runs); widen it deliberately if this fires — also widen
+        ``RE_TABLE_ROW_FIRST_CELL`` if the regex is what now governs
+        body-row acceptance.
+        """
+        markdown = (
+            "| Tool | Description |\n"
+            "| :--- | :---------- |\n"
+            "`ToolA` | first |\n"
+            "`ToolB` | second |\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.extract_tools(markdown)
+        self.assertIn("zero PascalCase tool names", str(ctx.exception))
+
 
 # ---------------------------------------------------------------------------
 # Parse catalog

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -378,6 +378,27 @@ class ExtractToolsTests(unittest.TestCase):
             mod.extract_tools(markdown)
         self.assertIn("header row", str(ctx.exception))
 
+    def test_present_nonmatching_header_raises(self) -> None:
+        """Pin: a table whose header is present but does not match
+        ``Tool | Description |`` is rejected at ``RE_TABLE_HEADER``.
+
+        Covers the realistic header-drift axis (column rename, reorder, or
+        count change) where the document still has a table — distinct from
+        ``test_no_header_row_raises`` which feeds content with no table at
+        all. Both tests trip the same ``RE_TABLE_HEADER`` guard and produce
+        the same ParseError; this one pins the present-but-nonmatching shape
+        explicitly so a future regex widening that mistakenly accepts a
+        renamed first column surfaces here.
+        """
+        markdown = (
+            "| Name | Permission | Description |\n"
+            "| :--- | :--------- | :---------- |\n"
+            "| `Bash` | Yes | shell |\n"
+        )
+        with self.assertRaises(mod.ParseError) as ctx:
+            mod.extract_tools(markdown)
+        self.assertIn("header row", str(ctx.exception))
+
     def test_header_without_body_raises(self) -> None:
         markdown = (
             "# Tools\n\n"
@@ -457,20 +478,24 @@ class ExtractToolsTests(unittest.TestCase):
     #
     # The four ``test_single_row_pipe_led_*`` and ``test_pipe_less_*`` tests in
     # this class pin the helper's "pipe-led table required" contract by
-    # exercising each extraction stage against a pipe-less variant. Other
-    # shape-drift axes are caught by their own guards in extract_tools and are
-    # pinned by the negative tests above this group: a header that no longer
-    # matches ``Tool | Description |`` (column rename, reorder, or count
-    # change) trips ``RE_TABLE_HEADER`` and is pinned by
-    # ``test_no_header_row_raises``; a header followed by something other than
-    # a ``| :--- | :--- |`` row trips ``RE_TABLE_SEPARATOR`` and is pinned by
+    # exercising each extraction stage against a fully pipe-less variant (no
+    # leading or trailing ``|``, matching the canonical GFM form called out
+    # in ``tool-catalog-drift.py``'s ``RE_TABLE_ROW_FIRST_CELL`` contract
+    # comment). Other shape-drift axes are caught by their own guards in
+    # extract_tools: a header that no longer matches ``Tool | Description |``
+    # (column rename, reorder, or count change) trips ``RE_TABLE_HEADER`` —
+    # the same missing-header error path is covered by
+    # ``test_no_header_row_raises`` (no table at all) and
+    # ``test_present_nonmatching_header_raises`` (table with a different
+    # header); a header followed by something other than a ``| :--- | :--- |``
+    # row trips ``RE_TABLE_SEPARATOR`` and is covered by
     # ``test_header_without_separator_raises``; HTML body cells or any other
-    # non-backticked first-cell content trips the malformed-body-row branch
-    # and is pinned by ``test_unbackticked_row_raises``; and backticked
-    # identifiers that all fail the PascalCase shape trip the final
-    # zero-PascalCase guard and are pinned by
-    # ``test_zero_pascalcase_matches_raises``. Widening any of those pins to
-    # cover finer-grained sub-cases is out of scope for Finding 7.
+    # non-backticked first-cell content (with a leading ``|``) trips the
+    # malformed-body-row branch and is covered by
+    # ``test_unbackticked_row_raises``; and backticked identifiers that all
+    # fail the PascalCase shape trip the final zero-PascalCase guard and are
+    # covered by ``test_zero_pascalcase_matches_raises``. Widening any of
+    # those covers to finer-grained sub-cases is out of scope for Finding 7.
     #
     # These tests use full-phrase error substrings (vs. the short substrings
     # used elsewhere in this class) so each pipe-less stage's ParseError is

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -496,19 +496,22 @@ class ExtractToolsTests(unittest.TestCase):
         self.assertEqual(mod.extract_tools(markdown), {"ToolA"})
 
     def test_pipe_less_header_rejected(self) -> None:
-        """Pin: a pipe-less GFM table is rejected at the header check.
+        """Pin: a fully pipe-less GFM table (no leading or trailing ``|``)
+        is rejected at the header check.
 
-        If upstream ``tools-reference.md`` flips to pipe-less rendering (HTML
-        conversion, theme migration, table rebuild), this test starts failing.
-        That is the intended signal — widen ``RE_TABLE_HEADER`` and the
-        contract comment block at ``RE_TABLE_ROW_FIRST_CELL`` deliberately
-        when it fires. Silent absorption would risk hiding other simultaneous
-        shape changes.
+        Matches the canonical pipe-less form called out in
+        ``tool-catalog-drift.py``'s ``RE_TABLE_ROW_FIRST_CELL`` contract
+        comment. If upstream ``tools-reference.md`` flips to pipe-less
+        rendering (HTML conversion, theme migration, table rebuild), this
+        test starts failing. That is the intended signal — widen
+        ``RE_TABLE_HEADER`` and the contract comment block at
+        ``RE_TABLE_ROW_FIRST_CELL`` deliberately when it fires. Silent
+        absorption would risk hiding other simultaneous shape changes.
         """
         markdown = (
-            "Tool | Description |\n"
+            "Tool | Description\n"
             "--- | ---\n"
-            "`ToolA` | first |\n"
+            "`ToolA` | first\n"
         )
         with self.assertRaises(mod.ParseError) as ctx:
             mod.extract_tools(markdown)
@@ -535,22 +538,23 @@ class ExtractToolsTests(unittest.TestCase):
         self.assertIn("not followed by a separator", str(ctx.exception))
 
     def test_pipe_less_body_rows_rejected(self) -> None:
-        """Pin: pipe-led header + separator with pipe-less body rows is rejected.
+        """Pin: pipe-led header + separator with fully pipe-less body rows
+        (no leading or trailing ``|``) is rejected.
 
         Body-only flip case (likely real-world drift shape — a CDN keeping
-        the header pipe-led but rewriting body rows). The body-row loop
-        breaks on the first non-``|`` line, leaving the extracted set empty,
-        which trips the zero-PascalCase guard. The ``startswith("|")``
-        guard is the load-bearing check for this path (the regex never
-        runs); widen it deliberately if this fires — also widen
-        ``RE_TABLE_ROW_FIRST_CELL`` if the regex is what now governs
-        body-row acceptance.
+        the header pipe-led but rewriting body rows to the canonical
+        pipe-less GFM form). The body-row loop breaks on the first non-``|``
+        line, leaving the extracted set empty, which trips the
+        zero-PascalCase guard. The ``startswith("|")`` guard is the
+        load-bearing check for this path (the regex never runs); widen it
+        deliberately if this fires — also widen ``RE_TABLE_ROW_FIRST_CELL``
+        if the regex is what now governs body-row acceptance.
         """
         markdown = (
             "| Tool | Description |\n"
             "| :--- | :---------- |\n"
-            "`ToolA` | first |\n"
-            "`ToolB` | second |\n"
+            "`ToolA` | first\n"
+            "`ToolB` | second\n"
         )
         with self.assertRaises(mod.ParseError) as ctx:
             mod.extract_tools(markdown)
@@ -1379,9 +1383,9 @@ class MainTests(unittest.TestCase):
         ExtractToolsTests pass but this fires.
         """
         pipe_less_markdown = (
-            "Tool | Description |\n"
+            "Tool | Description\n"
             "--- | ---\n"
-            "`Bash` | shell |\n"
+            "`Bash` | shell\n"
         )
         with _CatalogTempFile(_HAPPY_CATALOG) as path, \
              _patched_fetch(pipe_less_markdown):

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -1358,6 +1358,34 @@ class MainTests(unittest.TestCase):
             self.assertEqual(code, 3)
             self.assertIn("catalog_provenance", stderr.getvalue())
 
+    def test_pipe_less_upstream_exits_three(self) -> None:
+        """Pin: a pipe-less upstream page makes the scheduled run hard-fail
+        (exit 3) loudly, not succeed-with-wrong-payload silently.
+
+        Complements ``test_parse_error_exits_three`` (catalog-parsing
+        ParseError) by covering the upstream-extraction ParseError path —
+        both routes exit 3 but originate at different boundaries; both must
+        remain pinned. If a future refactor wraps extract_tools in a
+        try/except that swallows the raise, the unit tests in
+        ExtractToolsTests pass but this fires.
+        """
+        pipe_less_markdown = (
+            "Tool | Description |\n"
+            "--- | ---\n"
+            "`Bash` | shell |\n"
+        )
+        with _CatalogTempFile(_HAPPY_CATALOG) as path, \
+             _patched_fetch(pipe_less_markdown):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr), redirect_stdout(io.StringIO()):
+                code = mod.main([
+                    "--dry-run",
+                    "--catalog-path", path,
+                    "--today", "2026-05-01",
+                ])
+            self.assertEqual(code, 3)
+            self.assertIn("header row", stderr.getvalue())
+
     def test_summary_out_help_describes_json_interaction(self) -> None:
         # The --summary-out help text must describe its interaction
         # with --json — under --json, stdout receives the JSON payload

--- a/.github/tests/test_tool_catalog_drift.py
+++ b/.github/tests/test_tool_catalog_drift.py
@@ -478,11 +478,22 @@ class ExtractToolsTests(unittest.TestCase):
     #
     # The four ``test_single_row_pipe_led_*`` and ``test_pipe_less_*`` tests in
     # this class pin the helper's "pipe-led table required" contract by
-    # exercising each extraction stage against a fully pipe-less variant (no
-    # leading or trailing ``|``, matching the canonical GFM form called out
-    # in ``tool-catalog-drift.py``'s ``RE_TABLE_ROW_FIRST_CELL`` contract
-    # comment). Other shape-drift axes are caught by their own guards in
-    # extract_tools: a header that no longer matches ``Tool | Description |``
+    # exercising each extraction stage against either a fully pipe-less table
+    # or a partial-flip table that keeps earlier rows pipe-led so a later
+    # stage's guard becomes load-bearing. Specifically:
+    # ``test_pipe_less_header_rejected`` feeds a fully pipe-less table (no
+    # leading or trailing ``|`` anywhere, matching the canonical GFM form
+    # called out in ``tool-catalog-drift.py``'s ``RE_TABLE_ROW_FIRST_CELL``
+    # contract comment) and trips ``RE_TABLE_HEADER`` at line 0;
+    # ``test_pipe_less_separator_rejected`` is a partial flip — pipe-led
+    # header + pipe-less separator — that trips ``RE_TABLE_SEPARATOR``;
+    # ``test_pipe_less_body_rows_rejected`` is a partial flip — pipe-led
+    # header and separator + pipe-less body rows — that breaks the body-row
+    # loop's ``startswith("|")`` guard and falls through to the
+    # zero-PascalCase guard; and ``test_pipe_less_upstream_exits_three`` is
+    # the fully pipe-less form again, but routed through ``main`` to pin the
+    # exit-3 contract. Other shape-drift axes are caught by their own guards
+    # in extract_tools: a header that no longer matches ``Tool | Description |``
     # (column rename, reorder, or count change) trips ``RE_TABLE_HEADER`` —
     # the same missing-header error path is covered by
     # ``test_no_header_row_raises`` (no table at all) and


### PR DESCRIPTION
Closes #188.

## Spec-deviation note (read first)

The source design doc (`docs/v1.3.0-tool-catalog-drift-regression-tests.md`) proposes three tests covering findings 7, 8, and 11. Findings 8 and 11 are already covered by pre-existing `test_eof_insertion_repairs_missing_trailing_newline` and `test_unbackticked_row_raises` in `.github/tests/test_tool_catalog_drift.py` (shipped before this branch opened). This PR ships finding 7 only — expanded per iterative critique to four unit-stage pipe-led pins and one `main`-boundary integration pin — plus one review-driven addition: `test_present_nonmatching_header_raises` explicitly covers the header-drift axis (column rename, reorder, or count change) at the same `RE_TABLE_HEADER` guard that `test_no_header_row_raises` already covers via the no-table-at-all input shape.

## Summary

`extract_tools`'s pipe-led table contract is pinned via four tests in `ExtractToolsTests`: a 1-row positive test that documents the minimum-viable shape independently of the captured upstream fixture, and three stage-specific rejection tests covering pipe-less header, pipe-less separator, and pipe-less body. `test_pipe_less_header_rejected` feeds a fully pipe-less table (no leading or trailing `|` anywhere); the separator and body tests are partial flips that keep earlier rows pipe-led so a later stage's guard becomes load-bearing. Each rejection test pins `ParseError` at its specific extraction stage with a full-phrase error substring chosen to disambiguate from the existing short-substring tests on the same paths.

The upstream-extraction `ParseError` exit-3 path through `main` is pinned by `test_pipe_less_upstream_exits_three`, which mocks `fetch` to return pipe-less markdown and asserts exit code 3 with the expected stderr substring. Complements `test_parse_error_exits_three` (catalog-parsing `ParseError` exit-3 path) — both routes hit exit 3 but originate at different boundaries; both must remain pinned. If a future refactor wraps `extract_tools` in a try/except that swallows `ParseError`, the unit tests pass but this fires.

`test_present_nonmatching_header_raises` (review-driven addition) pins the realistic header-drift axis where the document still has a table but its first two header columns no longer match `Tool | Description |`. The pre-existing `test_no_header_row_raises` exercises the same `RE_TABLE_HEADER` guard via the no-table-at-all shape; the new test exercises the present-but-nonmatching shape so a future regex widening that mistakenly accepts a renamed first column surfaces here.

A scope-clarifying class-internal comment block documents the local substring-style deviation (full-phrase substrings vs. the short forms used elsewhere in `ExtractToolsTests`) and names each existing negative test that covers each non-pipe-less shape-drift axis: `test_no_header_row_raises` + `test_present_nonmatching_header_raises` cover the header axis, `test_header_without_separator_raises` covers the separator axis, `test_unbackticked_row_raises` covers the non-backticked-body axis, and `test_zero_pascalcase_matches_raises` covers the all-non-PascalCase axis. The comment also distinguishes the fully-pipe-less tests from the partial-flip tests so a reader debugging a future failure can match the failing test back to its precise contract.

## Test plan

- [x] `python -m unittest discover -s .github/tests -p "test_*.py" -v` — 93/93 green locally.
- [x] Tests are purely additive — no source changes to `.github/scripts/tool-catalog-drift.py`.
- [x] No new fixtures on disk — inline markdown only.
- [ ] CI green on ubuntu and windows runners.
- [ ] Required-check gate passes (`test` matrix x2, `verify`, `verify-release-label`).
